### PR TITLE
Enable email opt-in for dataset comms on the dataset page

### DIFF
--- a/common/newsletters.ts
+++ b/common/newsletters.ts
@@ -1,0 +1,13 @@
+export type Newsletter = 'common-voice' | 'common-voice-datasets';
+export type Subscriptions = Record<Newsletter, boolean>;
+export const newsletters: Newsletter[] = [
+  'common-voice',
+  'common-voice-datasets',
+];
+export const emptySubscriptions: Subscriptions = newsletters.reduce(
+  (acc, key) => ({
+    ...acc,
+    [key]: false,
+  }),
+  {} as Subscriptions
+);

--- a/web/locales/en/messages.ftl
+++ b/web/locales/en/messages.ftl
@@ -11,6 +11,7 @@ email-opt-in-info = I'd like to receive emails such as goal reminders, my progre
 email-opt-in-info-title = Join the Common Voice mailing list
 email-opt-in-info-sub-with-challenge = Receive emails such as challenge and goal reminders, progress updates, and newsletters about Common Voice.
 email-opt-in-privacy = By opting in to receive emails you state that you are okay with Mozilla handling this info as explained in Mozilla’s <privacyLink>Privacy Policy<privacyLink>.
+dataset-email-opt-in-info = I’d like to receive Common Voice dataset updates and feedback requests via email.
 indicates-required = * Indicates required field
 not-available-abbreviation = N/A
 
@@ -563,7 +564,7 @@ dataset-description-hours =
         Each entry in the dataset consists of a unique MP3 and corresponding text file. Many of the <b>{ $total }</b> recorded hours in the dataset also include demographic metadata like age, sex, and accent that can help train the accuracy of speech recognition engines.
 
         The dataset currently consists of <b>{ $valid }</b> validated hours in <b>{ $languages }</b> languages, but we’re always adding more voices and languages. Take a look at our <languagesLink>Languages page</languagesLink> to request a language or start contributing.
-want-dataset-update = Want updates when we release a new version of the Common Voice dataset? Subscribe to our newsletter.
+dataset-update-signup = Sign up to receive Common Voice dataset updates and feedback requests via email.
 subscribe = Subscribe
 get-started-speech = Get Started with Speech Recognition
 other-datasets = Other Voice Datasets

--- a/web/src/components/pages/dashboard/goals/custom-goal-steps.tsx
+++ b/web/src/components/pages/dashboard/goals/custom-goal-steps.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { CustomGoal, CustomGoalParams } from 'common';
 import { UserClient } from 'common';
 import URLS from '../../../../urls';
-import { useAccount, useIsSubscribed } from '../../../../hooks/store-hooks';
+import { useAccount } from '../../../../hooks/store-hooks';
 import { useRouter } from '../../../../hooks/use-router';
 import { getManageSubscriptionURL } from '../../../../utility';
 import {
@@ -23,7 +23,6 @@ import {
 } from '../../../ui/icons';
 import { Button, LabeledSelect, LinkButton } from '../../../ui/ui';
 import { CircleProgress, Fraction } from '../ui';
-import { useEffect } from 'react';
 
 const Buttons = ({ children, ...props }: React.HTMLProps<HTMLDivElement>) => (
   <div className="buttons padded" {...props}>
@@ -97,8 +96,9 @@ interface CustomGoalStepProps {
 
   state: CustomGoalParams;
 
-  subscribed: boolean;
-  setSubscribed: (subscribed: boolean) => void;
+  isLoadingSubscriptions: boolean;
+  isSubscribed: boolean;
+  setIsSubscribed: (subscribed: boolean) => void;
 }
 
 interface AccountProps {
@@ -244,19 +244,18 @@ export default [
     closeButtonProps,
     completedFields,
     nextButtonProps,
-
-    subscribed,
-    setSubscribed,
+    isLoadingSubscriptions,
+    isSubscribed,
+    setIsSubscribed,
   }: CustomGoalStepProps & AccountProps) => {
     const account = useAccount();
     const [privacyAgreed, setPrivacyAgreed] = useState(false);
-    const isSubscribed = useIsSubscribed();
 
     return (
       <div className="padded">
         {completedFields}
         {account.basket_token ? (
-          isSubscribed !== null && (
+          !isLoadingSubscriptions && (
             <>
               <Localized
                 id={
@@ -264,7 +263,7 @@ export default [
                     ? 'receiving-emails-info'
                     : 'not-receiving-emails-info'
                 }
-                bold={<b />}>
+                bold={<strong />}>
                 <p className="subscription-info" />
               </Localized>
               <a
@@ -284,8 +283,8 @@ export default [
             <label className="box">
               <input
                 type="checkbox"
-                checked={subscribed}
-                onChange={event => setSubscribed(event.target.checked)}
+                checked={isSubscribed}
+                onChange={event => setIsSubscribed(event.target.checked)}
               />
               <Localized id="email-opt-in-info">
                 <div className="content" />
@@ -316,7 +315,7 @@ export default [
             rounded
             className="submit"
             {...nextButtonProps}
-            disabled={subscribed && !privacyAgreed}>
+            disabled={isSubscribed && !privacyAgreed}>
             <CheckIcon />{' '}
             <Localized id="confirm-goal">
               <span />

--- a/web/src/components/pages/dashboard/goals/custom-goal-steps.tsx
+++ b/web/src/components/pages/dashboard/goals/custom-goal-steps.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { CustomGoal, CustomGoalParams } from 'common';
 import { UserClient } from 'common';
 import URLS from '../../../../urls';
-import { useAccount } from '../../../../hooks/store-hooks';
+import { useAccount, useSubscriptions } from '../../../../hooks/store-hooks';
 import { useRouter } from '../../../../hooks/use-router';
 import { getManageSubscriptionURL } from '../../../../utility';
 import {
@@ -96,9 +96,8 @@ interface CustomGoalStepProps {
 
   state: CustomGoalParams;
 
-  isLoadingSubscriptions: boolean;
-  isSubscribed: boolean;
-  setIsSubscribed: (subscribed: boolean) => void;
+  shouldSubscribe: boolean;
+  setShouldSubscribe: (subscribed: boolean) => void;
 }
 
 interface AccountProps {
@@ -244,12 +243,14 @@ export default [
     closeButtonProps,
     completedFields,
     nextButtonProps,
-    isLoadingSubscriptions,
-    isSubscribed,
-    setIsSubscribed,
+    shouldSubscribe,
+    setShouldSubscribe,
   }: CustomGoalStepProps & AccountProps) => {
     const account = useAccount();
     const [privacyAgreed, setPrivacyAgreed] = useState(false);
+    const [isLoadingSubscriptions, subscriptions] = useSubscriptions();
+    const isSubscribed =
+      !isLoadingSubscriptions && subscriptions['common-voice'];
 
     return (
       <div className="padded">
@@ -283,8 +284,8 @@ export default [
             <label className="box">
               <input
                 type="checkbox"
-                checked={isSubscribed}
-                onChange={event => setIsSubscribed(event.target.checked)}
+                checked={shouldSubscribe}
+                onChange={event => setShouldSubscribe(event.target.checked)}
               />
               <Localized id="email-opt-in-info">
                 <div className="content" />
@@ -315,7 +316,7 @@ export default [
             rounded
             className="submit"
             {...nextButtonProps}
-            disabled={isSubscribed && !privacyAgreed}>
+            disabled={shouldSubscribe && !privacyAgreed}>
             <CheckIcon />{' '}
             <Localized id="confirm-goal">
               <span />

--- a/web/src/components/pages/dashboard/goals/custom-goal.tsx
+++ b/web/src/components/pages/dashboard/goals/custom-goal.tsx
@@ -1,13 +1,8 @@
 import { Localized } from 'fluent-react/compat';
 import * as React from 'react';
 import { useState } from 'react';
-import { CustomGoalParams, Subscriptions } from 'common';
-import {
-  useAccount,
-  useAction,
-  useAPI,
-  useSubscriptions,
-} from '../../../../hooks/store-hooks';
+import { CustomGoalParams } from 'common';
+import { useAccount, useAction, useAPI } from '../../../../hooks/store-hooks';
 import { User } from '../../../../stores/user';
 import Modal from '../../../modal/modal';
 import { PenIcon } from '../../../ui/icons';
@@ -224,17 +219,7 @@ export default function CustomGoal({
   }
 
   const [touchedStepIndex, setTouchedStepIndex] = useState(STEPS.INTRO);
-  const [
-    isLoadingSubscriptions,
-    subscriptions,
-    setSubscriptions,
-  ] = useSubscriptions();
-  const isSubscribed = subscriptions['common-voice'];
-  const setIsSubscribed = (subscribed: boolean) =>
-    setSubscriptions((oldSubscriptions: Subscriptions) => ({
-      ...oldSubscriptions,
-      'common-voice': subscribed,
-    }));
+  const [shouldSubscribe, setShouldSubscribe] = useState(false);
 
   const initialState = customGoal
     ? {
@@ -297,7 +282,7 @@ export default function CustomGoal({
           }),
         });
       }
-      if (isSubscribed) {
+      if (shouldSubscribe) {
         await api.subscribeToNewsletter(email);
       }
       refreshUser();
@@ -384,9 +369,8 @@ export default function CustomGoal({
           state={state}
           {...{
             dashboardLocale,
-            isLoadingSubscriptions,
-            isSubscribed,
-            setIsSubscribed,
+            shouldSubscribe,
+            setShouldSubscribe,
           }}
         />
       )}

--- a/web/src/components/pages/dashboard/goals/custom-goal.tsx
+++ b/web/src/components/pages/dashboard/goals/custom-goal.tsx
@@ -1,8 +1,13 @@
 import { Localized } from 'fluent-react/compat';
 import * as React from 'react';
 import { useState } from 'react';
-import { CustomGoalParams } from 'common';
-import { useAccount, useAction, useAPI } from '../../../../hooks/store-hooks';
+import { CustomGoalParams, Subscriptions } from 'common';
+import {
+  useAccount,
+  useAction,
+  useAPI,
+  useSubscriptions,
+} from '../../../../hooks/store-hooks';
 import { User } from '../../../../stores/user';
 import Modal from '../../../modal/modal';
 import { PenIcon } from '../../../ui/icons';
@@ -219,7 +224,18 @@ export default function CustomGoal({
   }
 
   const [touchedStepIndex, setTouchedStepIndex] = useState(STEPS.INTRO);
-  const [subscribed, setSubscribed] = useState(false);
+  const [
+    isLoadingSubscriptions,
+    subscriptions,
+    setSubscriptions,
+  ] = useSubscriptions();
+  const isSubscribed = subscriptions['common-voice'];
+  const setIsSubscribed = (subscribed: boolean) =>
+    setSubscriptions((oldSubscriptions: Subscriptions) => ({
+      ...oldSubscriptions,
+      'common-voice': subscribed,
+    }));
+
   const initialState = customGoal
     ? {
         daysInterval: customGoal.days_interval,
@@ -281,7 +297,7 @@ export default function CustomGoal({
           }),
         });
       }
-      if (subscribed) {
+      if (isSubscribed) {
         await api.subscribeToNewsletter(email);
       }
       refreshUser();
@@ -366,7 +382,12 @@ export default function CustomGoal({
             onClick: () => handleNext(),
           }}
           state={state}
-          {...{ dashboardLocale, subscribed, setSubscribed }}
+          {...{
+            dashboardLocale,
+            isLoadingSubscriptions,
+            isSubscribed,
+            setIsSubscribed,
+          }}
         />
       )}
     </div>

--- a/web/src/components/pages/datasets/subscribe.tsx
+++ b/web/src/components/pages/datasets/subscribe.tsx
@@ -48,7 +48,8 @@ class Subscribe extends React.Component<Props, State> {
     this.setState({ submitStatus: 'submitting' });
     try {
       await api.subscribeToNewsletter(
-        account ? account.email : this.state.email
+        account ? account.email : this.state.email,
+        'common-voice-datasets'
       );
       addNotification(
         <Localized id="profile-form-submit-saved">
@@ -77,7 +78,7 @@ class Subscribe extends React.Component<Props, State> {
 
     return (
       <div className="dataset-subscribe">
-        <Localized id="want-dataset-update">
+        <Localized id="dataset-update-signup">
           <h2 />
         </Localized>
         <div>

--- a/web/src/components/pages/profile/settings/settings.css
+++ b/web/src/components/pages/profile/settings/settings.css
@@ -108,26 +108,31 @@
             }
         }
 
-        & label {
+        label {
             color: var(--near-black);
             opacity: 0.5;
         }
 
-        & input {
+        label + label {
+            padding-top: 1em;
+        }
+
+        input {
             align-self: flex-start;
         }
 
-        & a {
+        a {
             color: var(--blue);
             text-decoration: underline;
         }
 
-        & .privacy-and-terms {
+        .privacy-and-terms {
             display: flex;
             flex-direction: row;
             justify-content: space-between;
+            padding-top: 1em;
 
-            & svg {
+            svg {
                 margin-inline-end: 5px;
                 flex-shrink: 0;
                 width: 16px;
@@ -136,10 +141,16 @@
                     fill: var(--warm-grey);
                 }
             }
+
+            @media (--md-up) {
+                padding-top: 0;
+            }
         }
 
-        & .terms {
+        .terms {
+            display: block;
             font-weight: 600;
+            padding-top: 1em;
         }
     }
 

--- a/web/src/components/pages/profile/settings/settings.tsx
+++ b/web/src/components/pages/profile/settings/settings.tsx
@@ -22,7 +22,7 @@ import {
 } from '../../../ui/ui';
 
 import './settings.css';
-import { useIsSubscribed } from '../../../../hooks/store-hooks';
+import { useSubscriptions } from '../../../../hooks/store-hooks';
 
 const Section = ({
   title,
@@ -59,7 +59,7 @@ interface Props extends LocalizationProps, PropsFromState, PropsFromDispatch {}
 
 function Settings(props: Props) {
   const { account, addNotification, getString, saveAccount } = props;
-  const isSubscribed = useIsSubscribed();
+  const [isLoadingSubscriptions, subscriptions] = useSubscriptions();
 
   useEffect(() => {
     const { pathname, search } = location;
@@ -115,18 +115,29 @@ function Settings(props: Props) {
             </a>
           }>
           <div className="email-section">
-            {isSubscribed == null ? (
+            {isLoadingSubscriptions ? (
               <div />
             ) : (
-              <LabeledCheckbox
-                disabled={true}
-                checked={isSubscribed}
-                label={
-                  <Localized id="email-opt-in-info">
-                    <span />
-                  </Localized>
-                }
-              />
+              <div>
+                <LabeledCheckbox
+                  disabled={true}
+                  checked={subscriptions['common-voice']}
+                  label={
+                    <Localized id="email-opt-in-info">
+                      <span />
+                    </Localized>
+                  }
+                />
+                <LabeledCheckbox
+                  disabled={true}
+                  checked={subscriptions['common-voice-datasets']}
+                  label={
+                    <Localized id="dataset-email-opt-in-info">
+                      <span />
+                    </Localized>
+                  }
+                />
+              </div>
             )}
             <div className="privacy-and-terms">
               <InfoIcon />
@@ -136,7 +147,6 @@ function Settings(props: Props) {
                   privacyLink={<LocaleLink to={URLS.PRIVACY} blank />}>
                   <div />
                 </Localized>
-                <br />
                 <Localized id="read-terms-q">
                   <LocaleLink to={URLS.TERMS} className="terms" blank />
                 </Localized>

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,7 +1,7 @@
 import { AllGoals, CustomGoalParams } from 'common';
 import { LanguageStats } from 'common';
 import { UserClient } from 'common';
-import { WeeklyChallenge, Challenge, TeamChallenge } from 'common';
+import { WeeklyChallenge, Challenge, TeamChallenge, Newsletter } from 'common';
 import { Locale } from '../stores/locale';
 import { User } from '../stores/user';
 import { USER_KEY } from '../stores/root';
@@ -254,8 +254,13 @@ export default class API {
     });
   }
 
-  subscribeToNewsletter(email: string): Promise<void> {
-    return this.fetch(API_PATH + '/newsletter/' + email, { method: 'POST' });
+  subscribeToNewsletter(
+    email: string,
+    newsletter: Newsletter = 'common-voice'
+  ): Promise<void> {
+    return this.fetch(`${API_PATH}/newsletter/${newsletter}/${email}`, {
+      method: 'POST',
+    });
   }
 
   saveAvatar(type: 'default' | 'file' | 'gravatar', file?: Blob) {


### PR DESCRIPTION
Implements [OI-1449](https://jira.mozilla.com/browse/OI-1449)

This commit adds a new common-voice-datasets mailing list, and
paves the way for easily adding additional mailing lists in the
future.

Note: we also still need to *create* this mailing list. It doesn't
currently exist on https://www.mozilla.org/en-US/newsletter/existing.

Screenshots:

<img width="1057" alt="Screen Shot 2020-03-26 at 7 51 52 PM" src="https://user-images.githubusercontent.com/1840854/77717325-63045b80-6f9d-11ea-82bc-581c6113eb32.png">
<img width="933" alt="Screen Shot 2020-03-26 at 7 58 29 PM" src="https://user-images.githubusercontent.com/1840854/77717330-64358880-6f9d-11ea-892d-c8a62360551a.png">
