### PR TITLE
Add 2 variants to Catalan language for learners (non-native) speakers

### DIFF
--- a/web/src/stores/demographics.ts
+++ b/web/src/stores/demographics.ts
@@ -11,6 +11,8 @@ export const ACCENTS: any = {
     northwestern: 'nord-occidental',
     northern: 'septentrional',
     valencian: 'valencià',
+    learner_es: 'aprenent (recent, des del castellà)',
+    learner_other: 'aprenent (recent, des d\'altres llengües)',
   },
   cy: {
     united_kingdom: 'Y Deyrnas Unedig Cymraeg',


### PR DESCRIPTION
It just add 2 variants for Catalan non-native speakers. One value for Spanish native speakers, and other one for native speakers of other languages.