### PR TITLE
speak: add "discard ongoing recording" shortcut

### DIFF
--- a/web/locales/en/messages.ftl
+++ b/web/locales/en/messages.ftl
@@ -287,7 +287,7 @@ shortcut-record-toggle-label = Record/Stop
 shortcut-rerecord-toggle = [1-5]
 shortcut-rerecord-toggle-label = Re-record clip
 
-shortcut-discard-ongoing-recording = Backspace
+shortcut-discard-ongoing-recording = ESC
 shortcut-discard-ongoing-recording-label = Discard ongoing recording
 
 shortcut-submit = Return

--- a/web/locales/en/messages.ftl
+++ b/web/locales/en/messages.ftl
@@ -287,6 +287,9 @@ shortcut-record-toggle-label = Record/Stop
 shortcut-rerecord-toggle = [1-5]
 shortcut-rerecord-toggle-label = Re-record clip
 
+shortcut-discard-ongoing-recording = Backspace
+shortcut-discard-ongoing-recording-label = Discard ongoing recording
+
 shortcut-submit = Return
 shortcut-submit-label = Submit clips
 

--- a/web/src/components/pages/contribution/speak/speak.tsx
+++ b/web/src/components/pages/contribution/speak/speak.tsx
@@ -207,7 +207,7 @@ class SpeakPage extends React.Component<Props, State> {
     this.audio.setVolumeCallback(this.updateVolume.bind(this));
 
     document.addEventListener('visibilitychange', this.releaseMicrophone);
-    document.addEventListener('keyup', this.handleKeyUprerecording);
+    document.addEventListener('keyup', this.handleKeyUp);
 
     if (
       !this.audio.isMicrophoneSupported() ||
@@ -218,7 +218,7 @@ class SpeakPage extends React.Component<Props, State> {
   }
 
   async componentWillUnmount() {
-    document.removeEventListener('keyup', this.handleKeyUprerecording);
+    document.removeEventListener('keyup', this.handleKeyUp);
 
     document.removeEventListener('visibilitychange', this.releaseMicrophone);
     if (!this.isRecording) return;
@@ -229,7 +229,12 @@ class SpeakPage extends React.Component<Props, State> {
     return this.state.recordingStatus === 'recording';
   }
 
-  private handleKeyUprerecording = async (event: KeyboardEvent) => {
+  /**
+   * Shortcuts which need more complex matching than a single "key comparison"
+   * are handled here.
+   * If possible use the `shortcuts` prop of `ContributionPage` instead.
+   */
+  private handleKeyUp = async (event: KeyboardEvent) => {
     let reRecordIndex = null;
     //for both sets of number keys on a keyboard with shift key
     if (event.code === 'Digit1' || event.code === 'Numpad1') {
@@ -242,7 +247,7 @@ class SpeakPage extends React.Component<Props, State> {
       reRecordIndex = 3;
     } else if (event.code === 'Digit5' || event.code === 'Numpad5') {
       reRecordIndex = 4;
-    } else if (event.key === "Backspace" || event.key === "x") {
+    } else if (event.key === "Esc" || event.key === "Escape") {
       if (this.isRecording) {
         trackRecording('discard-ongoing', this.props.locale);
         await this.discardRecording();
@@ -752,15 +757,14 @@ class SpeakPage extends React.Component<Props, State> {
               {
                 key: 'shortcut-discard-ongoing-recording',
                 label: 'shortcut-discard-ongoing-recording-label',
-                icon: <span>⌫</span>,
-                // This is handled in handleKeyDown, separately.
+                // This is handled in handleKeyUp, separately.
                 action: () => {},
               },
               {
                 key: 'shortcut-submit',
                 label: 'shortcut-submit-label',
                 icon: <ReturnKeyIcon />,
-                // This is handled in handleKeyDown, separately.
+                // This is handled in handleKeyUp, separately.
                 action: () => {},
               },
             ]}

--- a/web/src/components/pages/contribution/speak/speak.tsx
+++ b/web/src/components/pages/contribution/speak/speak.tsx
@@ -229,26 +229,31 @@ class SpeakPage extends React.Component<Props, State> {
     return this.state.recordingStatus === 'recording';
   }
 
-  private handleKeyUprerecording = async (event: any) => {
-    let index = null;
+  private handleKeyUprerecording = async (event: KeyboardEvent) => {
+    let reRecordIndex = null;
     //for both sets of number keys on a keyboard with shift key
     if (event.code === 'Digit1' || event.code === 'Numpad1') {
-      index = 0;
+      reRecordIndex = 0;
     } else if (event.code === 'Digit2' || event.code === 'Numpad2') {
-      index = 1;
+      reRecordIndex = 1;
     } else if (event.code === 'Digit3' || event.code === 'Numpad3') {
-      index = 2;
+      reRecordIndex = 2;
     } else if (event.code === 'Digit4' || event.code === 'Numpad4') {
-      index = 3;
+      reRecordIndex = 3;
     } else if (event.code === 'Digit5' || event.code === 'Numpad5') {
-      index = 4;
+      reRecordIndex = 4;
+    } else if (event.key === "Backspace" || event.key === "x") {
+      if (this.isRecording) {
+        trackRecording('discard-ongoing', this.props.locale);
+        await this.discardRecording();
+      }
     }
 
-    if (index !== null) {
+    if (reRecordIndex !== null) {
       trackRecording('rerecord', this.props.locale);
       await this.discardRecording();
       this.setState({
-        rerecordIndex: index,
+        rerecordIndex: reRecordIndex,
       });
     }
   };
@@ -743,6 +748,13 @@ class SpeakPage extends React.Component<Props, State> {
                 key: 'shortcut-rerecord-toggle',
                 label: 'shortcut-rerecord-toggle-label',
                 action: this.handleRecordClick,
+              },
+              {
+                key: 'shortcut-discard-ongoing-recording',
+                label: 'shortcut-discard-ongoing-recording-label',
+                icon: <span>⌫</span>,
+                // This is handled in handleKeyDown, separately.
+                action: () => {},
               },
               {
                 key: 'shortcut-submit',

--- a/web/src/services/tracker.ts
+++ b/web/src/services/tracker.ts
@@ -69,6 +69,7 @@ export function trackRecording(
     | 'record'
     | 'submit'
     | 'rerecord'
+    | 'discard-ongoing'
     | 'view-shortcuts'
     | 'shortcut'
     | 'skip'


### PR DESCRIPTION
Allow the user to signal that he messed up and want to begin again.

Could also consider starting recording again immediately? (this would be my personal preference, but without extra work it isn't really visible to the user that something happened. If there was a duration counter visible it would be less of an issue.)

Related to: #1052, #2105