### PR TITLE
Download personal recorded dataset (#1210).

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -50,6 +50,7 @@
     "redlock": "^4.0.0",
     "request": "^2.85.0",
     "request-promise-native": "^1.0.7",
+    "s3-zip": "^3.1.3",
     "stream-transcoder": "0.0.5",
     "ts-node": "^8.6.2",
     "universal-analytics": "^0.4.20"

--- a/server/src/lib/api.ts
+++ b/server/src/lib/api.ts
@@ -83,6 +83,7 @@ export default class API {
     );
     router.post('/user_client/avatar_clip', this.saveAvatarClip);
     router.get('/user_client/avatar_clip', this.getAvatarClip);
+    router.get('/user_client/recordings', this.getRecordings);
     router.get('/user_client/delete_avatar_clip', this.deleteAvatarClip);
     router.post('/user_client/:locale/goals', this.createCustomGoal);
     router.get('/user_client/goals', this.getGoals);
@@ -353,6 +354,12 @@ export default class API {
       response.statusMessage = 'save avatar clip error';
       response.json(error);
     }
+  };
+
+  getRecordings = async (request: Request, response: Response) => {
+    response.attachment('recordings.zip');
+    let recordings = await this.bucket.getRecordedClips(request.client_id);
+    recordings.pipe(response).on('end', () => { response.end(); });
   };
 
   getAvatarClip = async (request: Request, response: Response) => {

--- a/web/locales/en/messages.ftl
+++ b/web/locales/en/messages.ftl
@@ -834,6 +834,17 @@ why-delete-recordings = Common Voice recordings are used by academics, small bus
     Can you let us know why you would like your recordings deleted?
 profile-form-delete = Delete Profile
 
+## Profile Download
+download-q = Need to download your data?
+download-info = Tell us what you'd like to download:
+download-profile-title = Profile
+download-profile-info = Includes email, username & demographic info
+download-recordings-title = Recordings
+download-recordings-info = Includes mp3's and related sentences
+download-size = Size
+download-speed = ### k/mb
+download-selected = Selected
+download-start = Start [# k/mb] Download
 
 ## Landing
 welcome-staff = Welcome { $company } staff!

--- a/web/src/components/pages/profile/download/download.css
+++ b/web/src/components/pages/profile/download/download.css
@@ -1,0 +1,89 @@
+@import url('../../../vars.css');
+
+.profile-download {
+    margin-top: 40px;
+
+    &:first-child {
+        margin-top: 0;
+    }
+
+    & .download-item.three-columns {
+        display: flex;
+        flex-direction: row;
+
+        & > * {
+            box-sizing: border-box;
+            width: 100%;
+
+            @media (--sm-down) {
+                margin-bottom: 10px;
+            }
+
+            @media (--md-up) {
+                width: calc(50% - var(--profile-column-margin) / 2);
+
+                &:nth-child(2n) {
+                    margin-inline-start: var(--profile-column-margin);
+                }
+            }
+        }
+    }
+
+    & .section-title {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+    }
+
+    & h2 {
+        margin-bottom: 10px;
+        font-family: var(--strong-font-family);
+        font-size: var(--font-size-lg);
+        font-weight: 600;
+    }
+
+    & .section-info {
+        border-bottom: 2px solid var(--grey);
+        padding-bottom: 2em;
+        color: var(--near-black);
+    }
+
+    & .section-body {
+        padding-top: 32px;
+        display: flex;
+        flex-direction: column;
+    }
+
+    & .button {
+        margin-top: 2em;
+        background-color: var(--valid-green);
+    }
+
+    & .download-item {
+        border-bottom: 2px solid var(--grey);
+        padding-bottom: 2em;
+        margin-bottom: 2em;
+
+        & p {
+            color: var(--near-black);
+        }
+    }
+
+    & .download-item-info {
+        flex-shrink: 0.2;
+    }
+
+    & .download-item-size2 {
+        border-left: 2px solid var(--grey);
+        border-right: 2px solid var(--grey);
+        padding-left: 3em;
+    }
+
+    & .download-size {
+        text-transform: uppercase;
+    }
+
+    & .download-item svg {
+        filter: grayscale(1) contrast(5);
+    }
+}

--- a/web/src/components/pages/profile/download/download.tsx
+++ b/web/src/components/pages/profile/download/download.tsx
@@ -1,0 +1,170 @@
+import {
+  Localized,
+  withLocalization,
+  WithLocalizationProps,
+} from '@fluent/react';
+import * as React from 'react';
+import { MicIcon, UserIcon } from '../../../ui/icons';
+import {
+  LabeledCheckbox,
+  Button,
+} from '../../../ui/ui';
+const pick = require('lodash.pick');
+import './download.css';
+import API from '../../../../services/api';
+import { useState } from 'react';
+import { useAPI, useAccount } from '../../../../hooks/store-hooks';
+import { UserClient } from 'common';
+
+const Section = ({
+  title,
+  titleAction,
+  info = '',
+  className = '',
+  children,
+  ...props
+}: {
+  title: string;
+  titleAction?: React.ReactNode;
+  info?: string;
+  className?: string;
+  children?: React.ReactNode;
+}) => (
+    <section className={'profile-download ' + className} {...props}>
+      <div className="section-title">
+        <h2>{title}</h2>
+        {titleAction}
+      </div>
+      <div className="section-info">
+        <p>{info}</p>
+      </div>
+      {children && <div className="section-body">{children}</div>}
+    </section>
+  );
+
+const Item = ({
+  icon,
+  title,
+  info = '',
+  className = '',
+  isSelected = true,
+  setIsSelected,
+  children,
+  ...props
+}: {
+  icon: React.ReactNode;
+  title: string;
+  info?: string;
+  className?: string;
+  isSelected: boolean;
+  setIsSelected: any;
+  children?: React.ReactNode;
+}) => {
+
+  return (
+    <div className={'download-item three-columns' + className} {...props}>
+      {icon}
+      <div className='download-item-info'>
+        <h3>{title}</h3>
+        <p>{info}</p>
+      </div>
+      <div className='download-item-size'>
+        <Localized id="download-size">
+          <p className="download-size" />
+        </Localized>
+        <Localized id="download-speed">
+          <p className="download-speed" />
+        </Localized>
+      </div>
+      <LabeledCheckbox
+        checked={isSelected}
+        onChange={(event: any) => {
+          setIsSelected(event.target.checked);
+        }}
+        label={
+          <Localized id="download-selected">
+            <span />
+          </Localized>
+        }
+      />
+    </div>
+  );
+}
+
+function downloadTextAsFile(filename: string, text: string) {
+  return downloadAsFile(filename, 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
+}
+
+function downloadBlobAsFile(filename: string, blob: any) {
+  return downloadAsFile(filename, window.URL.createObjectURL(blob));
+}
+
+function downloadAsFile(filename: string, url: string) {
+  var a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.style.display = 'none';
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+}
+
+function getProfileInfo(account: UserClient) {
+  return [
+    ...Object.entries(pick(account, 'email', 'username', 'age', 'gender')),
+    ...account.locales.reduce((all, l, i) => {
+      const localeLabel = 'language ' + (i + 1);
+      return [
+        ...all,
+        [localeLabel, l.locale],
+        [localeLabel + ' accent', l.accent],
+      ];
+    }, []),
+  ]
+    .map(([key, value]) => key + ': ' + value)
+    .join('\n');
+}
+
+function download(account: UserClient, api: API, infoSelected: boolean, recordingsSelected: boolean) {
+  if (infoSelected)
+    downloadTextAsFile('profile.txt', getProfileInfo(account));
+
+  if (recordingsSelected)
+    api.fetchRecordings()
+      .then((response: any) => response.blob())
+      .then((blob: any) => downloadBlobAsFile('recordings.zip', blob))
+      .catch((err: any) => console.error(err));;
+}
+
+function DownloadProfile(props: WithLocalizationProps) {
+  const api = useAPI();
+  const account = useAccount();
+  const { getString } = props;
+
+  const [infoSelected, setInfoSelected] = useState(true);
+  const [recordingsSelected, setRecordingsSelected] = useState(true);
+
+  return (
+    <Section title={getString('download-q')} info={getString('download-info')} >
+      <Item
+        icon={<UserIcon />}
+        title={getString('download-profile-title')}
+        info={getString('download-profile-info')}
+        isSelected={infoSelected}
+        setIsSelected={setInfoSelected}
+      />
+      <Item
+        icon={<MicIcon />}
+        title={getString('download-recordings-title')}
+        info={getString('download-recordings-info')}
+        isSelected={recordingsSelected}
+        setIsSelected={setRecordingsSelected}
+      />
+      <Localized id="download-start">
+        <Button rounded disabled={!infoSelected && !recordingsSelected} onClick={() => download(account, api, infoSelected, recordingsSelected)} />
+      </Localized>
+    </Section>
+  );
+}
+
+export default withLocalization(DownloadProfile);

--- a/web/src/components/pages/profile/layout.css
+++ b/web/src/components/pages/profile/layout.css
@@ -4,6 +4,7 @@
     &.info,
     &.avatar,
     &.settings,
+    &.download,
     &.delete {
         & header {
             @media (--lg-up) {

--- a/web/src/components/pages/profile/layout.tsx
+++ b/web/src/components/pages/profile/layout.tsx
@@ -22,38 +22,9 @@ import AvatarSetup from './avatar-setup/avatar-setup';
 import DeleteProfile from './delete/delete';
 import InfoPage from './info/info';
 import Settings from './settings/settings';
+import DownloadProfile from './download/download';
 
 import './layout.css';
-
-function downloadData(account: UserClient) {
-  const text = [
-    ...Object.entries(pick(account, 'email', 'username', 'age', 'gender')),
-    ...account.locales.reduce((all, l, i) => {
-      const localeLabel = 'language ' + (i + 1);
-      return [
-        ...all,
-        [localeLabel, l.locale],
-        [localeLabel + ' accent', l.accent],
-      ];
-    }, []),
-  ]
-    .map(([key, value]) => key + ': ' + value)
-    .join('\n');
-
-  const element = document.createElement('a');
-  element.setAttribute(
-    'href',
-    'data:text/plain;charset=utf-8,' + encodeURIComponent(text)
-  );
-  element.setAttribute('download', 'profile.txt');
-
-  element.style.display = 'none';
-  document.body.appendChild(element);
-
-  element.click();
-
-  document.body.removeChild(element);
-}
 
 interface PropsFromState {
   user: User.State;
@@ -62,11 +33,12 @@ interface PropsFromState {
 interface Props extends LocalePropsFromState, PropsFromState {}
 
 const Layout = ({ toLocaleRoute, user }: Props) => {
-  const [infoRoute, avatarRoute, prefRoute, deleteRoute] = [
+  const [infoRoute, avatarRoute, prefRoute, deleteRoute, downloadRoute] = [
     URLS.PROFILE_INFO,
     URLS.PROFILE_AVATAR,
     URLS.PROFILE_SETTINGS,
     URLS.PROFILE_DELETE,
+    URLS.PROFILE_DOWNLOAD,
   ].map(r => toLocaleRoute(r));
   return (
     <div className="profile-layout">
@@ -86,6 +58,7 @@ const Layout = ({ toLocaleRoute, user }: Props) => {
               icon: <TrashIcon />,
               id: 'profile-form-delete',
             },
+            { route: downloadRoute, icon: <CloudIcon />, id: 'download-profile' },
           ]
             .slice(0, user.account ? Infinity : 1)
             .map(({ route, icon, id }) => (
@@ -96,14 +69,6 @@ const Layout = ({ toLocaleRoute, user }: Props) => {
                 </Localized>
               </NavLink>
             ))}
-          {user.account && (
-            <a onClick={() => downloadData(user.account)} href="#">
-              <CloudIcon />
-              <Localized id="download-profile">
-                <span className="text" />
-              </Localized>
-            </a>
-          )}
         </div>
       </div>
       <div className="content">
@@ -113,6 +78,7 @@ const Layout = ({ toLocaleRoute, user }: Props) => {
             { route: avatarRoute, Component: AvatarSetup },
             { route: prefRoute, Component: Settings },
             { route: deleteRoute, Component: DeleteProfile },
+            { route: downloadRoute, Component: DownloadProfile },
           ].map(({ route, Component }) => (
             <Route
               key={route}

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -234,6 +234,10 @@ export default class API {
     );
   }
 
+  fetchRecordings(): Promise<Response> {
+    return fetch(API_PATH + '/user_client/recordings');
+  }
+
   fetchUserClients(): Promise<UserClient[]> {
     return this.fetch(API_PATH + '/user_clients');
   }

--- a/web/src/urls.ts
+++ b/web/src/urls.ts
@@ -12,6 +12,7 @@ export default Object.freeze({
   PROFILE_AVATAR: PROFILE + '/avatar',
   PROFILE_SETTINGS: PROFILE + '/settings',
   PROFILE_DELETE: PROFILE + '/delete',
+  PROFILE_DOWNLOAD: PROFILE + '/download',
 
   DASHBOARD,
   STATS: '/stats',


### PR DESCRIPTION
This PR addresses the issue described in #1210.

### Notes
-  `Recordings.zip` contains all mp3 files in `client_id/` S3 'folder' (see `Bucket.getRecordedClips`).
-  `Profile.txt` and `recordings.zip` are downloaded as 2 separate files.

### Questions
1. Is `### k/mb` a placeholder for actual size of items?
2. What should we do with huge downloads?
3. Is filtering by `mp3` extension logic is good enough?
4. Is downloading 2 separate files is good enough?
5. Is endpoint `/user_client/recordings` properly named?
6. Have I properly figured out where to put methods in `bucket.ts`, `api.ts`, `download.tsx`?
7. Should download functions be moved out of `download.tsx`?

### Need help with
- Styling.
- Translations.

### Tested
 - Locally using docker with Auth0 and S3.
 - Needs testing for bigger accounts.

### UX notes
Should Download button be green? There are different button colors in Profile now:
 - `Download` - green in mock design
 - `Save` - grey
 - `Delete` - blue
 - `Record voicewave` - white
