### PR TITLE
Add optional scrollable parameter to stats cards for overflow

### DIFF
--- a/web/src/components/pages/dashboard/stats/stats-card.tsx
+++ b/web/src/components/pages/dashboard/stats/stats-card.tsx
@@ -22,6 +22,7 @@ export default function StatsCard({
   overlay?: React.ReactNode;
   tabs?: { [label: string]: (props: { locale?: string }) => any };
   challenge?: boolean;
+  scrollable?: boolean;
   currentLocale?: string;
 }) {
   const [locale, setLocale] = useState(ALL_LOCALES);

--- a/web/src/components/pages/dashboard/stats/stats.tsx
+++ b/web/src/components/pages/dashboard/stats/stats.tsx
@@ -33,6 +33,7 @@ const StatsPage = ({ allGoals, dashboardLocale }: Props) =>
 
       <div className="cards">
         <StatsCard
+          scrollable
           key="contribution"
           title="contribution-activity"
           currentLocale={dashboardLocale}

--- a/web/src/components/pages/home/stats.tsx
+++ b/web/src/components/pages/home/stats.tsx
@@ -37,14 +37,16 @@ function StatsCard({
   children,
   onLocaleChange,
   header,
+  scrollable,
 }: {
   children?: React.ReactNode;
   header: React.ReactNode;
   onLocaleChange: (locale: string) => any;
+  scrollable?: boolean;
 }) {
   const [locale, setLocale] = useState(ALL_LOCALES);
   return (
-    <div className="home-card">
+    <div className={`home-card ${scrollable ? 'scrollable' : ''}`}>
       <div className="head">
         {header}
         <LanguageSelect
@@ -342,6 +344,7 @@ export const VoiceStats = connect<PropsFromState>(mapStateToProps)(
       const { data } = this.state;
       return (
         <StatsCard
+          scrollable
           header={
             <div>
               <Localized id="voices-online">

--- a/web/src/components/plot/plot.css
+++ b/web/src/components/plot/plot.css
@@ -1,25 +1,33 @@
 .plot {
     margin-top: 28px;
     height: 170px;
-    @media (--md-only) {
-        width: 175%;
-    }
-    @media (--xs-only) {
-        width: 200%;
-    }
 
-    & .tick-label {
+    .tick-label {
         font-size: var(--font-size-xs);
         fill: var(--warm-grey);
     }
 
-    & rect {
+    rect {
         &.bg {
             fill: var(--grey);
         }
 
         &.current {
             fill: var(--valid-green);
+        }
+    }
+}
+
+.scrollable {
+    overflow-x: scroll;
+
+    .plot {
+        @media (--md-only) {
+            width: 175%;
+        }
+
+        @media (--xs-only) {
+            width: 200%;
         }
     }
 }


### PR DESCRIPTION
* Fixes bug introduced by #3006 that plots on homepage are overflowing into 200% width
* Introduces optional `scrollable` parameter for stats cards to selectively allow for overflow scroll to preserve readable labels in mobile for graphs