### PR TITLE
Reduce min recording length back down to 1s

### DIFF
--- a/web/src/components/pages/contribution/speak/speak.tsx
+++ b/web/src/components/pages/contribution/speak/speak.tsx
@@ -47,7 +47,7 @@ import { SentenceRecording } from './sentence-recording';
 
 import './speak.css';
 
-const MIN_RECORDING_MS = 1500;
+const MIN_RECORDING_MS = 1000;
 const MIN_RECORDING_MS_BENCHMARK = 500;
 const MAX_RECORDING_MS = 10000;
 const MIN_VOLUME = 8; // Range: [0, 255].


### PR DESCRIPTION
We originally increased the min recording length to 1.5s in an attempt to deal with blank clips, but that wasn't actually the source of the problem, so I'm dropping it down to 1s to better support languages with shorter sentence segments.