### PR TITLE
Fix #2398: Compressing over-sized avatars to allow uploading an avatar of any size

### DIFF
--- a/server/src/lib/api.ts
+++ b/server/src/lib/api.ts
@@ -232,8 +232,8 @@ export default class API {
     { body, headers, params, user }: Request,
     response: Response
   ) => {
-    let avatarURL;
-    let error;
+    let avatarURL: string;
+    let error: string | null = null;
     switch (params.type) {
       case 'default':
         avatarURL = null;
@@ -273,9 +273,10 @@ export default class API {
 
     if (!error) {
       await UserClient.updateAvatarURL(user.emails[0].value, avatarURL);
+      response.sendStatus(200);
+    } else {
+      response.status(406).send(error);
     }
-
-    response.json(error ? { error } : {});
   };
 
   saveAvatarClip = async (request: Request, response: Response) => {

--- a/web/src/components/pages/profile/avatar-setup/avatar-setup.tsx
+++ b/web/src/components/pages/profile/avatar-setup/avatar-setup.tsx
@@ -167,19 +167,20 @@ class AvatarSetup extends React.Component<Props, State> {
     const reader = new FileReader();
     reader.readAsDataURL(image);
 
-    reader.onloadend = async () => {
+    reader.onload = async () => {
       const base64 = reader.result as string;
-      if (base64.length > 8000) {
-        const alteredQuality = (8000 / base64.length) * quality;
+      const bufferLength = 8000;
+
+      if (base64.length > bufferLength && quality > 0.1) {
+        const alteredQuality = (bufferLength / base64.length) * quality;
         this.saveFileAvatar(files, alteredQuality);
         return;
       }
       try {
         await api.saveAvatar('file', image);
-      } catch ({ message }) {
-        if (message === 'too_large') {
-          this.saveFileAvatar(files, quality / 2);
-          return;
+      } catch (error) {
+        if (error.message === 'too_large') {
+          addNotification(getString(`file_${error.message}`));
         }
       }
       refreshUser();

--- a/web/src/components/pages/profile/avatar-setup/avatar-setup.tsx
+++ b/web/src/components/pages/profile/avatar-setup/avatar-setup.tsx
@@ -170,7 +170,8 @@ class AvatarSetup extends React.Component<Props, State> {
     reader.onloadend = async () => {
       const base64 = reader.result as string;
       if (base64.length > 8000) {
-        this.saveFileAvatar(files, quality / 2);
+        const alteredQuality = (8000 / base64.length) * quality;
+        this.saveFileAvatar(files, alteredQuality);
         return;
       }
       try {

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -258,16 +258,21 @@ export default class API {
     return this.fetch(API_PATH + '/newsletter/' + email, { method: 'POST' });
   }
 
-  saveAvatar(type: 'default' | 'file' | 'gravatar', file?: Blob) {
-    return this.fetch(API_PATH + '/user_client/avatar/' + type, {
-      method: 'POST',
-      isJSON: false,
-      ...(file
-        ? {
-            body: file,
-          }
-        : {}),
-    }).then(body => JSON.parse(body));
+  async saveAvatar(type: 'default' | 'file' | 'gravatar', file?: Blob) {
+    try {
+      const body = await this.fetch(`${API_PATH}/user_client/avatar/${type}`, {
+        method: 'POST',
+        isJSON: false,
+        ...(file
+          ? {
+              body: file,
+            }
+          : {}),
+      });
+      return JSON.parse(body);
+    } catch (err) {
+      throw err;
+    }
   }
 
   saveAvatarClip(blob: Blob): Promise<void> {


### PR DESCRIPTION
So I made what I believe to be a horrible fix to issue #2398. Please don't merge this just yet.
I'd like to brain-storm possible fixes to this problem, so, here's a brief about where the problem lies..

The resizing function was already in place, but the problem was that if the avatar quality is a little too high, the condition in the back-end would not be met so an error banner was being thrown in the front-end and of course, the avatar would not be updated.

What I've done is that I've made a "recursive call" (shouldn't be called more that thrice at worst) that would reduce the quality of the image to half each time the back-end rejects it. 
The problem of course is that I'm sending a full image to the back-end each time to check if the condition is met and TBH, this is making my eyes bleed every time I look at it.

So possible solutions would be:

- Removing the condition in the back-end and risk saving possibly the world's largest 200x200 avatar.
- Just keep this implementation I've done and take the hit if sending image files between the front-end and back-end won't be that bad of an idea considering the images are only 200x200 anyway.
- Sticking to a low image quality like 0.2 which shouldn't get out of hand, but then, some avatars would look really pixelated.

I wasn't smart enough to find a way of compressing images on the front-end beforehand. So, if there's a way please guide me and I'd be happy to give it a try.

Also, I've added a notification banner that shows up when the avatar is successfully uploaded, the string that show in the notification banner won't localize at least yet. I don't know if it's okay to add it now and localize later or if there's already a localized string that indicates something along the lines of "upload complete".

One more thing, I've changed the back-end endpoint to throw errors instead of sending error messages as json strings. We could definitely revert this but I believe it's a good practice? certainly more expressive when dealing with on the front-end.