### PR TITLE
Fix a race condition when updating demographics data

### DIFF
--- a/server/src/lib/model/user-client.ts
+++ b/server/src/lib/model/user-client.ts
@@ -280,10 +280,9 @@ const UserClient = {
     );
     // the accountClientId can't be a placeholder value otherwise it'll
     // treat any ? in the username or email as a placeholder also and the query will break
-
-    updateDemographics(accountClientId, data.age, data.gender);
-
+    const updateDemographicsPromise = updateDemographics(accountClientId, data.age, data.gender);
     await Promise.all([
+      updateDemographicsPromise,
       this.claimContributions(accountClientId, clientIds),
       locales && updateLocales(accountClientId, locales),
     ]);


### PR DESCRIPTION
This is caused by not awaiting the updateDemographics() promise. It
it therefore scheduled for running, but may be executed *after* the
UserClient.findAccount() call is awaited. Therefore, there is race
between updating the demographics and querying for it later, resulting
in a non-deterministic retrieval and the gender/age data sometimes
disapearing from the form. This is confusing for the user who thinks
the data was not saved.

I've seen it happening on the prod website.