### PR TITLE
Add danish europarl sentences

### DIFF
--- a/server/data/da/europarl-v7-da.txt
+++ b/server/data/da/europarl-v7-da.txt
@@ -30,7 +30,6 @@ Det er fasen for forhåndsregistrering af stoffer.
 Det bliver en vidunderlig kontrol!
 Udvidelser, som er imod borgernes ønske, bør undgås.
 Vi har til gode at se, hvad der menes med genopbygning.
-Et andet vigtigt punkt er transportørvalg og transportørforvalg.
 Lovgivningen, som vi udtaler os om i dag, byder på mange muligheder.
 I dialogen med de indonesiske myndigheder påpeges også nødvendigheden af frie og fair valg.
 Det er noget, vi er nødt til at tage meget, meget alvorligt.
@@ -74,7 +73,6 @@ Men kan man se, kan man identificere de forskellige mål med idrætsudøvelsen?
 Den bureaukratiske byrde for virksomhederne skal reduceres, og de retlige rammer skal forenkles.
 Jeg formoder, det var en finne.
 Vi må være helt klar over følgerne af det, der bliver foreslået.
-Vi ser tidens tegn, hvis vi vedtager den tredje jernbanepakke.
 Det er trods alt den nyttigste måde at anvende pengene på.
 De er tæt forbundet til dem og afhængige af dem.
 Vi bekymrer os over menneskerettighederne, og jeg vil rejse to spørgsmål.
@@ -99,12 +97,10 @@ Det ville føre til mindre sikkerhed kun at udføre kontroller efter hændelsen.
 Dog må man i ærlighedens og realismens navn tilføje et forbehold.
 Der er ikke foretaget nogen stresstest endnu.
 Betænkningen pålægger ikke de formidlende banker oplysningspligt.
-Derfor er en foranstaltningspakke påkrævet så hurtigt som muligt.
 Af denne årsag stemte jeg imod.
 Det var den ene mulighed, nemlig at anvende kriteriet objektivt dårligt stillede regioner.
 Vi må forenkle fremtiden og lægge fortiden bag os.
 I dag er disse ord blevet latterlige.
-For selvservicering kommer der nu ikke noget obligatorisk tilladelsessystem.
 Jeg mener, at det er på høje tid at opgive den historiske tilgang.
 Lad os tale åbent om dette spørgsmål.
 Derfor mine lykønskninger.
@@ -122,7 +118,6 @@ Den slår til lyd for en offensiv, ekspansionistisk politik.
 Så kom det indre marked og den fælles europæiske mønt imidlertid.
 Det var også min holdning.
 Jeg håber, at det fører til, at sagen hurtigt bliver taget op igen.
-Jeg vil navnlig gerne her fokusere på en styrkelse af flerniveaustyring.
 Vi ønsker en prioritering af multilaterale tiltag til løsning af internationale problemer.
 Jeg ønsker at takke kommissæren.
 Fører vores helt sikkert gode hensigter stadig til de rigtige resultater?
@@ -144,7 +139,6 @@ Det har efterladt mange af os med flere spørgsmål end svar.
 Det er enten sundhed, der er vigtigst, eller også er det markedet.
 Med direktivet indføres der harmonisering af uddannelseskravene til sygeplejersker.
 De var de primære ofre for de selvudnævnte hellige krigeres kaste.
-Vi opfordrer de belarussiske myndigheder til at løslade disse øjeblikkeligt.
 Jeg har imidlertid forbehold vedrørende de sprog, der skal anvendes.
 Lad mig for det tredje nævne undtagelsesbestemmelserne.
 Vi vil være forsigtige med nye love, for erhvervslivet klager over for meget regulering.
@@ -161,7 +155,6 @@ Det medfører både menneskelige, økonomiske og sociale omkostninger.
 På denne måde opstilles kunstige barrierer for tjenesteudbydernes virksomhed.
 De har varetaget formandskabet med succes.
 For det fjerde findes der også misbrug af statsmonopoler.
-Bør vi gå mere i retning af et formelt banktilsynssystem?
 Men det endelige ord har vores befolkninger.
 Forbrugerorganisationerne vil blive hørt om indholdet i disse mandater.
 Vi er på opløbsstrækningen, men resten af vejen vil stadig være fyldt med udfordringer.
@@ -175,7 +168,6 @@ Dermed vender jeg tilbage til den forrige taler.
 Dette punkt medtages sidst på dagsordenen for i dag.
 Vil kommissæren skride til handling på grundlag af disse forslag?
 Vi må imidlertid ikke glemme, at disse spørgsmål er særdeles politisk følsomme.
-Indtil for nylig var malkekvægbrug askepotsektoren i den britiske landbrugsindustri.
 Derfor har klassificeringen ugyldiggjort sig selv.
 Hvis det er tilfældet, så har jeg misforstået spillet.
 Det giver en mere levende adgang til forhandlingerne end blot en tør tekst.
@@ -183,7 +175,6 @@ Tidligere på året opgav jeg mine vigtigste prioriteter.
 Udvekslingen af bedste praksis er meget vigtig.
 Alt sammen eksempler på de talrige spørgsmål, der rejser sig.
 Det ene er et ortodokst pilgrimscentrum, mens det andet er et katolsk pilgrimscentrum.
-Dette omfatter fem portugisiske langlinefartøjer.
 Der hviler de med et utal af andre børn, og alle er de skuffede.
 Vi har derfor brug for et bedre klima.
 Udlændinge fra tredjelande beskæftiges ofte i de tungeste og lavest betalte job.
@@ -191,7 +182,6 @@ Jeg erkender, at man kan argumentere mod centralisering.
 Så sluttelig vil jeg sige, der skal ligge nogle meget klare svar.
 Jeg kan ikke se, at det kan være længere end seks uger.
 De er et stort fremskridt med hensyn til institutionel beskyttelse af mindretallenes rettigheder.
-Industrien betaler allerede sine infrastrukturafgifter, hvoraf nogle går til miljøforbedringer.
 At bekæmpe handel med kvinder er at bekæmpe et mål, der er i bevægelse.
 Dernæst skal vi tilføje målrettede politikker.
 Har de skjulte ambitioner om at blive en stat?
@@ -206,14 +196,11 @@ Tjenesteydelser af almen interesse er også blevet udelukket.
 De har nu i syv dage levet og overlevet i et absolut helvede.
 Konventet er et instrument.
 Der er derfor behov for klare regler og tillidsskabende foranstaltninger.
-Det, vi alle betaler dyrt for med vore bidrag, skal beviseligt have positive virkninger.
-Vi sender en valgobservatørmission, men vi sender også denne mission.
 Disse foranstaltninger kan inddeles i fem hovedbeskyttelsesniveauer.
 Han har vundet den store gevinst!
 Rusland er jo virkelig det vigtigste problem i vores udenrigspolitik.
 Men erfaringerne skræmmer.
 Det sker både nationalt og internationalt.
-Endvidere, hvor stort vil det maksimale støttebeløb være, målt i procent af skadesomkostningerne?
 Alle nationale mærker bør dog ikke skubbes i baggrunden.
 Rumfarten skal have et nyt skub fremad.
 Nogle slagterforretninger er blevet lukket.
@@ -245,7 +232,6 @@ Jeg hylder disse modige kvinder.
 Vi må undgå, at der sker sociale lagdelinger.
 Derfor kan man vel ikke ønske at patentere disse ting.
 Det er ikke let for dem at involvere sig.
-Personaleressourcerne skal kunne reallokeres mere fleksibelt, og overflødige stillinger nedlægges.
 Jeg vil især fokusere på større bøder og omkostninger i forbindelse med manglende overholdelse.
 Afskedigelser bliver mere og mere almindeligt.
 I den periode har vi oplevet både højdepunkter og lavpunkter i den europæiske politik.
@@ -257,7 +243,6 @@ Det samme gælder udviklingen af nye lægemidler.
 Erfaringen viser, at det er nødvendigt at oprette en permanent europæisk udrykningsstyrke.
 Der er desværre mange fiskeriaftaler, der er værre end denne.
 Den ville således først og fremmest berøre vores medborgere.
-Trichet oplyst, at de langsigtede finansieringsforanstaltninger er blevet forlænget endnu en gang.
 Derfor er det vigtigt, at regeringskonferencen ikke træder et skridt tilbage.
 Trods særdeles gode udgangsbetingelser forløber konjunkturen uregelmæssigt og kommer ikke i fart.
 Vi har afsat hjælp til fiskeriregionerne og hjælp til grænseregionerne.
@@ -319,7 +304,6 @@ For det andet er der en overflod af ordninger.
 Trods de prisværdige hensigter er denne beslutning mangelfuld.
 De talte også om nye elementer.
 Men vi fik først dokumenterne tilsendt i september.
-En sådan overgang kan ikke klares med et seksugerskursus, men kræver et længere uddannelsesforløb.
 Dette er en anden detalje, som vi må tage hensyn til.
 Vi kan sige, at vi er nået det punkt, hvor historiske begivenheder kan ske.
 Det synes imidlertid ikke at ske i biludlejningsindustrien.
@@ -332,7 +316,6 @@ Måske vil han rydde op i sit affald.
 Hermed er dette punkt på dagsordenen afsluttet.
 For de tre foranstaltninger gjaldt der forskellige betingelser for støtte.
 Vi kan ikke kritisere dem for at gøre det, men vi kan undre os.
-Helcom er indehaver af en handlingssplan for reducering af belastninger fra næringsstoffer.
 Det er den form for dynamik og drivkraft, vi behøver for at komme videre.
 Så har vi ikke noget demokrati at tabe, men alt at vinde med samarbejde.
 Jeg ønsker formandskabet held og lykke i det næste halve år.
@@ -343,16 +326,13 @@ Personligt går jeg ikke ind for nyprotektionistiske tendenser i international h
 Uden en enhedsregering for palæstinenserne kan fredsprocessen ikke styres.
 Jeg har stemt for det fælles forslag til beslutning, som jeg finder afbalanceret.
 Jeg vil også nævne det cypriotiske spørgsmål.
-Under den nuværende interimsaftale bliver overholdelsen af disse principper periodisk overvåget.
 Forenkling af processerne er derimod den bedste forudsætning for at bekæmpe disse fænomener.
 Jeg synes, at vi har valgt den forkerte vej.
 Medlemsstaterne er desværre ikke længere herre i eget hus.
 Jeg tror, at vi kan have et fordrejet billede af virkeligheden.
-Hvor bliver den horisontale antidiskriminationslovgivning af?
 Det er bestemt fristende at tænke på gengældelsesaktioner via toldtariffer.
 Støjgener er lokale og bestemt ikke grænseoverskridende.
 Min gruppe stemmer derfor imod alle dele i beslutningen, der indeholder en sådan konklusion.
-Duff vil korrigere mig, hvis jeg har fået lidt forkert fat i tallet.
 Vi lægger vægt på opholdet i andre europæiske lande.
 Liberalisering kan kun gennemføres gradvist og må nødvendigvis ledsages af reguleringsprocedurer.
 Det skyldes naturligvis holdningen fra den amerikanske regering og de multinationale selskaber.
@@ -363,10 +343,8 @@ Hvis det er det, ordføreren har foreslået, kan jeg tilslutte mig denne opdelin
 Endvidere savner jeg incitamenter til at vælge mere sikre trafikmidler såsom toget og cyklen.
 Vi understreger derfor, at denne indsats kræver retfærdige, upartiske og uafhængige retssager.
 Rådets opfattelse i dette spørgsmål er meget mærkelig og desuden urovækkende.
-Selfplanning og analyse kan sættes i gang med det samme.
 Fru formand, det er første gang, man gør mig opmærksom på dette problem.
 Jeg håber, at de vil reagere på kommissærens opfordring.
-Martyrapporten er skrevet på en endnu mindre ansvarlig måde.
 Kosovos uafhængighedserklæring skaber store bølger i vores region.
 Direktivet er baseret på patienternes behov og ikke på finansielle ressourcer.
 Jeg er altid spændt på, hvordan de oversætter sådan noget.
@@ -377,7 +355,6 @@ Det er dejligt at se, at du gør, hvad du lover.
 Tyrkiets reformproces er i gang.
 Det er skuffende, at den nye forfatning ikke kunne vedtages før udvidelsen.
 Jeg er ikke enig i undermineringen af udstationeringsdirektivet.
-Men mangelen på finansiering skal afhjælpes for at høste fordelene ved disse projekter.
 Kan vi ikke nok tilskynde andre donorer til at fokusere på disse områder?
 Man bliver syg efter indtagelse af en vildtmiddag.
 Vi bliver nødt til at finde den rette balance her.
@@ -390,7 +367,6 @@ Et andet område, hvor der er brug for forandring, er pressefrihed og ytringsfri
 Efterhånden som debatten skrider frem på regeringskonferencen, får denne uantagelige konturer.
 Ligger det ud over jeres forestillingsevne?
 Dobbeltregulering af reklame løser ikke problemet.
-Galileo er et nyttigt projekt.
 De strider ikke mod hinanden.
 Samtidig sikrer den borgerne beskyttelse med chartret om grundlæggende rettigheder.
 Israel kan gennemføre langt større operationer i dette område end tidligere.
@@ -419,7 +395,6 @@ Jeg tænker her især på merværdiafgiften.
 Jeg har allerede sagt, hvad vi vil gøre, når jeg har fået oplyst kendsgerningerne.
 Forhåbentlig er der en række undtagelser og reduktioner for børn, studerende og aktive unge.
 Hvad angår alternativerne, er de fremlagt i rammeprogrammet.
-Zuma, at det ganske enkelt ikke er en mulighed.
 Nigeria er desværre et eksempel, som vækker bekymring.
 I denne forbindelse er det postdirektivet, som er lakmusprøven.
 Valget er ikke legitimt, eftersom den siddende præsident kom til magten ved et statskup.
@@ -445,7 +420,6 @@ Denne undervurdering er ikke uskadelig.
 Vi skal åbne døren helt for oplysninger, vi selv søger.
 Disse mål, demokrati og effektivitet, nås kun gennem en føderalistisk model.
 Sundhedstjenester, socialt boligbyggeri, lokalsamfund og børnepasning må ikke behandles som varer.
-Det har bragt os frem i førtiltrædelsesfasen.
 Det betyder, at der inden for seks år vil blive behov for en revision.
 Kosovos regering må forstå, at respekt for mindretals rettigheder er en europæisk værdi.
 Hensigten med dette forslag er, at vi skal kunne sige det samme om skattefar.
@@ -473,18 +447,14 @@ Indlæg af et minuts varighed om politisk vigtige sager
 Under sådanne omstændigheder ville det være dumt ikke at udvide dagsordenen.
 Hundredtusindvis er spærret inde, og mange har ikke adgang til humanitær bistand.
 Positiv særbehandling skal ikke bruges hovedløst og automatisk.
-Der er en række positive ting i denne dechargebetænkning.
 Jeg rejste dertil og spurgte ad.
 Tøver vi nu, siger vi, at menneskerettigheder ikke har nogen plads i international politik.
 Vi skal derfor snarest fremsætte et ændret forslag.
 Jeg vil som dansker gerne sige, at det er jeg fuldstændig enig i.
-Afgørelse om uopsættelighed
 Det bliver endnu vanskeligere at nå legitime økonomiske mål.
 Det er jo faktisk hele processens troværdighed, der står på spil.
 Det skal i højere grad dreje sig om varig turisme.
-Vi tager punktet ad notam, men jeg ønsker ikke at genåbne forhandlingen nu.
 Det er trods alt blot et system, som har givet reelle liberaliseringer af verdenshandelen.
-Bitumenholdigt sands miljøpåvirkning er klar.
 Denne kriminalitet udvikler sig på tværs af grænser.
 Europa er trækplaster nok til, at journalister ikke behøver at få en godtgørelse.
 Fællesskabets indvandringspolitik er fortsat skizofren.
@@ -494,12 +464,9 @@ Vi har løst de problemer, som programmet havde i starten.
 Det syntes jeg, at jeg ville understrege, for det kan være blevet glemt.
 Flystøj er dermed blevet en plage for en stadig større del af befolkningen.
 Vi vil også skabe sikkerhed for, at udvalgsformændene ikke bistås af medarbejdere.
-Derfor håber jeg, at vi enstemmigt vedtager en betænkning, der kritiserer disse forhold.
 Jeg er uenig i dette, da det kan føre til øget korruption og overtrædelser.
-This is the game that we came here for.
 Men nogle tjenestegrene synes at udnytte den aktuelle uklare situation til egen fordel.
 Analyser viser, at elforbruget på verdensplan vil blive fordoblet i de nærmeste årtier.
-Nielson nu har vist initiativ til at ville gøre det.
 Der blev givet en vetoret baseret på befolkningsantal til brug for de store lande.
 Jeg trøster mig med, at jeg ikke er den eneste.
 Disse mennesker prøver at forbedre deres liv, og det er ikke en forbrydelse.
@@ -524,7 +491,6 @@ Jeg har nu to års erfaring i min nye kapacitet.
 Økonomiske sanktioner har samme mål.
 Det vil også lette presset på vejene og flytte transportstrømme over til jernbanen.
 Desværre kan vi intet gøre for de forsvundne, men blot kondolere deres familier.
-Beslutningsforslaget er fyldt med det kendte julestads som f.eks.
 Nederlænderne har ofte ved plenarmødet klaget over, at det nederlandske fjernsyn ikke kan ses.
 Allergene parfumestoffer forbydes også i overvejende grad.
 Normalt bliver det ikke til meget mere end diskrete hentydninger.
@@ -539,7 +505,6 @@ Det virker helt utroligt på mig.
 Jeg plæderer for, at man ikke driver en kile ind mellem parlamenterne og regeringerne.
 Fremskridt forbindes med høj kvalitet på højere læreanstalter.
 Der kom et polariseret svar ud af konsultationen.
-Fiori for et bemærkelsesværdigt engagement i denne sag.
 Jeg synes, at det er en meget klog beslutning.
 Vi skal i sidste ende opnå en politisk løsning.
 Jeg mener, at det vil føre til ustabilitet.
@@ -576,7 +541,6 @@ Det er ubegribeligt, at man kan indgå aftale med en retspolitisk bananrepublik.
 Kun at tale om watt siger ikke en stor del at menneskene noget.
 Jeg har altid forsøgt at lade så mange som muligt komme til orde.
 Det var min hensigt, men jeg vendte papiret for hurtigt.
-Transponderne udsender flyets kode og dets position.
 Det ville helt sikkert have resulteret i et nej.
 Den er uegnet til manden på gaden.
 Tiltrædelsesforhandlingerne fortsætter målbevidst under det finske formandskab.
@@ -626,7 +590,6 @@ Det virker sandsynligt, at disse udsving vil fortsætte, fru kommissær.
 De to forordninger er trådt i kraft, og vi anvender allerede den nye pagt.
 Logisk set burde kravet om klarificering af procedurerne heller ikke gøre det.
 Der er ikke bare trojanske heste, men også mange falske identiteter på nettet.
-Jeg er bange for, at denne tekst vil vække bekymring i målgruppelandene.
 Jeg har derfor uden forbehold stemt for frigivelsen af støtte fra fonden.
 Kære kolleger, det drejer sig ikke her om et fantasifuldt initiativ.
 Ingen europæisk sejr eller civilisation er betydningsfuld på verdensplan uden økonomisk innovation.
@@ -665,12 +628,10 @@ Andre prioriteter er afbetalingen af høj statsgæld og omstruktureringen af pen
 Denne arbejdsløshedskrise forsvinder ikke, fordi vi nægter at afholde flere møder.
 Vi har ikke brug for en eskalering af overskrifter i pressen.
 Websteder af samfundsmæssig interesse omfatter for øvrigt også websteder af kommerciel art.
-Derfor bør man naturligvis være påpasselig med enhver form for triumferen og jublen.
 Jeg vil også gerne understrege betydningen af garanti mod handelsforvridning.
 Vores klima trues af både vores udnyttelse og afhængighed af fossile brændstoffer.
 Den nye version er en forbedring i forhold til den første.
 På den måde kan forbrugerne vælge på velinformeret grundlag og opnå bedre lånevilkår.
-Men det er bare sådan, at vi ikke har en fælles visapolitik.
 Er deres stemmeforklaringer så gyldige eller ej?
 Det er desuden billigere end at anvende ineffektivt biobrændsel.
 Pakken er ligeledes et led i vores forsvar af euroen.
@@ -680,14 +641,12 @@ I et år, hvor vi oplever masseafskedigelser, er dette aspekt næppe helt irrele
 Først da kan vi atter vinde de europæiske vælgeres støtte.
 Den anden type ændrer forslaget materielt ved at tilføje eller slette visse vigtige bestemmelser.
 Kommissionen skal begynde at behandle middelhavslandbrugerne rimeligt.
-I den forbindelse er den europæiske naboskabspolitik et vigtigt instrument.
 Desværre er tempoet for dem faldet.
 Vi skal især lægge vægt på at beskytte sårbare grupper som børn og gravide.
 Disse områder øger blot bureaukratiet og tynger budgettet uden at bidrage med væsentlige resultater.
 Tre europæiske statsborgere holdes stadig som gidsler.
 Vi skal vælge ægte frihed.
 Virkningerne er katastrofale.
-Det sker på grund af en manglende europæisk integreret havpolitik.
 Derfor er de såkaldte europæiske partier på udkig efter nye næringsveje.
 Alle omkostninger, der lægges til ordrens værdi, afholdes af sælgeren.
 De udgjorde et betydeligt fremskridt.
@@ -718,9 +677,7 @@ Denne ensidige løsrivelse skaber en utilladelig præcedens i internationale rel
 Ovenstående retningslinjer sigter også mod at styrke vor konkurrenceevne.
 I takt med at befolkningen forandres, gør deres kultur det også.
 En tredje fælde er måske uklarhed.
-Der skal gives nødlån og ikke andet.
 Men behovet for yderligere, ubegrænsede beføjelser er ikke blevet bevist.
-Uddannelsesmæssig segregering er en af de værste former for forskelsbehandling for romanibørnene.
 Hydroelektricitet er en vedvarende energikilde.
 Som følge heraf går hver dag mange europæiske arbejdspladser tabt, og nye bliver oprettet.
 Hvem giver medlemsstaterne pengebeløbene i første omgang?
@@ -728,19 +685,16 @@ Vi må ikke forveksle humanisme med naiv optimisme.
 En tilpasning af denne begrundelse forekommer mig derfor nærliggende.
 Jeg vil omtale nogle af de vigtigste ændringsforslag nærmere.
 På det punkt vil vi være urokkelige.
-Disse oplysninger findes iøvrigt stadig på hjemmesiden, hvis nogen skulle være interesseret deri.
 Efter de ufødte børn kommer turen til oldingene.
 Rådet er besluttet på at støtte de stærkt forgældede fattige lande.
 Det vil sige, når der er tale om forsæt og grov uagtsomhed.
 Det bør stå klart for forbrugerne, hvad de lægger i kurven.
 Dette har ikke udmøntet sig i højere lønninger eller en væsentlig stigning i beskæftigelsen.
-Mange børn og gamle mennesker dør allerede af sult.
 Samtidig skal de tilpasse deres interne procedurer og om nødvendigt opgradere deres udstyr.
 Massemediernes dækning under valgperioden anses for at være ensidig.
 Det stiller os over for et grundlæggende dilemma.
 Meget store mængder brugt affald fra atomubåde er lagret under meget dårlige forhold.
 Det andet praktiske spørgsmål vedrører den blå boks.
-Hvis det er ulovligt, er vi nødt til at indlede en overtrædelsesprocedure.
 Men jeg gentager, at dette kun kan være et første skridt.
 Men det er også nødvendigt at bygge broer til de andre kontinenter.
 Jeg kan også acceptere, at visse grundlæggende kriterier overføres fra bilagene til artiklerne.
@@ -785,7 +739,6 @@ Alle foranstaltningerne, som i bogstavelig forstand skal sættes på skinner, ha
 Er en centraliseret pengepolitik acceptabel for lande, som har så udpræget forskellige rentesatser?
 Direktivet indplacerer entydigt kosttilskud som fødevarer.
 Syrien er en kæmpe katastrofe.
-Derfor kommer den femte samhørighedsrapport på det helt rette tidspunkt.
 Udviklingslandene kan nemmere nå tærskelen.
 Ville det ikke være en lovende metode?
 De bliver fritaget for at betale skat.
@@ -823,7 +776,6 @@ Jeg ved, at landbrugerne ikke plejer at holde sig tilbage.
 Alligevel er de udenlandske reserver nødvendige.
 Vi skal sørge for at lette byrden for producenter, distributører og detailhandlere.
 Den modvirker hele intentionen med betænkningen.
-Fiori var inde på, og at for meget realisme virker svækkende.
 På sundhedsområdet må vi overveje, hvordan vi især kan behandle aldersrelaterede sygdomme.
 Renaults ledelse, som ikke har fremsat noget konkret forslag, fastholder sin beslutning.
 Dermed ikke være sagt, at andre forureningsrelaterede sygdomme ikke skal omhandles af dette program.
@@ -833,7 +785,6 @@ Det var en meget malende beskrivelse.
 Disse ord var ubesindige og byggede ikke på fakta.
 Ellers får vi en helt mislykket kemikaliepolitik.
 Vi ønsker at fortsætte med samme omhu for vores forhandlingsdokumenter.
-Vi kan ikke have en visumpolitik, hvis ikke vi har grænsekontrol.
 Den skulle træde i kraft om nogle måneder.
 Enhver havn eller ethvert skib er specifikt.
 Dette er imidlertid stadig kun dråber i et hav af behov.
@@ -852,7 +803,6 @@ Vi udleverer også lister til dem og siger, her, her, her, noget skal gøres.
 Deres forventninger skal endvidere imødekommes.
 Tal om at skyde spurve med kanoner!
 Med henblik herpå skal den optages i traktaterne.
-Tibetanerne er berørt af dem, men også ugurerne og mongolerne.
 Vi talte om, at han var i fare for at dø.
 Dette er rigtigt og på sin plads, idet familien og børns trivsel bliver inddraget.
 Ifølge deres rådgivning bør alle lovforslag opridse formålet med den foreslåede lovgivning.
@@ -866,10 +816,8 @@ Men dette er ikke reelle besparelser.
 Direktivet forbyder kloning.
 Sådanne netværk har vi brug for.
 Her er der også store ubalancer.
-Tekstiler og tøj er især berørt, særligt på grund af sektorens høje gradueringstærskel.
 Denne beskrivelse er også dækkende i negativ forstand.
 Udviklingen i det indre marked skal ikke overlades til markedets nåde.
-Coelho med yderligere to succesfulde betænkninger.
 Militære øvelsesflyvninger i lav højde skal forbydes, hvis der er risiko for borgerne.
 Parlamentet skal gøre det ved at turde give ansvarsfrihed, når der er problemer.
 Hun foreslår, at differencen skal betales ud af de nuværende kvoteejeres lommer.
@@ -884,11 +832,9 @@ Alle flypriser skal uanset salgsvejen fremstilles omfattende og detaljeret.
 Ensartet anvendelse af forordningen er desuden af stor betydning.
 Spredningen over generationer og risici gør, at fondene kan investere så meget i aktier.
 I den nuværende situation er der mere end nogensinde brug for en sådan domstol.
-Vi må erkende, at usikkerhed og blomstrende opiumsvalmueproduktion er to sider af samme sag.
 Vi har også forslag om minimumsnormer vedrørende information, samråd og delagtighed.
 Man gav mig mit gamle kort tilbage.
 Der er en imponerende ambition heri.
-Jeg glæder mig også over den gradvise fremgangsmåde og udelukkelsen af lavrisikoaktiviteter.
 Vi forventer langt mere, ikke bare som den europæiske venstrefløj, men som europæiske borgere.
 Vi bør heller ikke glemme, at fødselstallet er faldet i de seneste år.
 Han standsede for at hjælpe et medmenneske, der var i nød.
@@ -896,9 +842,7 @@ Jeg vil gerne slå fast, at jeg er imod anvendelsen af dødsstraf for mindreåri
 Disse informationer er ikke et resultat af det årlige budget.
 Østrig har også regelmæssigt bragt dette emne på bane.
 Traktatreform er den korrekte reaktion på borgernes forventninger.
-Denne militante xenofili og antipatriotisme er meget opslidende.
 Det har gjort det muligt at identificere de relevante emner.
-Kommissionen støtter forskning i passende metoder til deinstitutionalisering.
 Så vil vi højst sandsynligt være nødt til at gå i forhandling.
 Klagerne kom altså også fra videnskabelige cirkler, men også fra andre boghandler.
 Vi ved alle sammen godt, at tiden nu er ved at udløbe.
@@ -917,7 +861,6 @@ Vi lader forbryderen gå ustraffet og behandler ofret letsindigt.
 Vi har brug for enkle regler om overførsel af erhvervstilknyttede pensioner.
 Den indonesiske hær greb ikke ind for at beskytte befolkningen.
 Han var beleven, klog, flot, principfast og umådeligt effektiv.
-Ordføreren mener, at fatalismetankegangen fremmer narkotikamisbruget.
 Rådet mindede ligeledes om sin sædvanlige og stærke modstand mod dødsstraffen.
 Det er ufatteligt, at man forelægger formanden et sprog, hun ikke taler.
 Den kan også have ødelæggende virkninger, både fysisk og psykisk.
@@ -937,7 +880,6 @@ Formandskabet befinder sig i krydsild.
 Der er endnu ikke draget nogen faste konklusioner, men smuthullet er blevet afsløret.
 På et overordnet plan har forslaget til betænkning affødt en række spørgsmål.
 Hvordan ønsker vi at udforme frekvenspolitikken?
-Garosci, for det fremragende arbejde, de har gjort.
 Men det er beklageligt, at vi ikke nåede helt frem.
 Det er derfor på høje tid, at kreditvurderingsbureauerne holdes i kort snor.
 Hvorledes vil det løse problemet, og hvilke foranstaltninger har det til hensigt at iværksætte?
@@ -947,7 +889,6 @@ Den vigtigste årsag er først og fremmest den øgede befolkningstilvækst i tre
 Generalen overtog magten ved et kup.
 Vi ved vældig meget, og der er ingen genvej.
 Landbrugsudvalget har rent faktisk den holdning, at vi bør vove springet.
-Det første punkt er corporate governance.
 Jeg så ingen maskiner i går.
 På langt sigt har vi brug for mere kongruens, hvis vi vil undgå konkurrenceforvridninger.
 Der kan også være andre årsager til det stigende antal døde.
@@ -959,7 +900,6 @@ Racisme er et hårdnakket og voksende problem i de europæiske samfund.
 Vi udtrykker således vores ambition om at højne globaliseringen i moralsk henseende.
 I andre områder sælger man vin på strøer.
 Banebrydende resultater kan kun opnås på grundlag af velplanlagte langfristede investeringer.
-Donnelly kom ind på dette.
 Det drejer sig om jægere og sportsskytter, som rejser til konkurrencer.
 Klokken er nu et minut over tolv.
 Dette er baggrunden for, at de ikke bryder sig om konventionen.
@@ -970,9 +910,7 @@ Bekymrer vi os ikke den mindste smule for vores omdømme?
 For det første forbedring af de legale indvandringskanaler
 Jeg mener derfor, at der stadig er enorme mangler i denne henseende.
 Hvad tobakken angår, baserer vores forslag sig også på en vidtrækkende konsekvensanalyse.
-Det er en uretslov og en skamplet.
 De forsøger at erstatte reformerne, som endelig sker, med flere oplysningskampagner og salgsfremstød.
-Poettering har jo gjort klart, at valgkampen allerede er i gang.
 Ordføreren har tilegnet sig en gradvis fremgangsmåde, der er den helt rigtige.
 Kommissionen vedtog først direktivforslaget sidste onsdag.
 Det er naturligvis vanskeligt at besvare direkte.
@@ -980,20 +918,15 @@ Hovedproblemet inden for landbruget er landbrugernes lave indkomster.
 Derfor er det latterligt, at man nu skændes om, hvordan dette instrument skal finansieres.
 Undertrykkelse integrerer ingen, det fører til disintegration.
 Er de glade for det på de nærliggende loppemarkeder?
-Morillon udeladt dette aspekt, som jeg synes er vigtigt.
 Der skal afholdes et trepartsmøde i aften.
 Åbning af den årlige session
 Jeg havde krævet, at dette agentur skulle være en uafhængig og gennemskuelig instans.
-Alle undersøgelser, som søger at kaste lys over fakta, er velkomne i denne sag.
 Allerede i dag findes der alternativer uden fluororganiske forbindelser på markedet.
 Men vi har svært ved at tage nogle af de nævnte problemer alvorligt.
 Jeg mener, at der er nogle huller i deres forslag.
 Jeg kan kun bekræfte, at der skal afholdes et kabinetsmøde i overmorgen.
-Balikonferencen resulterede i en moderat succes.
-Vi kan ikke have en discountudgave af fair trade.
 Fremover skal det være gravemaskiner, der rasler med kæderne hos jer, ikke panservogne!
 Men vi må have fragten igennem.
-Nogle af de foranstaltninger under tredje søjle, som er under forberedelse, som f.eks.
 Det er ikke legitimt udelukkende at betragte bøger som et økonomisk gode.
 De gamle medlemsstater modtager mest, og de nye modtager langt mindre.
 Grænsen mellem skjult reklame og produktionshjælp er meget vag, hvilket skaber tvivl og diskussion.
@@ -1007,7 +940,6 @@ Så lad os følge franskmændene.
 Hvilke situationer er menneskelig set vanskeligere end det illegale ophold?
 Jeg har stemt for votummet.
 Sådanne overgreb kan ikke tolereres uden en stærk reaktion fra de europæiske institutioner.
-Fischlers og min holdning.
 Der er mange tilfælde af svig, navnlig i de østlige og sydlige medlemsstater.
 Det skaber større ulighed end den, der hidrører fra forskelle i købekraft.
 Vi må forstå, hvorfor flere statschefer ikke mødte op.
@@ -1024,13 +956,10 @@ Det forbliver ved de smukke ord, og den konkrete handling udebliver.
 Hvilket lingvistisk system skal der anvendes?
 Desuden er det uhyre vigtigt for havmiljøet, at støtten til de flydende fiskefabrikker ophører.
 Det er på ingen måde uproblematisk.
-Clerides, som indtil videre ikke har givet mærkbare resultater.
 Men vi eksporterer al denne uld i uforarbejdet stand.
 Indenlandsk produceret kul er langt mere miljøvenligt end importeret kul.
 Afrika er det kontinent, hvor man finder flest kapitalindskydere.
 Flere redningsholds erfaringer var ikke engang tilstrækkelige.
-Derfor kan ækvidistance være et instrument, selv om målet for mig afgjort er upartiskhed.
-Corbetts forslag bliver forkastet på onsdag.
 Der er dog noget, jeg gerne vil dementere.
 Det er vores amerikanske venner nødt til at acceptere.
 Det kan man udmærket gøre også med særskilt afstemning.
@@ -1039,13 +968,11 @@ De har endvidere mulighed for at få initiativer ført ud i livet.
 Desværre forbliver disse ord sommetider kun smukke ord.
 Vi har ventet her i aften i mange timer for at tale.
 Hvad er den egentlige leje?
-Jeg refererer hovedsageligt til de kommende forhandlinger om den fælles landsbrugspolitiks fremtid.
 Kommissionen har forsømt dette område i sin grønbog.
 En ny strategi til et gammelt mål!
 De er overregulerende, overbureaukratiske og unødvendige.
 Et yderligere væsentligt punkt som led i udvidelsen mod øst er beskyttelsen af arbejdstagerne.
 Rehabiliteringen af både kommunistiske og nazistiske symboler skal fordømmes i lige høj grad.
-De olympiske lege var det første organiserede fredssystem.
 For det andet forestiller nogle sig ofte, at er synonym med selvregulering.
 Afslutningsvis blot en enkelt sætning.
 Dette var oprindelig en foranstaltning vedrørende sædskifte, fordi sædskifte også krævede vegetation.
@@ -1057,8 +984,6 @@ Disse mænds og kvinders mod er beundringsværdigt.
 Jeg og mange aktører mener ikke, at det er en ønskelig udvikling.
 Jeg synes imidlertid heller ikke, at fredsforhandlingerne var en komplet fiasko.
 Vrede over fødevareprisernes himmelflugt har ført til stor uro i mange lande.
-Jeg hørte et interview med en tyrkiskcypriotisk ung kvinde i radioen.
-Poettering om, at det østrigske formandskab skal kigge i kalenderen igen.
 Denne opgave bør overlades til uafhængig akademisk forskning og offentlig debat.
 Er det mon det, man ønsker?
 Uden salt og uden sukker går det ikke.
@@ -1078,8 +1003,6 @@ Det opnår man ikke med tvang.
 Er det helt umuligt at skabe balance i den ligning?
 Kommissionens forslag vedrører ikke indholdet af mærkningen med ingredienser.
 Som medmennesker er hendes kamp immervæk også vores kamp.
-Databeskyttelsesmyndighedernes uafhængighed er nøglen til et vellykket stykke arbejde.
-For at kunne gennemføre en begrænset fiskeriindsats har vi brug for dybhavslicenser.
 Det er derfor, at mange vandområder tæt på kysten trænger til rensning.
 Den berygtede, nye økonomi kommer ikke til at tjene lønmodtagernes interesser.
 Støttemodtagerne skal udvælges på en demokratisk og gennemskuelig måde.
@@ -1117,7 +1040,6 @@ Man kan tit se affald smidt på gaderne og i baggårde i disse områder.
 Vi taler i øjeblikket om total deklaration af foderstofferne.
 Ud af betænkningens mange anbefalinger vil jeg gerne fremhæve to aspekter.
 Desuden blev forhandlingerne vanskeliggjort af de strukturelle særegenheder i flere medlemsstater.
-Roosevelts fjerde element var økonomiske investeringer.
 Den årlige tildeling må ikke overstige denne øvre grænse.
 Spørgsmålet om egne indtægter vil dukke op igen i de kommende måneder.
 Jeg rådgav virksomheder om mobile satellittjenester.
@@ -1136,7 +1058,6 @@ Dermed brydes den onde cirkel, og der skabes en sund udvikling!
 Så kære kolleger, vi må være på vagt!
 Vi venter på den såkaldte ketchupeffekt.
 Det ville være ligeså skadeligt for det indre marked som social dumping.
-Savary mindede om for lidt siden.
 Men disse problemer løses ikke bare med snak.
 Denne vision er fortsat relevant i dag.
 Hvad dyrehold i økonomisk øjemed angår, vil der også i fremtiden skulle være begrænsninger.
@@ -1149,14 +1070,11 @@ Deres borgere er mere trygge ved processen, og det endelige resultat har større
 Jeg håber, at der er opbakning til disse ændringsforslag.
 Alle patienter med blærekræft ønsker at nyde gavn af den østrigske viden og sagkundskab.
 Den europæiske referenceramme for kvalifikationer er en metaramme, som har tre opgaver.
-Det er så uspecifikt og populistisk!
 Det er de caribiske producenter til gengæld.
 Jeg tænker på lørdagens demonstration.
 Til gengæld er vold i hjemmet stadig meget dårligt indkredset, for den forbliver tabu.
 Før krisen accepterede koreanerne ingen kapacitetsreduktioner.
 Samtidig giver det beboere i grænseområder visse fordele, hvilket allerede er blevet påpeget.
-Målet er således at etablere virtuelle centres of excellence på prioriterede områder.
-Fitzsimons har desværre lagt sig syg med en lungebetændelse.
 I de fleste tilfælde er aggressoren kvindens mand eller partner eller et bekendtskab.
 Jeg har lært meget og haft det rart.
 Problemet er, at der ikke fandt nogen endelig afstemning sted.
@@ -1170,14 +1088,12 @@ Det, der holder i det lange løb, er samarbejde.
 Dette initiativ skal vare en årrække og nyder allerede temmelig stor succes.
 Vi må ikke hertil føje det, jeg ville kalde den digitale kløft.
 Det er for os et brudpunkt i denne tekst.
-Derfor kan man ikke henholde sig til proportionalitetsprincippet i dette tilfælde.
 Den første, den relativt mest harmløse, ramte også mit eget hus.
 Det er klart, at en sådan attitude er beklagelig.
 Det er imidlertid bevidst forsøgt at finde en stok til at slå hunden med.
 De forhandlere, hvis aftale opsiges, kan nu blive på markedet som autoriserede reparatører.
 Desværre kan svampefiskeri imidlertid ikke på nuværende tidspunkt medtages i aftalen.
 En bøf skal være en bøf, og en skinke skal være en skinke.
-Til sidst vil jeg påpege, at stivelseskartofler ikke kan sammenlignes med spisekartofler.
 Hvorfor siger jeg det, og hvorfor denne sælsomme sammenligning?
 Til september kan det være for sent.
 I år blev der her opdaget en gigantisk bedrageriring.
@@ -1208,11 +1124,9 @@ Den skal ajourføres og moderniseres.
 Forskningen i regionen må kunne samordnes bedre og rettes mod fælles spørgsmål.
 Der mangler en særdeles vigtig bid, og det er overholdelse.
 I en demokratisk stat har også politiske og etniske mindretal rettigheder.
-Når man taler med albanske kosovoer, er det det første, de spørger om.
 Dette nuværende tidspunkt er meget gunstigt, men det indebærer også mange udfordringer.
 Hvem overlader nutidens videnskabsmænd og forskere projekter, som nødvendigvis er djævelske?
 De døde således ofte som følge af sult og en grusom, umenneskelig behandling.
-Det handlede om at integrere det syvende forskningsrammeprogram bedre og orientere det mod trafik.
 De mistede milliarder, som kunne have været brugt til at sænke lønskatten.
 Vi skal have nogle kvantitative mål for ligestillingen.
 Hvordan fremmer vi bedst anstændighed, mådeholdenhed og pluralisme?
@@ -1228,7 +1142,6 @@ Sundhedsspørgsmål vil fortsat være centrale med en større præventiv indsats
 I det aktuelle tilfælde var det naturens kræfter, der satte lufttrafikken fuldstændig i stå.
 Som vi har hørt, har vi her et umotiveret mord på en uskyldig mand.
 Jeg valgte denne karriere, men jeg har nogen, der har valgt at blive hjemme.
-Samtidig giver en amnestilov militærpersonerne straffrihed for deres voldshandlinger og ugerninger.
 Vi ved, at spørgsmålet om beskatning af aviser ikke er løst.
 Det er bestemt et argument, det er værd at reflektere lidt over.
 Etnisk udrensning foregår stadig.
@@ -1243,24 +1156,19 @@ I modsat fald ville det naturligvis være fuldstændig absurd at gennemføre den
 Det handler både om ordentlige toldkontroller ved de ydre grænser og kontroller i medlemsstaterne.
 Herefter aflagde udenrigsministre og kommissærer besøg på øen.
 Udbredelse af europæiske film
-Vi taler alle om skandaleplagede borgere, der har mistet tilliden til fødevaresikkerheden.
 Lange har, nemlig at det i allerhøjeste grad ville være nyttigt at inkludere dem.
 Vi må imødegå den vedtagne lov med meget skarpe tiltag.
 Det lød som arrogance i mine øren.
 Der har de en fremragende platform for deres politiske budskab om had.
 I henhold til denne kræves der ordrer på amerikanske værfter til intern navigation.
 Kidnapningerne fortsætter.
-Uetisk forskning er fuldkomment unødvendig...
 Han vil formentlig være fristet til bare at tage pæren ud.
 Nødhjælpen skal fordeles så hurtigt som muligt og direkte til den nødlidende befolkning.
-Berlusconi snart kan forlade hospitalet, og ønsker ham hurtig bedring.
 Jeg takker alle de kolleger, som har medvirket til at udarbejde denne tekst.
 Men vi må ikke hvile på laurbærrene.
-Noget af det, man lærte af dioxinkrisen, var, at disse oplysninger ofte savnedes.
 Derfor går vi nu glip af en chance.
 Disse tilsagn danner igen i morgen grundlag for vores afstemning.
 At give visse sagsøgere fortrinsbehandling er ikke en passende adfærd for en neutral dommer.
-Vi finder endog til vores overraskelse fornuftige forslag til en voluntaristisk familiepolitik.
 Der er ingen tvivl om hushjælpens betydning.
 Der pågår desuden overvejelser om en eventuel ny koordinators mandat og opgaver.
 Jeg vil gerne give en kort definition på både varemærkeforfalskede og piratkopierede varer.
@@ -1288,9 +1196,7 @@ Det er de desperate, der rejser ud.
 Der var også mange, som åbenlyst viste deres sympati for oppositionspartierne.
 Hvordan kan vi hjælpe nordkoreanerne i denne situation?
 Fakta og fiktion er blandet sammen her.
-Jeg håber, at dette bliver en fordelagtig stimulans, navnlig for udbredelsen af onlinesalg.
 Det er ikke mit ønske at være smålig, når jeg siger dette.
-Titley så udmærket har forklaret det, er det nødvendigt at hjælpe bilisterne og passagererne.
 Budapests indbyggere mister imidlertid hele tre år af deres liv.
 I de nye rammer for denne lovgivning skal barnet anbringes i centrum af adoptionsprincippet.
 Europa skal have modet til at kalde en spade en spade.
@@ -1315,7 +1221,6 @@ Vi vil gerne vide, hvor længe disse to typer data bliver opbevaret.
 Vi må ikke handle uværdigt ved at forsøge at udnytte deres død.
 Hvilke trin består initiativet så af?
 Det er vanskeligt at fange lovovertræderne på internettet, men det er ikke umuligt.
-Gå ind på facebook for at standse tabet af biodiversitet, og støt kampagnen.
 Vores motto skal til enhver tid være gennemsigtighed, ansvarsfølelse og effektivitet.
 Spørgsmålet om ramperne er særdeles væsentligt.
 Køb af sex er vold og bibeholdelse af vold.
@@ -1330,7 +1235,6 @@ Det er om muligt endnu mere rædselsvækkende end heroin.
 For det andet hindringer for forståelse på grund af den uigennemskuelige hjemmeside.
 Man skal melde sig, inden stemmeforklaringerne begynder, men jeg er dog fleksibel.
 Vil det afstedkomme en udligning nedefter?
-Det samme system for alle, erga omnis , ingen undtagelser.
 Parlamentet vil drøfte dette spørgsmål senere på ugen.
 Fri handel, som denne aftale åbner op for, vil bringe alt dette i fare.
 Vi bør derfor gå imod de japanske og norske forslag om at genoptage erhvervet.
@@ -1342,8 +1246,6 @@ Vi ved, at afbrændingen af bøger betød meget mere end blot afbrænding af bø
 Derfor bør denne kategori defineres klart og være omfattet af statistikkerne.
 I modsat fald er der fornyet risiko for, at borgerkrigen vil blusse op igen.
 Foranstaltninger, der iværksættes på europæisk plan, skal supplere nationale og regionale strategier.
-Verheugens udtalelser om udvidelsen
-Leinen sig over den reviderede rammeaftale og tilslutter sig den.
 De kan ikke udnyttes termisk og heller ikke genanvendes.
 Jeg vil gerne fremsætte nogle politiske og faglige bemærkninger.
 Det er en milepæl på vores vej til fremtiden.
@@ -1359,9 +1261,7 @@ Sådanne forsinkelser skal ubetinget forhindres fremover!
 Vi har stærkt indtryk af, at der endnu ikke er truffet ordentlige bestemmelser derom.
 Der bør skelnes skarpt mellem terapeutisk kloning og reproduktiv kloning.
 Det sker også i de lande, der praler af stor åbenhed.
-Michelin er desværre langt fra en undtagelse på området.
 Vi må benytte princippet om at hjælpe folk til at hjælpe sig selv.
-Denne tilsyneladende konkurrence har sat landet i en politisk apati og devalueret dumaen.
 Parlamentet vil forblive en central figur i udviklingen af denne politik.
 Producenternes økonomiske resultater er for nedadgående.
 Rusland spiller en førende rolle på den internationale scene.
@@ -1376,8 +1276,6 @@ I kældrene er kloakeringen brudt samen, og de er oversvømmede med menneskers e
 Vi skal overveje artsspecifikke kontroller i forbindelse med toskallede bløddyr.
 Montenegros skæbne ligger derimod helt i landets egne hænder.
 Sydafrika har især en betydningsfuld rolle i sin egen sydafrikanske region.
-For det første opt in eller opt out.
-Skoleeksempler på beskyttelse af biodiversiteten er fugledirektivet og habitatdirektivet.
 Selv i sparetider skal man betale sin elregning.
 Økonomiske vækstperioder varer ikke evigt.
 Et tredje eksempel er nuklear sikkerhed.
@@ -1389,8 +1287,6 @@ Dette misforhold viser, hvor vigtigt det er at indføre et fælles observationss
 De inviteres til at sidde med ved bordet, men de deltager ikke.
 Uanset hvor erfarne chauffører er, skal de altid spænde sikkerhedsselen.
 Især blev ændringsforslagene vedrørende omfordeling af fiskerimulighederne nedstemt.
-Intermodalitet og intermodal godstransport
-Jeg vil imidlertid gerne tilføje, at valutakurskriteriet er vigtigt.
 Vinteren nærmer sig, og en ubønhørlig beskæftigelseskrise vil fjerne enhver udsigt til udvikling.
 Det lykkes højt udviklede lande at fastholde en næsten uændret miljøsituation.
 Det passer måske ikke, men alligevel er der et tonefald, som ikke lyver.
@@ -1405,7 +1301,6 @@ I januar lovede vi et parlamentsvenligt formandskab.
 Stenalderen sluttede ikke, fordi vi ikke havde flere sten.
 Ved uregelmæssigheder forstår man en overtrædelse af en europæisk lovbestemmelse.
 Men her har man sprunget kendsgerningerne over.
-Ciampi og hans embede, at det samme følgelig gælder hans indlæg.
 Oplysninger om etnisk eller racemæssig oprindelse indgår ikke normalt heri.
 Svig, dårlig forvaltning og nepotisme opstår ikke tilfældigt.
 Der er intet belæg for, at homoseksuelle par er dårligere forældre end andre.
@@ -1415,19 +1310,14 @@ Heri ligger der en stor rigdom.
 Jeg støttede ændringsforslagene vedrørende folkemordet på armenierne.
 Mange af vores lande har tropper og et betydeligt antal civile medarbejdere i landet.
 Nu får vi et ansigt, vi får en adresse.
-Den roamingforordning, vi har undertegnet her i dag, er et eksempel på det.
 De har lanceret et websted.
-Schengenområdet er dog også et område for tillid.
 Det er først i dette århundrede, at vi har fået lighed i skilsmisselovgivningen.
 Se i øjnene, at målsætningen om en tættere, utroværdig politisk union simpelthen er uopnåelig!
-Nødforanstaltningerne skal fremmes ved at udpege beskyttelseszoner, fortøjringszoner og nødhavne.
 Jeg er sikker på, at denne ubekymrede holdning skyldes ordførerens sindsligevægt.
 Det tredje punkt er rådighedstiden eller det tidsrum, hvor lastbilchaufførerne skal stå til rådighed.
 Jeg ville gerne vide, hvilke ulemper og for hvem.
 Videnskab er ikke et totem.
 Vi står kort sagt tilbage med en bunke problemer.
-Cook, forvandledes hurtigt til en omfattende krig mod en europæisk nation.
-Reach vil kun blive en succes, hvis svaret er ja.
 Nu er uddannelsessystemet fuldstændig decimeret.
 Vi skal have øget denne sum i de næste år.
 Heldigvis startede vi ikke på bar bund.
@@ -1456,9 +1346,7 @@ Hvorfor er mælkeindustrien bange for, at bestemte områder ødelægges ved afko
 Hver enkelt ø, hver enkelt territorium har sin egen særlige karakter, identitet og problemer.
 Derudover er den dobbeltmoralske holdning et irritationsmoment.
 I politik møder vi af og til snydeemballager.
-Men det nederlandske polderlandskab kan tillige være et topografisk motiv for et kørselsforbud.
 Hvis de søger kvalifikationer til medarbejderne, er de oppe mod en særdeles sektoropdelt politik.
-Kurderspørgsmålet må ikke længere fortrænges.
 Vi bør også have en demokratisk procedure for udnævnelse af dommere.
 Hvad nogle lande angår, vil vores ja være mere dæmpet, mere tøvende.
 Vi vil i hvert fald gerne have det afprøvet.
@@ -1478,9 +1366,7 @@ Jeg beklager, at det på denne måde faktisk er gået lidt skævt.
 Ellers er der ikke nogen ændringer af bestemmelserne for cadmium eller kviksølv.
 Vores langvarige kamp mod rygning har ikke været forgæves.
 Det er, fordi banditter og kriminelle ikke frygter loven.
-Blandt disse befolkningsgrupper er mapuchefolket den procentuelt største.
 For at opsummere har arbejdet været fokuseret på udpegelsen af områder.
-Vi skal også overveje, hvordan vi sammenfører new economy med den såkaldte old economy.
 Hvis vi ikke handler nu, vil det næste århundrede blive behersket af dramatiske problemer.
 Det er ikke nogen gave til fattige naboer.
 Det tredje indsatsområde er meget bredt og omfatter alt det, vi kalder rumapplikationer.
@@ -1490,7 +1376,6 @@ Til denne plenarforsamling er der genfremsat syv ændringsforslag.
 Uventede massearrestationer af styrets kritikere efterfølges af hurtige skinprocesser.
 Næste gang der byder sig en formel lejlighed, må vi have champagnen frem.
 Desuden slap vi for det oprindelige vanskelige udvalgsarbejde.
-Gigtsygdomme er den næsthyppigste årsag til lægebesøg.
 Efter min mening er den lære, der i dag kan uddrages, soleklar.
 Fælles operationer og pilotprojekter iværksættes efter aftale med de berørte medlemsstater.
 For bisværmene er reduceret drastisk igennem flere år til et niveau, der truer bestøvningen.
@@ -1507,11 +1392,8 @@ Det er på høje tid, at vi påtager os vores ansvar.
 Mindre er i den her forbindelse lig med mere!
 Uden tvivl vil denne strategi bære frugt, hvis den anvendes konsekvent.
 Spørgsmålet om profilering blev også taget op af det belgiske formandskab.
-Telekommunikationssektoren betragtes allerede som liberaliseret, og den er derfor ikke medtaget.
-Vi er ikke en tigger, der søger almisser ved den europæiske dør.
 Vi har allerede kedelige eksempler på dette i andre sammenhænge.
 Det er vel egentlig helt evident.
-Hvis vi skal dekoncentrere, betyder det forvaltning af programmer på stedet.
 Katastrofen står prentet i mange ukrainske indbyggeres hukommelse.
 Jeg prøvede tidligere i dag meget ihærdigt at opnå enighed om et fælles beslutningsforslag.
 Der er behov for strukturelle ændringer for at gøre dem mere hørbare.
@@ -1537,33 +1419,25 @@ Det er os, der formodes at omsætte deres vilje til handling og ikke omvendt.
 Dette følsomme biologiske område fortjener beskyttelse.
 Denne politik skal omvæltes.
 Disse værdier er også baseret på den hellenistiske arv og romersk lov.
-For at opnå dette minimumssikkerhedsniveau skal alt rullende materiel opfylde visse minimumskrav.
 At øge topledernes ansvar på denne måde er en af nøglerne til reformens succes.
 Vi må ikke glemme, at vi drøfter budgettet og ikke et sekundært spørgsmål.
-Brugen af smart cards og elektroniske punge vil snart falde os alle naturligt.
 Midtvejsevalueringen må ikke være endnu en forspildt lejlighed.
 Han havde derfor solgt den til den kroatiske husejer.
-Dublinbugten blev nævnt som et særligt beskyttet og vigtig område for fugle.
 Militær har grebet magten og enhver spæd fremgang er tilintetgjort.
 Mange forfalskede lægemidler kommer ind i forsyningskæden under omemballering.
 Også det europæiske gartneribrug berøres, om end indirekte, af denne aftale.
 Der kommer desværre provokationer fra de folk, der burde udvise lederskab.
-Kære kolleger, stol på kvæstorerne.
 Cancer er blevet den nye sorte død.
 Vi lever i en verden, som forandrer sig lynhurtigt.
 Alt det medfører førtidspensionering af en række tjenestemænd og ansættelse af nye personer.
 Jeg gør honnør for de modige ansøgerlande, som har støttet koalitionen med specialstyrker.
-Kombineret kraftvarmeproduktion
 Fanatismen klæder sig blot i et religiøst gevandt.
 Det var en forfærdelig skæbne at skulle bære fjendens uniform.
 Det vil sandsynligvis ikke blive nogen nem vej at gå.
 Serbien er et grelt tilfælde.
 Jeg anmodede selv den israelske ambassadør om at komme til mit kontor.
 Måske er det en generation, som ikke tilfældigvis er født i rigdom og velstand.
-Nogle gange er retsgrundlaget ikke blevet godkendt på grund af spørgsmål om komitologi m.v.
-Bowis med en klar betænkning og klar stillingtagen til et aktuelt problem.
 Han er stadig under husarrest og skal melde sig dagligt hos politiet.
-Det fører i en række tilfælde til utydelighed og til langvarige procedurer.
 Begge disse områder har relation til det europæiske perspektiv, men de kræver forskellige redskaber.
 Det er en stor misforståelse, at en regering foreslår at erstatte lossepladser med forbrændingsanlæg.
 Menneskers værdighed krænkes på de mest nedrige måder verden over.
@@ -1581,12 +1455,10 @@ Jeg går også ind for rettigheder til unge, ældre, handicappede og mange andre
 Kan vi virkelig være sikre på, at produkterne på vores køkkenbord er sikre?
 De har annulleret netop den mening.
 Den senegalesiske regering og alle de andre regeringer kan også bebrejdes.
-Lissabonstrategien var mellemstatslig og slog fejl.
 Europas landbrugsjord skulle derfor udtages, og produktionen drosles ned.
 Jeg synes stadig ikke, det er korrekt at koble den til rejseudgifterne.
 Denne sammenfatning vil blive vedlagt det fuldstændige forhandlingsreferat
 Vi har hørt nok dirrende stemmer.
-Jeg bifalder og støtter fuldt og helt det foreliggende kodificeringsforslag.
 Man kunne formulere det uhøjtideligt.
 Men nu kære kolleger, lad os ikke lade verdensdagen for fattigdommen gå upåagtet hen!
 I denne årsberetning har vi fire hovedbudskaber.
@@ -1598,7 +1470,6 @@ Lad mig skildre følgende case for kommissæren.
 Dog ser man sjældent tegn på fremskridt i mandens deltagelse i de huslige pligter.
 Den anden bremseklods er af meget mere politisk karakter.
 Intet land bør være et andet lands skraldespand.
-Det er lige præcis denne perverse virkning, som er blelvet opnået.
 Den europæiske historie fortælles næsten altid kun nationalt på nationale museer.
 Så driver de forretning på forsøgsbasis, før de etablerer et kontor eller en filial.
 De resterende beløb skal udredes af de nationale kasser.
@@ -1606,15 +1477,12 @@ I den sammenhæng er samhørigheden essentiel i implementeringsprocessen.
 Alligevel har termen globalisering en negativ klang.
 Vi kan stemme elektronisk uden asterisken.
 Vær så god, gå bare i gang!
-Derfor skal auktion af mobilkommunikationsfrekvenserne bekæmpes kraftigt.
 Rådet har faktisk opført sig som en bulldozer, og det på tre områder.
 Parlamentet iagttog stående et minuts stilhed
 Endelig har vi brug for tillid fra os alle, når det gælder domfældelse.
 De nationale regeringer står altid imellem.
-Stigningen i forbruget af biocidholdige produkter er alarmerende.
 Irland kræver ikke et klap på hovedet eller en præcisering af den nuværende traktat.
 De svenske skove, rygraden i svensk økonomi, forvaltes økologisk og under hensyntagen til miljøet.
-Thrombin bruges alligevel i nogle medlemsstater, uden at forbrugerne er informeret herom.
 Af analysen fremgår det, at der er behov for en ny udviklingsstrategi for byen.
 Hidtil er vi imidlertid ikke stødt på problemer vedrørende oplysningspligt.
 Men den barbariske behandling af kvinderne knytter sig ikke kun til præstestyret.
@@ -1626,14 +1494,10 @@ Vi skal dog afholde en afstemning for at få fastlagt næstformændenes rangføl
 Det er billigere end at lægge korn på lager.
 Økonomi, æstetik og teknologi indgår i en symbiose med hinanden.
 Situationen vil blive værre, hvis de unge ikke anspores til en forskningskarriere.
-Desuden virker førstegenerationsbrændstofferne som bro til anden generation.
 De skyldige udpeges klart, og det havde vi også bedt om.
 Lad os håbe, at det sætter en trend for fremtiden.
 Diverse radiostationer i ansøgerlandene går alt for vidt med hadetirader mod romaer og jøder.
-Flere og flere medlemsstater ser nu det akutte behov for visumlempelser og tilbagetagelse.
-I forslaget klarlægges bestemmelserne om udøvelse af vejtransporterhvervet.
 Det er en besnærende skelnen, som selv retsudvalget ikke kunne støtte.
-Hatzidakis, er blevet alt for forsinkede.
 Parlamentet vedtog sin betænkning om strategien i oktober.
 Hvis det skal det, skal disse lægemidler så doseres forskelligt?
 Mange af formuleringerne fortjener absolut ros.
@@ -1642,14 +1506,12 @@ Det islamiske regime har degraderet kvinder til andenklasses mennesker.
 Ved at tie pådrager vi os et medansvar.
 Problemet er, at politikere ofte er meget mindre ydmyge end forskere.
 Snigende reformer uden klare målsætninger skal afvises.
-I længden gælder samme acquis communautaire for alle medlemsstater.
 De vil aflægge rapport om, hvordan det bliver ført ud i livet.
 I de lande, der ikke har deltaget i aktionen, bliver kvæget i staldene.
 Jeg mener, vi bør drage politiske konsekvenser deraf.
 Jeg sagde dengang, at hver anden flyafgang aflyses.
 Vi vil kun ty til beskyttelsesforanstaltninger som en sidste udvej.
 Det, der mangler, er kvalificeret omskoling og uddannelsesmuligheder for unge arbejdsløse.
-Tampere by, arbejdsformidlingen og det regionale arbejdsmarkedsråd har undertegnet aftalen.
 Det giver os tilstrækkelig vished for, at processen virkelig omfatter alle interesserede parter.
 Dette glas skal bruges til at drikke af.
 Selim gik imidlertid endnu videre.
@@ -1662,14 +1524,10 @@ Alt dette og mere til dæmmer op for affolkningen af landdistrikterne.
 Hidtil er de nye medlemsstater blevet beskrevet som klynkehoveder.
 Arbejdsvilkårene om bord på mange af fartøjerne svarer til intet mindre end slavearbejde.
 Det lyder meget nemt og pænt.
-Sokrates er en mønstergyldig fornuftig og kontrollerbar investering i fremtiden.
-En institutionel opprioritering af turismen forudsætter, at den bliver budgetmæssigt synlig.
 Nu er bolden igen blevet spillet tilbage.
 For børneofrene skal det primære fokus være barnets tarv og strengere straffe til menneskesmuglerne.
-Pompidou, hvis store kompetence på det videnskabelige område, vi alle kender.
 Der er faktisk reelle problemer med at få dømt menneskehandlere.
 Den folkelige kamp må forenes mod det samlede imperialistiske system.
-I denne uge mødtes jeg med iatrogene patienter.
 En vital europæisk kultur skal betragtes som en vigtig drivkraft bag økonomisk vitalitet.
 Epidemiologisk overvågning
 Dossieret over denne evaluering er derfor afgørende.
@@ -1701,24 +1559,18 @@ Der er endvidere mange arter, som venter på at blive opdaget og beskrevet.
 Afskaffelsen af saksefælder løser jo ikke ubetinget problemet alene.
 Vi har hørt nok af fine tomme ord.
 Når vi forsøger at hjælpe kvinder, risikerer vi at straffe dem på jobmarkedet.
-Vi ved også, at antallet af leukæmitilfælde hos soldaterne er unormalt højt.
 Han afviser beskikkede advokater, hvis erfaring afspejler en eftergivenhed over for anklageskriftet.
 Jeg synes også, at vi skal være særlig opmærksomme på køn og handicap.
 Ikke en eneste familie i mit land har været upåvirket af den sovjetiske besættelse.
 Forordningens ikrafttræden vil gøre det nemmere for handicappede at rejse med bus.
 Dette handler om fælles forvaltning, ikke enegang.
 Forslaget til beslutning er velafbalanceret og rimeligt.
-Newman, der har gjort et godt stykke arbejde for at demonstrere dette udvalgs betydning.
 Den skaber også holdninger til aids i den bredere befolkning.
 Derfor skal dette spørgsmål tages op med stor finfølelse.
 Hvem vil tale for de udslidte og de ulyksalige?
-Der er sydlige stater med vanskelige søgrænser og lande med lange landgrænser.
-Beskyttelse af dyr på aflivningstidspunktet.
-Det er det grundlæggende aspekt i sagen og det strategiske, geopolitiske og geokulturelle nøglepunkt.
 Jeg tror, at stærke ord forstås bedre af vores russiske kolleger end undvigende adfærd.
 Og endelig når navigationen udvikles, er det fordi havene har geostrategisk betydning.
 Jeg glæder mig over, at der nu bliver en røgfri zone.
-Her er det egentlige spørgsmål, på hvilke betingelser conditional access skal indføres.
 Kommissionens udtalelse i dag vil jeg kalde for et gult kort.
 Sekretariatet begyndte at se frem til deres frokost.
 De siger, at det ikke er så let at kapre et fly.
@@ -1746,30 +1598,24 @@ Først vil jeg gerne vide, hvad man mener med en hårdere linje.
 Bjerget skælvede og fødte et bureaukratisk fantasifoster.
 For øjeblikket er dataene i omløb uden nogen form for garanti.
 Jeg mener, at vi har forbedret det nugældende direktiv på en række vigtige punkter.
-Lannoye i hans udtalelser om, at vores politikker skal ændres.
 Netop disse virksomheder har problemer med at skaffe risikokapital.
 Vores institutionelle system må ikke favorisere det ene eller andet system.
 Europas maritime interesser påvirker hverdagen og beskæftigelsen for millioner af vores borgere.
 En størrelse passer ikke alle, hvad enten det drejer sig om handelspolitik eller sko.
 Tuberkulose er et åbenlyst eksempel på den ulighed, der gennemsyrer vores verden.
 Jeg fryser, og jeg fryser faktisk meget!
-Derfor oplever vi denne bagvaskelseskampagne.
 Der er intet alternativ til tålmodig dialog.
 Europa har behov for et nyt pust, der er baseret på gennemsigtighed og demokrati.
 Fattigdom er den største enkelte determinant for sundhed.
 Parlamentarisk immunitet omfatter ikke almindelige straffesager.
 At giftige kemikalier har indvirkning på hormonbalancen, er indlysende.
-Frankenstein skabte med sin teknologi et monster, som overgik ham selv.
 Retningslinjer for vertikale begrænsninger
 Med andre ord, aftalen er ikke strålende, men den er rimeligt tilfredsstillende.
 Det tjekkiske formandskab har fulgt situation nøje længe inden årsskiftet.
 Det er hajer, som slipper gennem nettet.
 Området trues imidlertid af byplanlæggere, der ønsker at bygge huse.
-Vi ønskede at forhindre, at oplysningspligten kunne gemme sig bag immaterialrettighederne.
-Vi delte moldovernes begejstring over en ny fremtid.
 Dette blev slået fast i midten af juni, da betænkningen blev færdiggjort.
 Kommissæren ville betegne det som opsøgende arbejde.
-Jeg mener, at vi bør gå videre og ligeledes forbyde brug af bundsatte hildingsgarn.
 Nu er udsigterne dystre, idet planen er lagt på hylden af udelukkende politiske årsager.
 Der er ingen lovmæssig hindring.
 Det er adgangsstyring til digitalt tv.
@@ -1779,7 +1625,6 @@ Nairobi giver os mulighed for at gå løs på denne udfordring.
 De skulle jo fodres, så vi havde et alvorligt problem.
 Systemets pålidelighed er vigtig, da det skal fungere hele tiden.
 Kan man handle via kirker og på andre måder?
-Vi ønsker ikke nogen varig subvention.
 Menneskehandlen berører især kvinder, som er ofre for organiserede mafiaer og for prostitution.
 Brok, ville vi faktisk allerede været kommet langt videre.
 Krisens økonomiske omkostninger er endnu ikke endeligt opgjort.
@@ -1800,16 +1645,13 @@ Vi mener, at hyppigheden og omfanget af den tekniske inspektion af flyene bør �
 Sult og død hærger fortsat landet.
 Jeg kan se, han nikker bekræftende, så jeg har citeret ham korrekt.
 Lige som førhen står mange spørgsmål åbne.
-Jeg har også min rugbyklubs flag til at hænge derhjemme!
 Denne flove smag er efter min mening på ingen måde fjernet.
 Og for det tredje skal vi forfølge en holistisk politik, ikke en fragmenteret.
 Det tager meget lang tid at nedbryde batterier og akkumulatorer, der smides ud.
 På den baggrund bør anvendelsen heraf ske efter nøgtern overvejelse.
 For os er spørgsmålet om guld også vigtigt.
 Fællesskabets aktion kan og skal være et godt eksempel, også i vore store byområder.
-Derfor må vi ubetinget sige nej til import af klorkyllinger.
 Vi er ikke tvunget til at holde fast i denne forkerte afgørelse.
-Marques, og jeg vil gerne rose dem begge.
 På hvad kan man se, at denne genopbygningsbistand rent faktisk ankommer?
 Dette blev konstateret på den første donorkonference i juli.
 Kina har ændret sig, og det har vores forbindelser også.
@@ -1817,11 +1659,8 @@ Anerkendelsen af det civile samfund som en samarbejdspartner er en meget stor ny
 Jeg kan give et eksempel af nyere dato herpå.
 Sidste søndag var den internationale dag for udryddelse af fattigdom.
 Det vil således være uhensigtsmæssigt, hvis jeg på nuværende tidspunkt uddyber det nærmere.
-Dette skal ske ubureaukratisk og hurtigt.
-Værdipapirhandlere og omvekslingssteder får i år anmeldelsespligt.
 Til sidst vil jeg sige, at det finske formandskab var koldt, roligt og fattet.
 Jeg håber, at håbet vil vinde over skepsissen.
-Hvis cementovne samforbrænder affald, skaffer det mange penge.
 Her begår vi en fejl, og vi opfører os tåbeligt.
 Hverken skik og brug eller alkohol bør betragtes som formildende omstændigheder.
 Vi har fastholdt vores prærogativer.
@@ -1835,31 +1674,23 @@ Disse krævende genvindingsmål vil uden tvivl afæske industrien visse anstreng
 Jeg synes, at kønsulighed skal udfases.
 Det er derfor positivt at sænke tærskelen og udvide den kulturelle arena.
 Personligt er jeg stor tilhænger af behandling i brystcentre.
-Salmaan betalte for denne støtte med sit liv.
 Det er et fornuftigt og afpasset svar.
-Men man skal ikke tro, at vi kan skabe arbejdspladser ex nihilo.
 Loyalitet bygger ikke kun på statsborgerskab, men også på fælles holdninger.
 For det andet vokser andelen af plastik i affaldet.
 Vores handlinger har rakt langt videre.
 Det har aldrig benyttet sig af denne bemyndigelse.
-Når det gælder konkretiseringen af frister osv., er det dog stadig meget trægt.
 Det er en betænkning, der hædrer det parlamentariske arbejde.
-I denne forbindelse har vi vedtaget en række foranstaltninger vedrørende vinfremstillingsredskaber.
-Ved hjælp af denne kriminalisering forhindrer han fair play, også ved de forestående lokalvalg.
 Og det behøver vi både til benzinmotorer og til dieselmotorer.
 Det er sandt, at euroens dyder ikke taler for sig selv!
 En fastfrysning af deres lønninger på flere millioner dollars er ikke en straf.
 Alle går ind for europæisk samarbejde på dette felt.
-Vor dronning, der er oranier, er dronning for både katolikker og protestanter.
 Blandt de opstramninger jeg gerne vil pege på, er der dels anvendelsesområdet.
 For øvrigt skulle tusindvis af tjetjenere have kæmpet sammen med talebanerne.
 Vi må tage os i agt for sådanne tendenser.
 Der sejler i øjeblikket fire søsterskibe rundt.
-Rehder har givet et bidrag dertil.
 Vi ønsker ikke denne dødbringende dogmatisme overført til fællesskabsplan.
 Den ensidighed, som ofte præger diskussionen, er imidlertid påfaldende.
 Men nejsigernes triumf bliver kort.
-Derfor er spørgsmålet, hvorvidt vi tillader bodyscannere eller ej.
 Der bor et stort russisk mindretal i landet samt mange ungarere, tatarer og rumænere.
 Hvorfor har slagtedyr større ret til velfærd end fededyr?
 Der er en dyb kløft mellem den politiske retorik og de finansielle perspektiver.
@@ -1875,19 +1706,14 @@ Man kan trygt sige, at flyselskaberne tidligere ynkeligt har negligeret passager
 En indforståethed, der bringer volden med sig, som en tordensky bringer torden.
 Det er særligt uærligt over for det tyrkiske folk.
 Borgernes opvågnen er i alvorlig fare.
-Sammenfattende og til sidst slår jeg til lyd for en pax avianautica.
-Det lagde ud med fanfarer og slutter med dødsklokker ved den fattiges grav.
-Schulz, nemlig at det er vigtigt at fremhæve den multilaterale tilgang hertil.
 Finlands eget nationale parlament, , fejrer et særligt jubilæum.
 Europæiske intellektuelle ejendomsrettigheder vil opnå øget beskyttelse.
-Blair, der understregede, at der ikke vil blive afholdt en folkeafstemning.
 Det beskytter skibsfartens storkapital mod idømmelse af sanktioner.
 På grund af disse udfordringer må vi ikke være gerrige over for vores borgere.
 Alle glødede af optimisme, men det fusede ud.
 Det er ikke ukrainere, der i flokkevis ansøger om asyl hos os.
 Det er imidlertid bekosteligt at etablere biogasanlæg.
 Ligesom champignon efterlades briterne i mørket og fodres med møg.
-Og hvad med de medlemsstater, som finansierer dyrkning af agrobrændstof i sydlige lande?
 Rådet fornyede sanktionerne over for regimet, men slækkede samtidig på kravene.
 God gratis undervisning er væsentlig for udviklingen.
 Der lægges særlig vægt på forebyggelse af hiv i forhold til mødre og børn.
@@ -1905,16 +1731,13 @@ De små virksomheder og mikrovirksomhederne er de arbejdsløses bedste håb.
 Det virker som noget meget mystisk og specialiseret.
 De nye lovregler om fjernsyn uden grænser har ikke haft ubetinget succes.
 Ministerrådet må imidlertid ikke lade sig bagbindes af et eventuelt veto.
-O.k., men selv det ville kræve et møde i det korresponderende udvalg.
 På den anden side har vi gassen.
 Jeg er helt overbevist om, at vi vil ride stormen af denne gang.
 Efter vores mening er en aftale med bilfabrikanterne den rette fremgangsmåde.
 Angolas befolkning fortjener en anden skæbne.
 De mange minutters unødvendig tavshed her koster yderligere millioner, og sådan fortsætter det.
-Østersøstrategien bliver en af prioriteterne under det svenske formandskab.
 Jeg forstår, at der er brug for en reform af vinmarkedet.
 Jeg er ked af, at ændringsforslagene til disse betænkninger ikke blev vedtaget.
-Jeg har ikke benægtet gaskamrenes eksistens eller bagatalliseret emnet.
 Gang på gang bliver håbet knust.
 Havde vi ikke det indre marked, måtte den britiske regering betale hele gildet selv.
 Men det er allerede ti år siden.
@@ -1928,14 +1751,11 @@ De er desuden meget bioakkumulerende.
 På min fars tid blev de afgjort med nogle stokkeslag eller nogle lussinger.
 Det var umuligt at komme af motorvejen, og der var snart en lang kø.
 Der er sagt tilstrækkeligt om lodserne.
-Vi skal koncentrere os om at mindske risiciene ved zoonotiske agenser til et minimum.
 Uddannelse, långivning og netværksopbygning skal være de vigtigste støtteforanstaltninger.
 Jeg endte med ikke at stemme imod beslutningen.
-Det ligner lidt tæppehandlermetoder.
 Positive impulser er helt afgørende.
 Det er mange, der taler om benchmarking i alle mulige sammenhæng.
 Der vil være fare for alvorlig krise og stagnation.
-Den skal så være gældende, indtil reevalueringsproceduren er afsluttet.
 Jeg taler ikke om andre meget grusomme metoder at slå folk ihjel på.
 Forslaget gør det kompliceret for biblioteker, arkiver, kunstskoler og uafhængige filmproducenter.
 Men disse gode år er ovre.
@@ -1947,12 +1767,10 @@ Her har vi været frygtsomme og har gået som katten om den varme grød.
 Gid solidariteten vil sejre over det tøjlesløse ønske om profit.
 Lokal beskæftigelse, lokale tjenester, ok.
 Men de, der klamrer sig til fortidens job, begrænser fremtidens job.
-I modsat fald kan vi befordre absentisme.
 Der bør opmuntres til udenlandske studier.
 Som dreng kunne jeg ikke handle i en tyskejet butik.
 Sverige vil føre os ind i en ny æra i europæisk fællesskab.
 Alene fra årets start er tre fredelige demonstrationer blevet brutalt nedkæmpet.
-Gawronskis vegne, men vi vil vende tilbage til dette emne.
 Bioetiske anliggender vil helt sikkert beskæftige os mere fremover.
 En budbringer fortalte os, at vi var blevet udsat for en kollektiv afskedigelse.
 Som om vi alle gemmer kvitteringer for alle vores indkøb!
@@ -1961,9 +1779,7 @@ Det er et modbydeligt signal at sende, ikke mindst i disse urolige tider.
 Fremtiden for mobilitet i byer hænger derfor tæt sammen med fremtiden for flodtransport.
 Det var de radikale, der i første omgang bad om udsættelse.
 Jeg har imidlertid en bøn til de kommende formandskaber.
-Makhmour er en kurdisk flygtningelejr for tyrkiske kurdere med ca.
 Vi ser ingen grund til at revurdere holdningen heri.
-Gaza er en israelsk fangelejr!
 Den tilpasning kræver, at lederne træffer vanskelige beslutninger, som ofte er upopulære.
 Det ville nærmest minde om en advarselstekst af den type, der findes på cigaretpakker.
 Men en unilateral holdning uden begrundelse er utilgivelig.
@@ -1994,39 +1810,31 @@ I dagens episode ligger der politisk stof.
 Canada handler langt fra i god tro, og dermed opretholdes en fjendtlig holdning.
 Jeg synes, at det er et meget veludført arbejde.
 Enhver forsinkelse vil bane vejen for simpelt tyveri af intellektuel ejendom.
-Farlige stoffer som phthalater skal sættes ud af spillet og erstattes af ufarlige.
 Der skal ikke herske tvivl om, at jeg ikke ønsker at ty til demagogi.
 Landet befandt sig dengang i den mest alvorlige krise i nyere tid.
 Retten til at indgive andragender er en af de ældste rettigheder for enkeltpersoner.
 Sidste sommer overtog blågrønne alger hele havet med hjælp fra det varme vejr.
 Mønterne skal være påført særlige sikkerhedstræk for at begrænse mulighederne for bedrageri.
 En sådan måde at agere på er naturligvis politisk uacceptabel.
-Om det er bedrag, ond tro, inkompetence, sløsethed, uvidenhed?
 Vi kan ikke forhandle i ugevis og så se kompromiset undermineret i sidste øjeblik.
 Det afstedkommer naturligvis mange frustrationer.
 Vi må ikke fralægge os vores ansvar.
 Først da kan dette meget triste kapitel i regionens historie endeligt afsluttes.
 De kunne kombineres i et enkelt forslag på samme retsgrundlag i den første pille.
 Jeg vil gerne rette blikket mod nogle aspekter af den fælles landbrugspolitik.
-Kunstig inseminering og embryonoverførsel gør dette muligt.
 Det er ikke det blæk værd, som det er skrevet med.
-Dette punkt på dagordenen er afsluttet.
 Indtil da var det som bekendt kun forbudt for drøvtyggere.
 Derfor kunne vi spare penge på at bringe denne absurde månedlige udflytning til ophør.
 Grækenland har et særligt problem.
 Vi må frem for alt ikke skabe forbindelser, så længe alle cubaneres rettigheder krænkes.
 Det fører til, at vi udhuler respekten for vores egne høje principper.
 Det er ikke en beslutning om overgangsbestemmelsen i sig selv, men kun noget redaktionelt!
-Andor, mine damer og herrer!
 Europol får til opgave at kontrollere og godkende amerikanske begæringer.
 Indehaverne af disse licenser omfatter store globale energikoncerner.
 I øjeblikket står den ubrugt hen og bevogtes af tyrkiske tropper.
 Det udelukker ikke, at private udbydere kan og skal tumle sig her.
-Dupuis, der kræver fuldt medlemskab.
-Jarzembowski, hjertelig tillykke med det storartede arbejde, som de har udført.
 Der sættes handelsrekorder for køb af soja, majs og hvede.
 I optællingen var mit navn stadig med.
-Er den vikaransatte en arbejder som alle andre?
 Det er et interessant spørgsmål, for her kunne vi jo umiddelbart tage affære.
 Udviklingslandene er blandt dem, der lider mest under denne økonomiske recession.
 Den svenske opinion har også udviklet sig i positiv retning.
@@ -2043,23 +1851,18 @@ Jeg tænker navnlig på de mindste og nyeste medlemsstater.
 Men udviklingslandenes økonomi er hovedsageligt baseret på salg af disse råstoffer.
 Og hvis et tog kører forbi et rødt stopsignal, aktiveres bremserne også automatisk.
 Det er afgørende at sikre nøjagtig kontrol og registrering af omladninger og landinger.
-Flexicurity i sig selv er hverken en god eller en dårlig politik.
 Hvori består nu egentlig den skade, der udgår fra disse skibe og fra bekvemmelighedsflaget?
 Alle her husker, hvad der skete med en forfejlet landbrugsøkonomisk politik, med kogalskabsproblemet.
 Ud fra egen erfaring lovpriser han irakiske studerendes niveau.
 Mulder ville have været enig med mig, hvis han havde været til stede.
-Det er i alles interesse, at denne indsats gennemføres så glidningsløst som muligt.
 Spørgsmålet om sikkerhedspolitik var reduceret til en garanti om grænsernes ukrænkelighed.
 Alle bevillinger og al administration foretages i dag på edb.
 Uddannelse skal uddanne, ikke skabe billige, lydige arbejdere.
 Bygningens udvendige glasparti er snavset.
-Målet er udelukkende at fremme liberaliseringen og opbygge a level playing field.
 Her må såvel importører som ferierejsende og forbrugere være sig deres ansvar bevidst.
 Syn ved vejsiden af erhvervskøretøjer
 Men denne model vil redde liv i mange tilfælde, før ambulancen når frem.
-Euratoms sikkerhedskontrol viste derfor ikke, at angivelserne var forkerte.
 Jeg tror, at budgettet kan klare, at alle medlemmer får en papkasse til papirgenbrug.
-Derfor er det vigtigt, at vi ikke vedtager bestemmelser, som er tvetydige.
 Det andet punkt, hvor vi er i dissens, er natarbejde.
 For det femte er den påtænkte retlige brug af de nævnte oplysninger ukontrolleret.
 Hvis arterne uddør, forstyrres naturens balance, hvilket udløser en farlig dominovirkning.
@@ -2069,8 +1872,6 @@ Det belgiske formandskab har fortsat det svenske formandskabs kraftige og regelm
 Der findes mennesker, som foretrækker esperanto til grænseoverskridende kommunikation.
 Arbejdstagernes tålmodighed er nu sluppet op.
 Kommissionen skal være mere hård i flinten.
-I min korte tale vil jeg gerne fokusere på reintegrationen af brystkræftpatienter i arbejdslivet.
-Altså vokser produktionen i kødkvægsektoren mere og mere.
 Derfor vil vi stemme imod lempelsen af standarderne.
 Altid envejskommunikation, aldrig åben debat og altså så meget desto mindre folkeafstemning.
 Skadelige følger af rygning er også sorte rygerlunger og rådne tænder.
@@ -2086,13 +1887,9 @@ Vi har talt om valutauro, børskrak og finanskriser.
 Vi taler om linoleumsgulve med disse virkninger.
 Medlemsstaterne skal skabe alle mulige strukturer og procedurer for at fordele byttet.
 Lige fra begyndelsen har disse kriterier været genstand for heftige debatter.
-Occhetto på den anden side.
 Problemernes iboende natur gør, at der kræves multilaterale løsninger.
-Balkenende, det ved jeg, er en god kender af tysk historie.
-Koudiadis, fordi han gjorde det rigtige og opgav sin betænkning.
 Vi har konstateret, at når orkanen hersker på havet, bryder alt sammen.
 Den tåler kun dårligt markedskræfternes lammende greb.
-Her hjælper højglansbrochurer ikke noget.
 På den måde kan vi også sikre en godt udrustet og kompetent arbejdsstyrke.
 I alle samfund, også det litauiske samfund, er der lesbiske, bøsser og biseksuelle.
 Sådanne handlinger kan ikke regne med støtte fra enevældige myndigheder.
@@ -2104,11 +1901,9 @@ Fordelen er, at vi reducerer udgifterne til veksling af penge samt andre transak
 Vi bør ikke forbyde den jagt, der traditionelt udføres af inuitterne.
 Der skal også tages hensyn til statens subjektive opførsel.
 Et spørgsmål, som feminismen løbende har drøftet, er spørgsmålet om den hjemmegående husmoder.
-Dette beviser bl.a., at jagt kan drives uden de barbariske rævesakse.
 Min mor døde for en måned siden.
 Vi ønsker at vide, om denne aftale fremmer udviklingen af denne øgruppe.
 Der var et spørgsmål om enzymer og lovgivningen om genmodificerede fødevarer og foder.
-Disse resultater eller dette task force blev ikke nævnt.
 Vi har også indført fleksibilitet i forbindelse med pauserne.
 Dette forslag angår den srilankanske observatørmissions arbejde.
 Husk at tage sikkerhedsbælte på, også på bagsædet!
@@ -2116,22 +1911,18 @@ Det var et udmærket spørgsmål, men det kom ubelejligt.
 Disse artikler er særlig vigtige for individets og hele samfundets velbefindende.
 En anden god nyhed er, at sagsbehandlingstiden er faldet til ni måneder.
 Vi kan kun acceptere brugen af anordninger, der opfylder alle disse krav.
-Intimideringsmønsteret er klart.
 Før jeg kom her, svor jeg, at jeg ikke ville fortælle vittigheder.
 De bortførte estere er imidlertid stadig overladt til deres bortføreres nåde.
 I går var der trompeter og basuner lige uden for vores mødelokale.
 Brandfarlige møbler er et eksempel, som jeg har i tankerne.
 I den nederlandske tekst er der en fejltagelse eller en trykfejl.
 Selvfølgelig var der fejl ved deres plan, og deres fantasifulde monetære system brød sammen.
-Hvor bliver sodfiltrene på biler af?
 Irerne har sagt nej til at få den demokratiske kontrol væk fra borgerne.
 Disse manøvrer er latterlige.
 Særlig kosmetikindustrien er berørt af disse metoder.
 Ved hårdhændede udvisninger er der også tidligere faldet døde og sårede i andre medlemsstater.
 Hvad vil der ske, såfremt den drastiske rentenedsættelse medfører en overophedning af økonomien?
 Jernbanespeditørerne er et sammenbrud nær.
-Det handler også om guld, diamanter, cobalt og værdifuldt tømmer.
-Roche har fremsat under denne meget interessante forhandling.
 Vi er muligvis på nippet til at finde de politiske løsninger på vores problemer.
 Og så tager de ansvarlige benene på nakken.
 Det er uhøfligt over for medlemmerne, og det forstyrrer debatten.
@@ -2144,11 +1935,9 @@ Forslaget betoner alligevel i stor udstrækning både proportionalitet og subsid
 Det første er den audiovisuelle sektors betydning for sportens fremme.
 De fortjener alle et godt nytår!
 Det er en positiv beslutning efter et langt og til tider møjsommeligt arbejde.
-Der er tale om en nødvendig og kærkommen udvalgsinitiativbetænkning.
 Det burde skabe større likviditet.
 Det er urealistisk at fortsætte med braklægningsrettighederne.
 Opdræt af hjorte, af ræve og af mink er helt forskellige spørgsmål.
-Stevenson for hans fantastiske arbejde.
 Lad ikke fattigdomsbekæmpelsen bliver offer for dette dødvande i forhandlingerne.
 Kapitalisme er et kasino, hvor der trækkes lod om energiprisen på fondsbørserne.
 Det er derfor, vi har mødt problemet med fjernelse af hajfinner de senere år.
@@ -2175,33 +1964,27 @@ De nye medlemsstater er vant til årlige opgørelser.
 Vi må derfor undgå at skabe præcedens ved at acceptere asociale foranstaltninger.
 Hvad blev trampet ned af politiseringen?
 Derfor skal vi være varsomme, før vi prædiker over for resten af verden.
-Havmiljøet er helt klart grundlaget for vores havøkonomi.
 Køreplanen er således rigtigt tilrettelagt, og den skal overholdes.
 Cyperns befolkning har lidt kolossalt under øens deling.
 Jeg vil dog ikke remse alle fortidens historier op endnu en gang her.
-Ettl vil jeg tale om begge betænkninger samtidig, da de rejser de samme spørgsmål.
 Det er et nobelt forsøg, men stadig ikke tilstrækkeligt.
 De skal bevisligt opsamles, lagres, behandles og markedsføres separat.
 Det er et af de instrumenter, der er nødvendige for at kunne bekæmpe virussen.
 Og vi bør indrette vores lovgivninger, således at der sættes en stopper for sexturisme.
 De kan ikke puttes ned i den samme form, i den samme forhandling.
-Der skulle ganske rigtigt mange englebørn og ærkeengler til at skabe dette lille mirakel.
 Rygeforbuddet har allerede ført til hundredvis af publukninger med tab af arbejdspladser til følge.
 Vi hører fra eksperterne, at vandstanden kan stige med op til en meter.
 Vi har brug for fyrtårne i den europæiske forskning.
 Jeg taler om catalansk, mit og ni millioner andre europæeres modersmål.
-Haarder er jeg i høj grad utilfreds.
 Jeg vil især nævne fremskridt med hensyn til renere vand, hygiejne og sygdomsforebyggelse.
 Fru kommissær, bak op om mejerifonden!
 Jeg er omgivet af nogle meget opmærksomme mennesker her.
 Biler med polske nummerplader underkastes kontroller, der varer flere timer.
 Vi er nødt til at have en tydeligere sondring mellem dem.
 Hvordan står det til med udviklingen af disse filtersystemer til luftfartsselskaberne?
-Holodomor var produktet af et totalitært politisk regime.
 Kun paven er ufejlbarlig, vi er ikke.
 Hun har valgt en kort, generel og for hvert enkelt medlem enslydende evaluering.
 Men der er fortsat udfordringer, som skal takles.
-Det er ikke tilstrækkeligt med øjentjenester i form af høring.
 De må ikke overtages af de korporative interesser.
 Der findes ikke sådan noget som nulrisiko.
 Ja, naturligvis fortsætter diskussionen, men hvad dette punkt angår, vil løbet være kørt.
@@ -2240,10 +2023,8 @@ De begynder så småt at tro, at de ikke er ønskede.
 De pårørende håber stadig, at deres kære måske stadig er i live.
 Jeg går selv altid ind for nultolerance, hvad angår mærkning.
 Hidtil har det efter vores skøn ikke været nødvendigt.
-Hovedparten består af kulbrinteteknologi.
 Det betyder helt konkret, at indgreb kun er tilladt i tilfælde af groft misbrug.
 Eftersom jeg er i ekstraordinært godt humør, vil jeg rejse et tredje punkt.
-Jeg har ikke givet carte blanche til kernepolitikken.
 Derfor fordømmer vi naturligvis blasfemi.
 Vi går ind for, at vi udfylder dette behov for beskyttelse, dette vakuum.
 De nytilkomne har optaget helt nye eller ledige job.
@@ -2255,14 +2036,10 @@ Dette forslag er helt ude af trit med realiteterne inden for landbruget.
 Er det tilladt at indføre en statslig hashrus?
 Men jeg kan trods alt måske vove et smil.
 Den anden mulighed er at forbedre flymotorernes brændstofeffektivitet.
-Waltari er en finsk forfatter, der har skrevet en fremragende roman om en ægypter.
 Indbyggere kan stadig ikke vende tilbage og sygner hen i flygtningelejre.
-Det er ikke hensigtsmæssigt at fastsætte specifikke begrænsninger for raffinaderibrændstof.
-Shariaen udgør i dens ekstreme form en uovervindelig hindring for en normalisering af relationerne.
 Forarmet uran anvendes stadig på krigsscenen, på land og i by.
 Og vi kan nå stjernerne nu!
 Den skaber identiteter, og bogen skaber identitet.
-Garrigas efterlysning af realistiske budgetter.
 Men vi skal også lade fornuften og visdommen og visionerne herske i denne forbindelse.
 Ærede parlamentsmedlemmer, fru formand, hvordan skal vi bedømme vores femårige indsats?
 Efter notifikationen vil vi selvsagt forsøge at skabe klarhed i sagen i en fart.
@@ -2272,7 +2049,6 @@ Hightech skader ikke landdistrikterne.
 På denne måde ville vi hjælpe landmændene med at kunne blive boende i landdistrikterne.
 I mange år har man betragtet deponering som den letteste og billigste løsning.
 Jeg mener ikke, vi kan acceptere, at militæret beholder magten efter kuppet.
-Når beslutningstagende politikere går fra snøvsen, er konsekvenserne uforudsigelige og vidtrækkende.
 Først og fremmest giver de afkald på maksimale udbytter, og vi radrenser vores majs.
 Jeg ville bestemt ikke give dem topkarakter for deres arbejde.
 Og familie betyder ikke at have en vielsesattest.
@@ -2281,13 +2057,11 @@ Ganske vist har initiativtagerne skudt lidt over målet.
 Derfor kan vi i og for sig kun have lovord tilovers for denne beretning.
 Målene var at begrænse nitrogenemission, støj og forringelse af trafiksikkerheden.
 Nogle borgere i medlemsstaterne slagter traditionelt grise til jul og får til påske.
-Jasiden og nejsiden skulle have lige store offentlige tilskud.
 Der er tale om lovlige, halvlovlige og ulovlige immigranter.
 Men direktivet er aldrig blevet omsat til national lov.
 Som formand for det udvalg synes jeg, at hendes betænkning er et rosværdigt initiativ.
 Og dog af fortvivlelse kommer fatning, beslutsomhed og håb.
 Efter et par minutter kom stewardessen tilbage.
-Lad os udføre en costbenefitanalyse for alt, vi forordner.
 Jeg håber, at han i aften er lidt medgørlig med hensyn til ændringsforslagene.
 Vi har også en uensartet gennemførelse af de fælles regler i medlemsstaterne.
 Polen sætter sin lid til fælles europæisk politik, hvad angår dette anliggende.
@@ -2303,19 +2077,14 @@ Den engelske udgave skal betragtes som den originale tekst.
 Jeg var selv fraværende, men det har jeg fået bekræftet.
 Lad os tage et eksempel fra bilsektoren.
 Det andet arbejdsområde, der foreslås i hvidbogen, er rustning af borgerne.
-Det handler også om folkesundhed, tænk blot på aviær influenza.
-De buddistiske munke er intet lille elitært mindretal.
 Systemet indeholder data om savnede personer, stjålne varer og retssager.
-I øjeblikket er det stigende antal ukoordinerede nye kørselsforbud et mareridt for sektoren.
 Vækst ser ud til at være hæmmet af samfundets stigende usikkerhed.
 Men jeg ønskede ikke at lade dette ønske være uudtalt.
 Præferencer alene er ikke nok.
 Hvad er den rigtige anvendelse af ioniserende stråling?
 Det har i tres år været indprentet i vores kollektive hukommelse.
 Medierne, disse ualmindelig pædagogiske redskaber, skal bruges bevidst i denne sammenhæng.
-Trods de høje omkostninger, bør man efter min mening fremme leveringen af lysledernet.
 Derfor er opfindelsen altid noget uhåndgribeligt.
-Jeg er også enig med hensyn til cybertrusler.
 I min gruppe udlægger vi nejet helt anderledes.
 Vi stiller ikke urealistiske krav og søger ikke med vores krav politisk komfortable løsninger.
 Vi ønsker det slovenske formandskab al mulig succes.
@@ -2324,10 +2093,8 @@ Det er min vurdering af gårsdagens begivenheder.
 Ansvaret påhviler nu medlemsstaternes regeringer.
 Arbejdet bestod i sortering af dåser og flasker til genbrug.
 Rådets fælles holdning imødekommer ikke på alle punkter den europæiske fagbevægelses målsætninger.
-Hrusovsky og hans delegation får et behageligt og vellykket ophold.
 Positivt er også forslaget om mere elastiske forudsætninger for at få supplerende støtte.
 Den burmesiske regering gør sit ansvar for at beskytte til en farce.
-Dermed forsvandt tarifaftalerne mellem de forskellige belgiske forsikringsselskaber.
 En sådan form for uanstændigt management er uacceptabel.
 Ellers forsvarer vi altid aggressoren og frikender ham, mens vi prøver at berolige ofret.
 Endnu en gang bliver de generelle europæiske interesser ofre for kapitalismens grådighed.
@@ -2345,8 +2112,6 @@ For en liter mælk måtte han dengang arbejde ni minutter, i dag kun tre.
 Forskning i multipel sklerose bør også medtages i det syvende rammedirektiv.
 Lyt ikke til de polske politikere.
 Det er det, jeg ville kalde en kartesiansk klarhed.
-De tyer begge til vold, hvilket fastholder håndknuden.
-I dette memorandum of understanding skal de netop nævnte udgangspunkter også fastsættes.
 Her lader man hånt om alt, hvad man kan lade hånt om.
 Hun bor i det område, som min søn repræsenterer i byrådet.
 Jeg har især arbejdet for en forenklet procedure for professionelle brugere af fyrværkeri.
@@ -2365,16 +2130,12 @@ Denne keramikemballage består af ren, brændt lerjord og indeholder derfor inge
 Hvad angår vraget, er der nogen forvirring.
 Det ville være uheldigt at låse os fast i en forhandlingsposition nu.
 Vi skal dog også være udhvilede, vi skal handle besindigt.
-Han skjuler sig bag, at problemet udelukkende er et spørgsmål om eritreansk lovgivning.
 Det er alfa og omega i denne sag.
 Herved sikres det, at disse medspillere på markedet i fremtiden engageres ved nye udviklinger.
 Det havde været unaturligt.
-Gargani for klarheden og engagementet i hans betænkning.
 Hesten er allerede løbet løbsk.
 Internationalt er der jo i særdeleshed tale om en knivskarp priskonkurrence.
 Det har jeg erfaret på egen krop.
-Gklavakis for hans kommentarer.
-Svær fuel er det farligste produkt.
 Det er rigtigt, at antallet af marsvin er meget lavt.
 Jeg var ikke klar over, at han havde så ærefuld en fortid.
 Staes og andre medlemmer med rette har henvist til.
@@ -2383,16 +2144,12 @@ Det er aldrig godt at unddrage sig regler, man har tilsluttet sig frivilligt.
 Efter min mening er vin et af de mest elegante produkter, landbruget kan fremstille.
 Kvinder er fortsat underkastet diskriminerende love og dybt rodfæstet kulturel ulighed.
 Og alligevel løser det ikke ozonproblemet.
-Jeg kan derfor fuldt og helt gå ind for dette kommissionsforslag om scrapie.
 Halvdelen af de unge tjenestemænd, som rekrutteres fra de nye medlemsstater, er kvinder.
 Der tales i øjeblikket meget om bonuskulturen og aflønning af ledere.
 Det er en luksussituation.
 Den nuværende juridiske ramme er usammenhængende og ufuldstændig.
-Men her og nu må der sikres kaffebønderne en mindsteindtægt.
 Stadigvæk står eller sidder der femårige ved vævestolen, og deres forældre har intet arbejde.
-Wijsenbeek også, formoder jeg.
 Denne ordveksling må høre op.
-Disse vegatabilske produkter spiller i dag en vigtig rolle.
 Disse kys var naturligvis ikke helt uden et vist grundlag.
 For det andet skal vi tilpasse flådekapaciteten til fiskerimulighederne.
 Migrationspolitikken er usund.
@@ -2404,7 +2161,6 @@ Rådet fandt det nødvendigt at introducere yderligere to ændringsforslag.
 Der er ingen, der foreslår, at kobber skal udskiftes i husholdningerne.
 Dette omfatter navnlig fodnoterne til den tekst, der blev vedtaget i dag.
 Det baskiske samfund tager afstand fra organisationens forbrydelser.
-The next item is the vote.
 En sådan situation er både utålelig og ydmygende.
 Heller ikke i denne type spørgsmål kan der ydes nogen form for politisk rabat.
 Vist er korruption en ødelæggende svøbe.
@@ -2412,32 +2168,19 @@ Jeg noterede mig, at budgetblodet stadig løber i kommissærens årer.
 Ingen skal fare vild i en jungle af uigennemskuelige afgifter og gebyrer.
 Det er vigtigt, at vi får den skruet rigtigt sammen.
 Strafferetten henhører under medlemsstaternes kompetenceområde, og det bør den vedblive med.
-Estlands eksportstruktur beviser, at man imidlertid realiserer denne hightechmerværdi med succes.
-Bibiliotekets betydning for den vestlige civilisation og velfærdsvækst er kolossal.
 Derfor så han ingen mulighed for indrømmelser, så længe våbnene ikke var indleveret.
 Vi lader os ikke styre af fordomme, og tabloidaviserne skal ikke skrive vores manuskript.
-Ifølge dagsordenen afsluttes spørgetiden kl.
 Hvor akavet og ubekvemt demokrati er.
 Analyser og feedback fra medlemsstaterne viser, at retningslinjerne fungerer.
 Dette er et direktiv, der mere specifikt beskæftiger sig med råmaterialer end med tilsætningsstoffer.
 Det nytter ikke, at vi vil gøre lastvognene til en gås, der lægger guldæg.
 Tallene fra gråzonen er nok noget højere.
-For tiden giver svingningerne på råoliemarkedet problemer.
 Det udgør også den ultimative udfordring set ud fra en kommunikationssynsvinkel.
 I rammeafgørelsen er der ikke fastsat en seksuel lavalder.
-Den repræsenterer betydelige fremskridt sammenlignet med status quo.
-Medlemsstaterne kan lette netadgangen for små kraftvarmeenheder og mikrokraftvarmeoperatører.
-Flandern, med det formål at borgernes identitet anerkendes ved disse sportskampe.
 Beherskelse af it kræves nu til dags inden for de fleste professioner.
 Det glæder mig, at den laotiske kongefamilie er til stede her i dag.
-Virksomheder, som tilbyder deres tjenester via access for all , bliver snydt.
 Forarbejdningsstøtten til hør med lange fibre forårsager nu engang større omkostninger.
-Borgerne må ikke blive efterladt ude i den elektroniske motervejs nødspor.
-Den europæiske industri står over for et mægtigt konkurrencemæssigt pres fra udviklingslande.
-Vi er gået fra et substitutionsprincip til et uddelegeringsprincip.
-Newens, fordi de først og fremmest har taget bosættelsespolitikken i denne region op.
 Jeg gætter på, at nogle af vores kolleger vil tale om det her.
-Et meget vigtigt produkt under dette overbegreb er nifursol.
 Liberia har gennemlevet de mest forfærdelige og traumatiske tider.
 De ting, man antyder i dette beslutningsforslag, er meget, meget alvorlige.
 En sådan opførsel gør den sudanesiske regering til medskyldig i disse påståede forbrydelser.
@@ -2447,15 +2190,12 @@ Vi har også bragt et omtåleligt emne på banen.
 Intolerance og ekstremisme skyldes først og fremmest, at historien er blevet glemt.
 Og vi kan snart stå over for en overgang i det besatte, palæstinensiske område.
 I dette tilfælde er der tale om en hekseproces.
-Uighurerne er en moderat sunnitisk minoritet.
 Vi har brug for nye ligaer, vi skal ud af denne snævre nationalstatslige tankegang.
 Derfor skal der slås til lyd for en tosporet politik.
 Kroatien er et ungt demokrati, som stadig lider under krigens følger.
-Der er jo tale om inspektører, der også har deres virke i frøfirmaerrne.
 For øvrigt tales der igen om nettobidragydere, negative og positive saldi, engelske checks osv.
 Nåh nej, det står uafgjort.
 Men det er et langt og sejt træk.
-Asturien er støtteberettiget i henhold til traktaten.
 Det er akkurat nok til to telte og en varmedunk.
 Det er de store ords tid, ord, som er nødvendige.
 Jeg tænker på overvågningen af vores flyrejser, økonomiske affærer og privatliv.
@@ -2472,13 +2212,11 @@ Meget ofte bliver de europæiske værdier en hul frase.
 For det tredje er der angivet et for højt kødindhold.
 Vi har gjort dem til kannibaler.
 Princippet om nulvækst på budgettet forekommer både hensigtsmæssigt og klogt.
-Vi er sikre på, at den vil være et frisk pust i istitutionssystemet.
 Tilstandene i landet er kaotiske, og regeringen handler ud fra egne interesser.
 Det andet emne er modregning i eller handel med emissioner.
 Hele lovgivningen bliver desuden omgærdet af hemmelighedskræmmeri.
 Der er ingen lukkede grænser, og vi bliver ikke invaderet af indvandrere!
 Jeg har genlæst denne tale.
-Vores gruppe stillede forslaget om the call back procedure.
 I mit eget land er situationen for asylansøgere for nærværende fuldstændig utålelig.
 Spørgsmålet om biosikkerhed er meget vigtigt, og landbrugerne skal bidrage til at forebygge sygdomme.
 Alle næringsstoffer ville fås ved indtagelsen af den normale kost.
@@ -2486,7 +2224,6 @@ Hvad i alverden betyder det?
 Det er også, hvad millioner af europæere af tyrkisk herkomst ønsker.
 Men nej, vi vil ikke være dørmåtter!
 Jeg vil gerne fortælle en kort anekdote i denne forbindelse.
-Vigtige er også vores ønologiske traditioner, fru kommissær.
 De gør de grove karikaturer af eurokrater fuldstændig til skamme.
 De medfører oversvømmelser, jordskred, klimaforandringer og ødelæggelse af flor og fauna.
 Jeg er også bekymret over politikken om outsourcing af alle eksterne finansieringsprogrammer.
@@ -2496,7 +2233,6 @@ Så reagerede den kun halvhjertet, vidste ikke, at importvarerne hobede sig op i
 Jeg tror, at vi er enige om, at de filippinske søfolk også skal løslades.
 Sikken et forbryderisk spild af tapre unge menneskers liv!
 Flertallet af prostituerede lever et usselt liv med risiko for overfald, voldtægt, kønssygdomme osv.
-De vil være parier, forarmede og udstødte.
 Vi udtrykker vores solidaritet med det nepalesiske folk.
 Lad os ikke narre os selv.
 Vi er nødt til at nulstille.
@@ -2508,11 +2244,9 @@ Undertrykkelse er i højere grad skyld i dårligt helbred end malaria og trafiku
 Dette er en opgave for både paven og patriarken.
 Kriser kan dog blive trappet op til omfattende fjendtligheder.
 Det er ikke noget godt kompromis, det er en vakkelvorn basis.
-I dag er hun fængslet og vi, europaparlamentsmedlemmer, er afmægtige.
 På dette punkt er fiaskoen larmende, må man sige.
 Det er talakrobatik og udgør ingen garanti for borgerne.
 Alt imens ser resten af verden roligt til.
-De koster mindre, er opført som moduler og er derfor lettere at sikkerhedsteste.
 Restkoncentrationer af veterinærlægemidler i animalske levnedsmidler
 Det andet punkt, jeg vil påpege, er orlov.
 Naturligvis må man så også have rigtige parkeringspladser med sanitære faciliteter.
@@ -2525,10 +2259,8 @@ Medicinalindustrien vil aldrig få filantropi som målsætning.
 Marokkos grunde har ikke noget med bevarelse af ressourcerne at gøre.
 Det er absolut forbløffende og bekymrende og en kovending i den britiske regerings politik.
 Det er klart, at vi efterhånden har nået mætningspunktet.
-Det vil borgerne ikke accpetere i længden.
 Hvis vi giver dem kærlighed, bliver tilværelsen her på jorden lidt lysere.
 Det samme gælder for ftalater.
-Ansvarsfordelingen mellem landene for søredningsaktioner skal også afklares.
 Reglerne om bemanding gælder for skibets mandskab som helhed.
 De forskellige holdningsskift hos myndighederne viser klart deres rådvildhed.
 Oppositionen og uafhængige medier undertrykkes, og demokrati er en saga blot.
@@ -2559,17 +2291,11 @@ Rusland har en magtfuld præsident, der leder en spøgelsesstat.
 Det glæder mig at sige, at disse mål alle er intakte.
 Kun en sejr over erobrerne vil medføre ro og orden.
 Det gør vi med resignation.
-Vi ved f.eks, at de fleste dyreforsøg udføres på dyr af hankøn.
 Dette panel vil snarest påbegynde sit arbejde.
 For det andet kan man hidføre knaphed på det arbejdsvolumen, der står til rådighed.
-Men også her er der et aber dabei, nemlig lovgivningen om punktafgifter.
-Jeg vil fortsat støtte en opfordring til, at vi skal have et stærkt copyrightdirektiv.
 Selvfølgelig er der asymmetrier!
-Deprez, har blot nævnt dette for borgerrettighedernes vedkommende.
 Så længe lønforhandlinger er en sag for mænd, kan løndiskrimineringen ikke fjernes.
-Goebbels også bekendt med.
 En sådan database er det modsatte af hans udmeldinger i begyndelsen af hans embedsperiode.
-Den skal være åben, gennemsigtig og meritbaseret.
 Jeg købte de samme ting i mit eget land tre gange dyrere.
 Retsudvalget tæller jo mange, der arbejder inden for retsvæsenet.
 Der er tale om en harmonisering opefter.
@@ -2579,8 +2305,6 @@ I mit tidligere indlæg kunne jeg ikke afse tid til dette.
 Europæiske succeser i den globale konkurrence bygger på kyndige og engagerede mennesker.
 Congos myndigheder og hær kan ikke løse områdets problemer alene.
 Sol og vind skal ikke byttes ud med atomkraft.
-Argo kan heller ikke kun være et samarbejde mellem nationale bureaukratier.
-I samme passage findes der også en ræsonnering over, hvordan man bekæmper fattigdom.
 Sådanne beløb kan da også under bestemte betingelser opkræves af medlemsstaterne.
 Det handler ikke om at skabe en masse red tape.
 Den globale opvarmning er for vigtig til, at vi kan nøjes med denne trippen.
@@ -2590,38 +2314,28 @@ Den pakistanske regering ved, at det skal gøres.
 Store ord fra sådan nogle krystere!
 Alternativet er kaos og anarki, og det er ikke i nogens interesse.
 Det er de nøgne kendsgerninger.
-De er blevet overtrådt af militæret, men også af guerrillaen.
 Eneforhandleren kan dog sælge til enhver potentiel køber, der besøger hans forretning.
 Det første spørgsmål vedrører den fakultative arealbinding.
 Massedemonstrationer slås ubarmhjertigt ned.
-Dette er det mest vedholdende af årtusindudviklingsmålene.
-Hovedproblemet er eutrofiering, som ordføreren også fint beskrev konsekvenserne af.
-Nabucco kan vise sig at være et godt skridt hen imod energisikkerhed.
-Matsakis i, at blodsudgydelser ikke fører nogen steder hen.
 De frøtyper, der skal certificeres, skal kunne bruges i dyrkningsøjemed.
-Jeg kan acceptere det foreslåede resultat på området securitisation.
 Det kræver de rette geologiske forhold.
 Vi kan således sige, at han skyndte sig at komme før vores parlamentskollegas beslutning.
 Den har især støttet forskning i udarbejdelsen af harmoniserede metoder til at beskrive amfetamin.
-En præsidentagtig guru, der fører sig frem i verden og skaber ballade?
 Screening er afgjort påkrævet, men det er og bliver en sekundær forebyggende foranstaltning.
 Evans, denne rettelse vil blive foretaget.
 Også i weekenderne og på helligdage.
 De takster, som direktivet fastsætter, er dog knap så stor en succes.
 De taiwanske myndigheder har ikke haft adgang til meteorologiske oplysninger om tyfonens styrke.
-Øområderne møder mange vanskeligheder på grund af naturgivne og økonomiske handicap.
 Dette har skrækkelige konsekvenser, fordi der her allerede er etablerede ruter i hele verden.
 I direktivet fastsættes det endvidere i detaljer, hvornår man må sprøjte fra luften.
 I stedet for at føre an udgør vi nu bagtroppen.
 Han sagde, at kineserne skal bygge en stor mur mod separatisme.
 Festligholdelserne har både haft positive og negative følger.
 Vær opmærksom på, at midlerne til kultur hovedsageligt er rettet mod de store bycentre.
-Direktivet er under udfærdigelse, men der anvendes for megen tid til redegørelsesfasen.
 Arbejdstagerne er ikke kun brikker i et spil skak.
 For tiden skjules advarslerne fikst af en smart opstilling eller en farvestrålende pakke.
 Vi kan udbygge kontrollen og verifikationen af de forpligtelser, der er blevet påtaget frivilligt.
 Så hvad det angår, befinder vi os i en særdeles pudsig situation.
-Markedsføring af dichlormethan til erhvervsmæssig brug vil blive underlagt et generelt forbud.
 Men de vil finde sted inden for udemokratiske rammer.
 De foreslår at forvandle stabilitetspagten til en social regressionspagt.
 Det kalder vi samfundsorienteret erhvervsudøvelse som topsport.
@@ -2636,9 +2350,6 @@ Det er en debat for feinschmeckere som os.
 Nu er disse dæk ikke særlig usikre.
 Forbrugere er ikke tossede.
 Lægemiddelindustriens fortjeneste er til gengæld røget i vejret.
-Det truer på ny det højt besungne samhørighedsprincip.
-Hautala hævder, at det er teknisk muligt.
-Korakas, så kan jeg ikke være det mere.
 Vi skal have adgang til skove, enge samt strande ved have og søer.
 Colombia bliver heller ikke nævnt.
 Det er utænkeligt, at det blot på nogen måde ville blive tolereret.
@@ -2647,22 +2358,18 @@ Vi er ikke alle ustuderede røvere eller analfabeter.
 Man kan slet ikke anvende en aritmetisk opdeling a la halvt om halvt.
 Som erhvervsdrivende i en mellemstor virksomhed har jeg adspurgt mange af mine kolleger.
 Det er gyselig bagvaskelse, som har til formål at forvirre og vildlede.
-Swobodas gruppe har hovedansvaret for.
 Endelig understreger vi, at sedlerne skal bringe borgerne tættere på deres valuta.
 Resultatet heraf kan meget vel være meromkostninger og besvær og ikke frihed.
 De var ikke velhavende, men flygtede fra fattigdom.
 Vi taler ikke om fibre, men om andre materialer såsom pels.
 Men selv denne betænkning forfalder af og til at drøfte det grandiose og teoretiske.
-Den menneskeskabte globale opvarmning er en uafprøvet teori baseret på manipulatoriske statistikker.
 Flyoperatørerne skal have korrekte data, så de kan gennemføre de bedste løsninger.
 Lad os endelig også tænke på ofrene, være lydhøre over for ofrene.
 Kommissionens problemer med underbemandingen skal heller ikke betvivles.
-Fru kommissær, der er to spørgsmål, de polske bærfrugtavlere ikke kan forstå.
 Antibiotika må ikke dæmoniseres, men anvendes med forsigtighed hos både mennesker og dyr.
 Jeg er endvidere enig i, at de webbaserede sundhedsressourcer skal fremmes.
 Sigøjnerne er en meget bred, europæisk minoritet.
 Vi skal på dette grundlag i højere grad måle resultater i stedet for input.
-Traktaten om ikkespredning af atomvåben støtter denne nedfrysningsordning for kernevåben.
 Hans mission måtte opgives, da de usbekiske myndigheder nægtede at give ham visum.
 Forhandlingerne skrider planmæssigt frem, og vi overholder tidsplanen til punkt og prikke.
 Vi skal have gode uddannelser og bevidstgørelse for at fjerne vold og stereotyper.
@@ -2678,7 +2385,6 @@ Tusindvis af mennesker flytter stadig fra nord til syd.
 Sagen henvises til forvaltningsrådet, som efter en undersøgelse vil svare høfligt på anmodningen.
 Hidtil har der været en tilgang af nationale markeder normalt med offentligt ejede stålvirksomheder.
 Det er faktisk ikke blot sort og rundt, som en lægmand tænker.
-Jobklassificeringssystemerne er fejlbehæftede, hvis de overhovedet findes.
 Af de nordlige totalarealer anvendes under en promille til indvinding af tørv.
 Dette er imidlertid en lappeløsning.
 Vi gør fødevarerne sundere, vi gør kødet, dyreprodukterne, sundere.
@@ -2693,7 +2399,6 @@ Arktis er en del af verdensarven og skal også betragtes som sådan.
 Han mener, at finansministre er heksedoktorer, som ofrer job på deres altre.
 Dette er de spændende byfornyelsesinitiativer, som vi bør støtte.
 Universel adgang til højhastighed er i vid udstrækning afhængig af denne fordeling af frekvenser.
-Det ene handler om producentens uindskrænkede ansvar for tilbagetagelse af udrangerede køretøjer.
 Den, der siger r for reformer, må også sige a for afvikling af landbrugsstøtten.
 Jeg var optaget af et interview om denne betænkning, og mit ur gik forkert.
 På dette område ligger der for mig et uvurderligt potentiale.
@@ -2702,16 +2407,13 @@ Det er vigtigt at være helt på det rene med hensyn til ugifte partnere.
 Det er for en stor del kopilovgivning og imitationslovgivning.
 Det er rigtigt, at en af mulighederne er at forbyde natflyvninger.
 Chile er et land, hvor man investerer, og landets finansielle reserver øges.
-Øregionerne er økologisk sårbare områder.
 Der er ikke tale om velgørenhed, for velgørenhed er frivillig.
-Virrankoski, som har udført et grundigt stykke arbejde.
 Rissektoren har haft meget vanskelige tider i de seneste år.
 Der er en række tanker og pejlemærker i denne betænkning.
 I andre dele af verden hedder problemet overlevelse.
 Skal vi være et forum, hvor man gør nationale politiske udeståender op?
 Det var en enorm moske, større end denne sal, men ikke så smuk.
 Alt dette forekommer os useriøst!
-Dyrs velfærd er fortsat i for høj grad et konkurrenceforvridningselement mellem medlemsstaterne.
 Samdrægtigheden i det argentinske samfund opbygges gradvis under store vanskeligheder og spændinger.
 Det er i hvert fald mere behagelig læsning, hvad mine områder angår.
 Spørgsmålene om adgangsleverandørers og tjenesteyderes ansvar er subtile.
@@ -2723,13 +2425,11 @@ Efter min mening bør vi gøre dette klart for den yemenitiske regering i dag.
 Men det er den eneste måde, vi kan øve indflydelse på.
 Vi håber, at han får et stilfærdigt otium, men hans direktiv er fuldstændig dødt.
 Bronzesoldaten var blot en undskyldning.
-Additionaliteten af bevillingerne bør fortsat have høj prioritet.
 Vi skal også huske på, at indvandringsstrømme ikke behøver at være fuldstændig uafvendelige.
 Den bedste kur er forebyggelse.
 Apotekere har også behov for pålidelige forsyninger med produkter af høj kvalitet.
 Der er ikke et eneste medlem af min gruppe, der ikke deler denne gru.
 Ambition, ambition, javel, men denne ambition skal være til at få øje på!
-Hvem ejer den symfoni, som vor europahymne stammer fra?
 Kun på denne måde forsvarer man forbrugernes valgfrihed og sikrer også vinproducentens valgfrihed.
 Det skyldes måske til dels, at landbrugspolitikken har ændret sig i løbet af årene.
 Derfor kan disse fradragsretter være fri og udelukkende medlemslandets eget anliggende.
@@ -2739,44 +2439,32 @@ Vi har sandsynligvis brug for passive, men muligvis også aktive sendere til tun
 Det er åbenlyst, at vores skove er mangfoldighedens vugge.
 Store bogkæder overtager ved hjælp af priskrige kontrollen med sektorerne.
 For det andet er der det meget omdiskuterede budget.
-Han skal stadig i retten forsvare sig mod en gammel såkaldt spionagesag.
-Rettigheder uden ansvar svarer i etikkens verden til subprimelån i økonomiens verden.
 Ny økonomisk vækst er bestemt ikke synonym med sløjfning af den europæiske sociale model.
 Så lad os ikke slynge statistik omkring os som fornærmelser ved en fodboldkamp.
 Det kan være, at han ikke har opmålt sin jord korrekt.
 Det tjener intet formål at tale kønt om de handicappedes rettigheder.
-For det andet drejede det sig om at afgrænse mellem infrastruktur og suprastruktur.
-Washingtontopmødet resulterede i et imponerende katalog af prisværdige intentioner.
 Jeg finder dette ubegribeligt, fordi ingen pæn virksomhed behøver at frygte dette direktiv.
-Det andet emne er reduktionen af volatiliteten på fødevaremarkederne, især gennem større lagre.
 Parlamentet sidder for sit vedkommende ikke på tribunen, det er ikke tilskuer.
 Vi kan skimte dem, ikke blot som en vision, men faktisk som en realitet.
 Europa befinder sig ved en korsvej.
-Collins, der foreligger en fejl.
 Vi må bryde ud af den trætte debat om institutioner og forfatninger.
 Jeg vil dog ikke vædde min sidste euro på det.
 Der sker stadigvæk uacceptable ulykker på gårde og i fabrikkerne.
 Eurostat har indgået kontrakter med firmaer, som har fuppet og svindlet.
-Ligesom vi har olielagre, bør vi opbygge gaslagre.
 Den demokratiske debat højnes ikke af at øge antallet af løsgængere.
 Der er absolut ikke plads til cowboys på vejene.
 Vi har her naturligvis at gøre med et typisk tilfælde af mainstream.
 Der er tale om en yderst frimodig ombytning af rollerne.
 Værsgo, men pas på ikke at få det galt i halsen.
-Mingasson og hans medarbejdere for deres meget positive holdning i denne sag.
 Vi har de facto valgt at betragte agenturerne individuelt.
 Popkulturen formidler kulturelle og sociale budskaber.
 Energi er dog en råvare, som skal være underlagt de markedsøkonomiske principper.
 Det skal omdannes til et fissilt materiale ved hjælp af formeringsteknologi.
-Hodie mihi, cras tibi, i dag mig, i morgen dig!
-Jeg er stadig forvirret med hensyn til hakkekødssituationen.
 Efter min mening ville det være farligt at afskaffe disse særregler.
-I mit eget land bliver fluorose et stadig større tandproblem, navnlig hos teenagere.
 Næ, fremskridt og perspektivering har ganske anderledes reduceret betydning.
 Jeg deltog forleden i et seminar om grænseoverskridende kriminalitet.
 Denne situation er nedværdigende og bør stoppes.
 Det er et meget lille land, og de opruster helt ekstremt.
-Meijers fremragende arbejde, hvor vi for øvrigt støtter størstedelen af ændringsforslagene.
 Det skal sikres, at indrejsetilladelser for lærlinge ikke bliver et dække for ulovlig beskæftigelse.
 Nej, de skal skrottes forskriftsmæssigt af dertil godkendte virksomheder på stedet.
 Mugabes misregimente og korruption lammer hele landet.
@@ -2786,47 +2474,34 @@ Jeg sov meget dårligt i nat, for jeg havde et rigtigt mareridt.
 Bulkladninger, som kan indeholde gensplejsede organismer, skal mærkes.
 Den nye metodes markedsrettede karakter står også i kontrast til forskrifternes ubøjelighed.
 Det er vigtigt, mener jeg, at sætte fingeren på dette ømme punkt.
-Det, at flyrejser er blevet tilgængelige for alle, har åbnet for hidtil usete migrationsstrømme.
 Som et apropos hertil har der allerede været positive udviklinger inden for klimaændringer.
 Det er i vores interesse, at de brande slukkes så hurtigt som muligt.
 Udskiftning af kanyler fungerer.
 I de tre betænkninger skitseres flere mulige retninger for arbejdet i denne henseende.
 Denne optegnelse skal også regelmæssigt genvurderes og opdateres.
 Der er imidlertid nogle skavanker, som vi henviste til.
-Et fald i midlerne fra samhørighedspolitikken vil blive ved med at smadre vores økonomi.
 Især de unge er meget ilde stedt.
 I går tekstilmarkedet, i dag skomarkedet, hvad bliver det næste?
 Vi skal støtte ham og fortsat gå i brechen for det latinamerikanske folk.
 Så hvor er fødevarerne henne, og hvorfor har vi kun en begrænset forsyning?
 Argumenter baseret på fair konkurrence og miljøbeskyttelse vinder altid gehør hos befolkningen.
-Desuden er der begyndt at fremkomme nye skibsbygningslande på vedensmarkedet.
-Fukushimaulykken har vist os, at visse eksisterende atomkraftværker ikke er sikre.
-Det synes ike helt at være tilfældet for øjeblikket.
 Der skal opstilles passende mål for at sikre passende resultater frem for talmanipulation.
-Hebron er et eklatant eksempel på apartheid.
 Argumentet med, at familien og hjemmets arne er kvindens sande kald, bruges som påskud.
-Kommissionen foreslår nu at åbne markedet for kyllinger, som er desinficeret i en kloropløsning.
 Der er simpelthen ikke troværdigt at sammenligne med bybusser.
 Kommissionen behandler endnu en gang andre folks penge ryggesløst og uansvarligt.
 Lavere rangerende officerer og fascistiske bøllebander støtter denne forfølgelse.
 Endelig mener mange fiskere, at det bringer ulykke at lære at svømme.
 Adam, som har præsteret et usædvanligt godt stykke arbejde, for dette.
-Der bliver ikke nogen amerikansk modaftale på dette punkt.
 Det er naturligvis ikke ensbetydende med, at det pynter på handelsstriden, snarere tværtimod.
 I mellemtiden tikker den globale opvarmning roligt videre.
-I årevis er de blevet grinagtiggjort på grund af mælkesøer og smørbjerge.
 Måske har disse små øer gjort det, fordi de oplever faren meget tættere på.
 Planlægger den moldoviske regering virkelig at åbne ild mod demonstranter i nødsituationer fremover?
 At vi ikke udfaser dem, mener jeg, er uambitiøst, og mener jeg, er trist.
 Det glæder mig, at isolerede, smalsporede og fredede jernbaner vil være undtaget.
-Mange tak, fru kommissær, for at have skabt en quadrilog for os.
 Når man finansierer forebyggelse, begrænser man ligeledes de betydelige udgifter til genrejsning.
-Rehn har forklaret situationen.
 En urentabel produktion bør ikke holdes kunstigt i live i al evighed.
 Mexico er ikke et diktatur, men et demokrati.
-Det er absolut nødvendigt at overføre flyfragttransport over korte distancer til jernbanerne.
 Tak, og det siger jeg uden nogen form for guirlander, hvor relativeringerne gemmer sig.
-Dette er orwellsk newspeak, og det er uacceptabelt.
 Mener man virkelig, at vi er så dumme?
 Selvfølgelig skal dette forbud være veldefineret.
 Tusindvis af nonner og munke forfølges, fængsles og mishandles stadigvæk.
@@ -2836,7 +2511,6 @@ Det er nødvendigt med større støtte til bomuldsavlerne uden yderligere beskæ
 Mange af brøndene måtte lukkes.
 Derfor duer det ikke med en løsning, der er baseret på eksklusive krav.
 Vi kan således se, at den urbane dimension nu indtager en betydeligt større plads.
-Det guineanske styre er det mest korrupte regime i verden i dag.
 Mine damer og herrer, jeg vil ikke give ordet til alle med blåt kort.
 Ville en tese om større forbrug løse problemerne?
 Mellemamerika er lagt øde, genopbygningen vil vare årtier.
@@ -2860,15 +2534,12 @@ Det drejede sig primært om de lande, vi udtalte os om i fjor.
 Det internationale samfund vil ikke længere lade sig narre af denne siksakkurs.
 Fiskeriet skal begrænses, så der sikres en bæredygtig og naturlig fornyelse af laksebestandene.
 Fem års universitetsuddannelse kan ikke pludselig pakkes ind i en treårig bacheloruddannelse.
-De er påfaldende uimødekommende.
-Nisin er et antibiotikum, der måske på længere sigt kan give medicinresistens.
 Derfor foreslår vi, at denne begrænsning til eksotiske dyr eller selskabsdyr udelades.
 Schweiz ved, at lokalkendskab er nøglen til indvandringspolitikken.
 Der er opstillet fem betingelser, de famøse fem kriterier, som ikke kun er referenceværdier.
 Europa skal udelukkende baseres på solidaritet og gavmildhed og ikke på egoisme og smålighed.
 Vi plyndrer alt det, der er, og tager alle rigdommene.
 Det er desværre mit indtryk, at de fleste evalueringer bliver arkiveret lodret.
-En anden opgave kunne være at forsøge at forhindre våbensmugling til den kosovanske befrielseshær.
 Derudover udtrykker industrien bekymring over forbuddet mod pvc, navnlig inden for kabelindustrien.
 Vi er vidne til et hidtil uset voldsniveau med et hårrejsende antal ofre.
 Det er et centralt aspekt for strategiske investorer såsom dem på bilmarkedet.
@@ -2878,10 +2549,8 @@ Den prekære pengesituation truer til dels også accepten af de hidtil yderst po
 De skal være sikret uhindret adgang til telekommunikationsmidlerne.
 Enhver skødesløshed fra vores side kan have uigenkaldelige følger.
 Spar os for de politiske montager i medierne, der fandt sted under golfkrigen.
-Honeyballs betænkning er en af disse.
 Et eksempel er forskelsbehandlingen på lønområdet over for kvinder på arbejdsmarkedet.
 De har korrekt anvist den vej, der skal følges i sagen.
-I nord bruger de stadig liraen.
 Den findes i den kristne religion, hinduismen, den jødiske religion og islam.
 Jeg ville bare sige, at jeg er bonde og har interesser på dette område.
 Jeg har øvet mig på det i nogen tid nu.
@@ -2894,57 +2563,40 @@ Den srilankanske hærs angreb på civilbefolkningen kan endog betegnes som en ma
 Fri bevægelighed for læger og gensidig anerkendelse af deres eksamensbeviser
 Denne betænkning kunne have undgået offentlig bevågenhed.
 Vi griber ikke ind, men græder og råber i stedet som gamle kvinder.
-Vi mener, der er brug for en europæisk bompengetjeneste.
 Vi vil fortsat presse de tunesiske myndigheder for hurtigt at ophæve denne blokade.
 Betænkningens udsagn om det gnidningsfri samvirke er simpel juridisk nonsens.
 I de senere år har den europæiske biovidenskab og bioteknologi allerede haft succes.
 De opnåede resultater skal befæstes gennem passende politiske og lovgivningsmæssige initiativer.
-Vi vil ikke have noget med en mindstetjeneste for mindre bemidlede at gøre.
 Jeg har spurgt afdelingerne.
 Tøjfabrikanter og førende globale mærker forudser allerede en stigning i prisen på bomuldsvarer.
 Det er måske et lille stykke afbureaukratisering, som vi altid kræver på forskellige områder.
 Gennemførelsen af disse beslutninger vil kræve benhårdt arbejde.
 Med en chokerende kynisme foreslår ordføreren at liberalisere og deregulere markedet fuldstændigt.
-Siekierski tillykke med en fremragende betænkning.
 Det førte til, at priserne på mejeriprodukter ganske enkelt røg i vejret.
-Sidste år nævnte jeg echinacearoden som eksempel.
 Det vigtigste er, at pengene yngler.
 Frihandel er ikke noget uartigt ord.
 Jeg oplever, at slagterierne ganske enkelt vægrer sig ved at slagte dyr.
 En sådan strategi er ikke længere velegnet.
-Grooming blev nævnt af ordføreren.
-Kommissionen støtter også adskillige bluetongueforskningsprogrammer.
 Også revisionen af lovgivningen om dæks rullemodstand er vigtig.
 Trods utallige svulstige hensigtserklæringer er der endnu ikke sket nogen virkelig ny begyndelse.
 Deres udtalelser var imidlertid som altid meget afmålte, men dybest set meget overdrevne.
 De har givet mange tips om misforhold.
-Nogueira, hvis det skulle være nødvendigt.
-Omsættelsen af det saharanske folks selvbestemmelsesret har for os altid haft førsteprioritet.
 Det er bestemt tilladt at forske i cellelinjer, der allerede er blevet udtaget.
 Medlemsstaterne har gennemført deres egne nationale folketællinger i mange tiår.
 Indien forsvarer sine nationale interesser og oldgamle værdier.
-Formatet kan være dramaserier, konkurrencer, film, nyhedsrapporter, men også debatprogrammer o.l.
-Stamceller fra navlestrengsblod er et eksempel på, hvor der er sket fremskridt.
 Der kan også opstå stor afstand i et årelangt venskab.
-Tajani, mine damer og herrer!
 Hun brugte disse penge til at renovere en ødelagt bygning i byens centrum.
-Jeg kan ikke bare dele penge ud til en hvilken som helst ngo.
 Den økonomiske og finansielle krise medførte også et brat fald i verdenshandelen.
 Man ignorerede forbuddet mod anvendelse af animalsk mel som foder.
 Indtagelse af berigede fødevarer i en varieret diæt kan supplere indtagelsen af næringsstoffer.
-Crowleys spørgsmål, ville det ikke være diskret.
 Det er uimodsigeligt, at dyr udsættes for unødige lidelser.
 For mig som proeuropæer og føderalist er protektionisme antieuropæisk.
 Det bilbaserede samfund, som vi kender i dag, har således fået en betinget dom.
 Jeg tror faktisk, at kernen lå i første del af mit svar.
-Jeg vil dog ikke skjule, at vi ikke overlykkelige, når det gælder cabotageordningen.
-Vi ønsker at sikre bæredygtig udvikling, ikke ubæredygtig fattigdom.
-Samtidig dør dusinvis af millioner mennesker uden at kunne få behandling.
 Sexmisbrugere skal nægtes mulighed for at udøve erhverv, som indebærer kontakt med børn.
 Parlamentet har altid krævet, at babymad skal være uden pesticider.
 Allahs parti nævnes simpelthen ikke!
 Disse skyer vil overskygge vores økonomiske landskab i de kommende år.
-Winkler i denne forbindelse.
 Jeg er selv blevet stukket af potentielt inficerede nåle og instrumenter.
 Der skal drages omsorg for, at de kan identificere sig med deres eget sprog.
 Der er derfor intet at bekymre sig om, kære frue.
@@ -2958,24 +2610,19 @@ For det fjerde er en ny bilteknologi kun mulig med lave svovlindhold.
 Muligheden for at etablere en togkorridor er også blevet fremlagt.
 Politik uden finansielle ressourcer er kun tom gestikuleren.
 Forureningen med fint stof og ammoniak er meget hårdnakket.
-Dermed undgår vi, at dæklagre skal destrueres, hvilket ville skade miljøet yderligere.
 Situationen er helt kafkask.
 Myanmar fjerner sig fra demokratiske værdier med alarmerende hast.
 Kun en ambitiøs og fælles fremgangsmåde kan bevare den europæiske kulturs særkende.
-Doceren og lappeløsninger uden en egentlig undersøgelse nytter ikke noget.
 Bygningers energimæssige ydeevne
 Konsekvensen heraf ville blive en yderligt dalende valgdeltagelse.
 Princippet med dobbelt flertal er ikke et sagnvæsen.
 Når der tales om tyrekampe, tænkes der naturligvis på tyrefægtninger.
-Falconer, den er ført til protokols.
 Sexindustrien udnytter internettet og den seksuelle vold, som mange kvinder og børn udsættes for.
 Jakartas modforanstaltninger, især militære, har hidtil haft den modsatte virkning.
 Det er upraktisk, bureaukratisk og unødvendigt for at beskytte miljøet og sundheden.
 Af politiske årsager bør vi ikke støtte denne dosis.
 Derfor er det så tragisk at se landet styre lukt imod afgrunden.
-Linkohr så rigtigt har udtrykt det, er heller ikke blevet udviklet.
 Prisen på slagtesvin følger den sæsonmæssige nedadgående tendens.
-Bankerne er blevet rekapitaliseret, og den finansielle stabilitet er blevet prioriteret.
 Forhåbentlig kan vi få en god nats søvn i den nærmeste fremtid.
 Hvis det var så enkelt at lave politisk kirurgi, ville vi gøre hurtigere fremskridt.
 De begynder at hælde barnet ud med badevandet.
@@ -2984,7 +2631,6 @@ Flag og hymner er for nationer, ikke for økonomiske sammenslutninger for samarb
 Landbrugerne, som i forvejen er ved at bukke under for det aktuelle bureaukrati.
 Jeg mener også, at uorganiske stoffer skal håndteres anderledes end organiske kemikalier.
 Ifølge de seneste informationer har han fået kraniebrud og lidt et stort blodtab.
-Og forklaringen, måske den eneste, er den messiaslære, der er bag alt dette.
 De har da vist brug for et par tilsætningsstoffer for at køle lidt ned.
 Jeg gad vide, om det er til stede under forhandlingen i aften.
 Denne ubalance giver unægtelig også stof til eftertanke.
@@ -2998,7 +2644,6 @@ Horrible hændelser af denne slags kan ikke tolereres.
 Så stiger nervøsiteten og væddemålene om, hvem der først når målstregen.
 Revanchisme og rethaveri er kontraproduktive nu.
 Det er en eufemismernes traktat.
-Beazleys spørgsmål, som var meget specifikt.
 Aftenens forhandling udviklede sig desværre til en maratonforhandling.
 Klausulen indeholder forslag til yderligere foranstaltninger.
 Er den datobaserede eksportordning tilfredsstillende, hvad angår kødets og kødprodukternes sikkerhed?
@@ -3014,35 +2659,23 @@ I den aktuelle vanskelige og udfordrende økonomiske situation kan vi ikke tilla
 Arbejdet blev også rost flere gange.
 Små og svage partier, der udelukkende sværgede troskab mod deres ledere, blev skånselsløst udrenset.
 Jeg lever i en jægerfamilie tæt på den hollandske grænse.
-Srebrenica er et symbol på etnisk udrensning.
 Når fattigdom bliver til dyb armod, bliver det en trussel imod freden.
 Men det er kun toppen af det isbjerg, som må blotlægges.
 Fra at landet havde en kvindelig premierminister, går premierministerens hustru i dag med tørklæde.
-Kyoto har givet os en platfom.
-Man mister penge ved at privatisere golden share.
-Hvem har nogensinde hørt om, at enmotores fly er mere sikre end tomotores fly?
 Parlamentet træffer imidlertid beslutning herom, og den beslutning vil jeg bøje mig for.
 Den ydede bistands kvalitet og effektivitet er mindst lige så vigtig som dens kvantitet.
 Nu er vi alle dækket med ar og overdynget af dekorationer.
-Transportens forurening af miljøet er uomstridt.
-Vi skal bevare disciplinen, og det skal ske på bagrund af de samme prioriteter.
 De forsøger også at opildne forbrugerne til at tage del i deres kampagne.
-Putin er ikke en lydefri demokrat.
 Det er berettiget, for fedtholdige kroketter bliver ikke sunde ved at tilsætte nogle vitaminer.
-Fatuzzo, der repræsenterer pensionisterne, er overordentligt tilfreds.
 Der er tilfælde, hvor den ene forælder stjæler barnet fra den anden.
 Mener udvalget ikke, at disse krav ofte er kamuflage for den rene skinbarlige protektionisme?
-Det næste forhold vedrører anvendelse af lysdiodebaseret belysning, der er energibesparende og varig.
 Moderen løj, og det fædrene ophav var også en løgn.
 Der hersker verden over en ruinerende konkurrence inden for fødevaresektoren.
 Diskrimineringen og undertvingelse af kvinder har rod i selve islams hellige tekster.
-Den fælles fiskeripolitik bør ikke mere fungere som et lindringsmiddel eller middel til dødshjælp.
 Og den kan ikke iværksættes, sålænge medlemsstaterne ikke ratificerer dem.
 Frygten for en lavine af billig arbejdskraft har vist sig at være ubegrundet.
 Jeg vil også gerne fremhæve et andet aspekt, hvor vi ofte trækker en nitte.
-Det åbnede sluserne, og intimidation har vundet troværdighed.
 Dette har resulteret i prissvingninger og store økonomiske tab for bønderne.
-Liikanen, så vi bliver konkurrencedygtige og kan tage denne globale udfordring op.
 Da der kom flere radarer på de franske veje, faldt antallet af dødsofre straks.
 Et stort antal mennesker lider af astma og andre lidelser.
 Jeg tror, vi bliver nødt til at mase på.
@@ -3057,7 +2690,6 @@ Men også bestanden af sild og brisling er fortsat i en udmærket forfatning.
 Vi ser disse personligheder foran os og midt iblandt os her i dag.
 Jeg synes, at vi skal hæfte os ved de fremskridt, der er sket.
 I morgen skal du stå din første prøve.
-Forsikringer om, at det altsammen ikke er noget problem, klinger mere og mere hult.
 Sars er desværre kommet for at blive.
 For andre, til gengæld, er det en farce af næsten surrealistiske dimensioner.
 Disse opskrifter har været en total fiasko.
@@ -3072,7 +2704,6 @@ Endvidere er der den nærmende indføring af euroen og informationssamfundets op
 Oplysningen må imidlertid ikke være begrænset til plakatkampagner eller ministres besøg på skoler.
 Nu bliver den dem tildelt uden affyring af et eneste skud.
 Vi er kommet videre, så vi er nødt til at sætte det i datid.
-Det er hævet over enhver tvivl, at denne geschæft er svær.
 Det drejer sig altså om en tiendedel af budgettet.
 Måske skulle det være en turbodieselmotor.
 Botswana er et eksempel på dette.
@@ -3080,14 +2711,12 @@ Jeg tror, at denne kvalitetsgraduering opad ville være meget vigtig for forbrug
 Vi må derfor tage pulsen på ligestillingspolitikken, måle og veje den.
 Jeg håber, at budgetmyndigheden vil være mere behjælpelig og øge tildelingen.
 Denne metode ville være meget mere enkel og givtig.
-Qimonda er ikke blot en hvilken som helst virksomhed!
 Konflikten har ulmet i årevis.
 Er foranstaltningerne for gennemførelse af sviende sanktioner nu på plads?
 Men forbrugernes begejstring for grønne varer mangler stadig at blive matchet af industrien.
 Desuden er fiskeriet meget vigtigt for de tyndtbefolkede kystområder.
 Det er nødvendigt at tage situationen på medlemsstaternes gasmarkeder i betragtning.
 Vi bør se kritisk på den sydkoreanske domstols beslutning.
-Desertecprojektet er særlig betydningsfuldt, fordi det peger mod fremtiden.
 Sikke noget vrøvl, fuldkommen og ren og skær vrøvl!
 Situationen er jo en smule bizar, hvis jeg må udtrykke det sådan.
 For det tredje er tiden ved at rinde ud.
@@ -3098,8 +2727,6 @@ Jeg kommer ikke med en udtalelse vedrørende nulkvoter eller lignende.
 Jeg forkaster den krig og den heraf følgende todeling mellem sejrherrerne og de besejrede.
 Næsten alle chefredaktører blev fyret samtidig.
 Pyongyang søgte længe at benægte denne frygtelige virkelighed.
-Hvilken begrundelse er der for denne ågeragtige stigning?
-Katiforis ganske rigtigt understregede.
 Jeg kunne næsten røre ved smerten, virkelig føle denne kvindes smerte.
 Jordskælvet og tsunamien har skabt utænkelige ødelæggelser.
 Det skyldes dets amfibiske væsen.
@@ -3110,7 +2737,6 @@ Vi ønsker med andre ord at skabe et egentligt marked for clearing og afvikling.
 Der er i forbindelse med udvidelsen allerede sagt meget om tidsplaner, datoer og årstal.
 Den pågældende rapport er i det store og hele deskriptiv.
 Det drejer sig ikke om at kickstarte den økonomiske vækst i den sædvanlige retning.
-Shakespeare, men det tykkes mig, at betænkningen bedyrer for meget.
 Chip er farlige, når børn putter dem i munden.
 Antallet af ulykker til havs er uacceptabelt højt.
 Vi bifalder den robuste måde, hvorpå han har forsvaret balancen i dette direktiv.
@@ -3119,7 +2745,6 @@ Overalt forværres denne vold af opkomsten af ekstremistiske bevægelser.
 Salim for en uges tid siden, da han var på gennemrejse.
 Med klimaændringerne og klodens opvarmning ser fremtiden ikke lysere ud.
 Hver part har spillet sine trumfer.
-Nulemissionsmålet kan ikke være et mål.
 Aftalen viste sig blot at være en lap papir.
 Vi er kommet ind i en ny politisk epoke.
 De fælles strategier bygges op, larvefødderne findes frem og sættes på.
@@ -3128,7 +2753,6 @@ Hvis hendes kat drikker øl, er det nok det, der gør den syg.
 Dernæst viser den økonomiske situation en række lyspunkter.
 Hvem tog civile gidsler for at forhandle med den lokale guvernør?
 Det var floskler fra den socialistiske mølkiste, som overhovedet ikke bringer os videre.
-Eller tag den såkaldte hørsag.
 Nu er vi gudskelov kommet videre.
 Virkeligheden må vige for det liberale dogme, når kapitalens globalisering står på dagsordenen.
 I dag vil mange huske stunder i hendes livlige og altid stimulerende selskab.
@@ -3137,29 +2761,22 @@ Landmændene har brug for såsæd.
 Dette har ligeledes en stor betydning for virksomhedernes genplacering.
 De nuværende bestemmelser om fjernsyn bør fortsat være i kraft vedrørende lineære tjenester.
 Men den foreløbige version af denne beskæftigelsespagt er ærligt talt noget tam.
-Vi er nødt til at satse på træholdig snarere end flydende biobrændstof til transport.
-Indien vil femdoble sin bioteknologisektor i de næste fem år.
 Så ville de seneste ugers opstandelse virkelig kun have været spil for galleriet.
 På den anden side minder det os livagtigt om valg i totalitære stater.
-Ulæseligheden af vores lovtekster er desværre ikke kun de europæiske institutioners problem.
 Jamen, det er i stykker, og det skal repareres.
 Tyrkiet respekterer heller ikke de værdier, som vi anser for umistelige.
 Dræber jeg da ikke allerede?
-Fremover vil der kun være ideologiske skænderier om ufleksible tekster.
 Ligeledes ønsker jeg, at det spanske formandskab får succes og handler med stor kløgt.
 Topmødet er et tidspunkt for nogle drøje sandheder.
 Forbud mod kørsel i weekenden og kødannelser generer vejtransporten.
 Guillotinen eller den elektriske stol er symboler på den moderne tidsalder.
 Vi skal vedtage denne beslutning, som rummer tre noble forhåbninger.
-Det kan ikke gøres ad hoc.
 Efter evne skal denne støtte give den algeriske pressefriheds vågeblus den uundværlige ilt.
-Tsatsos, med den betænkning, de har præsenteret i dag.
 Bekymringerne for ulandene er hul.
 Jeg nævner kun stikordet prydplanter.
 Naturligvis kan vi kun fordømme disse voldshandlinger og dette hærværk.
 Barmhjertighed, når det gælder modtagelse af flygtninge, som er fordrevet fra deres hjemlande.
 Derfor er vores vurdering kritisk, og derfor mener vi, at resultaterne har være magre.
-Santers forslag og den underliggende rationale bag hele forslaget.
 Men for at kunne gøre det skal det korresponderende udvalg rådføre sig tidligere.
 Der er langt fra sko og støvler til mobiltelefoner.
 Det ser ud til, at søkortene er forsvundet.
@@ -3180,9 +2797,7 @@ Klimakrisen, fødevarekrisen og den sociale krise kan stadig mærkes med usvækk
 Det tilbydes generøst og uden beregning, utvungent og uden betingelser.
 Måske viser sådan en reportage, at det er nødvendigt med nogle vedtægter.
 Det, vi diskuterer her, er ikke uvæsentligt.
-Dvs., at de forskellige retsmyndigheder virkelig begynder at arbejde sammen i et tillidsforhold.
 Personer, som døde ensomme og overladt til sig selv.
-Nu er der ikke tid til mere fjumren og forsinkelse.
 De samme piktogrammer anvendes til at vise de samme oplysninger.
 Bogbrændinger hører til dagens orden.
 Jeg synes ærlig talt, at den indflydelsesrige avis er lunefuld.
@@ -3192,24 +2807,15 @@ Baglandet, de mennesker, som sejler, spørger, hvornår vi gør noget konkret.
 Vi må også erkende, at denne betænkning kun er en brik i et puslespil.
 Endelig har jeg også selv modtaget spam.
 I forbindelse med samme operation blev alfonserne anholdt.
-Det første er medlemsstaternes forpligtelse til at udforme nødplaner til brug i foderstofkriser.
-Der er ikke religionsfrihed, der er ikke laicisme efter fransk forbillede.
-Bontempis betænkning om korruption.
 Jeg synes, at det så afgjort er rationelt og bestemt ædelt.
 Udpiningen af fiskebestandene er et miljøproblem, men også et socialt problem.
-Rulletobaks bufferfunktion er afgørende for at undgå en stigning i smugling på europæisk territorium.
 Der er for det første et enormt behov for omskoling af en hel faggruppe.
 Hun må føle det, som om hun netop har modtaget en buket blomster.
 Man kan ikke bede et skelet om at spænde livremmen ind.
 Hovedparten af handelen udgøres imidlertid af pattedyr, som i reglen vejer over et kilo.
-Jeg tænker med glæde tilbage på den vedholdenhed, hun lagde for dagen under trilogerne.
 Det gik lige så godt, så hvorfor spolere det?
-Toulouse har brug for finansiel og logistisk bistand.
-Den aktuelle modus vivendi er efter alt at dømme ikke tilfredsstillende.
-Kalandia, som ligger midt i det palæstinensiske område, er netop blevet omdannet til grænseterminal.
 Der kan man se, hvilket niveau vi er sunket ned på.
 Ved reorganisationer bestemmer aktionærer og chefer, og arbejde er den sidste post.
-Shippingindustrien er den første til at erkende dette.
 Jeg vil understrege, at det er den engelske udgave, der er den autentiske tekst.
 Ganske vist står det tilstræbte mål i spagat, som derfor skal kunnes.
 Skal lærere eller læger tage stoffer, der virker opkvikkende?
@@ -3221,8 +2827,6 @@ Det kommer vi til at gå noget i clinch med i den kommende tid.
 Jeg håber, det er et hypotetisk spørgsmål.
 Ja, interessen for de tre kaukasiske lande er stor.
 Episoderne i forbindelse med betænkningen var alt andet end flatterende.
-Jeg er bestemt ikke klar til at sige adieu.
-Samtidig tager dokumentet ikke tilstrækkelig højde for andre beplantningsmuligheder.
 Vi må sørge for, at de bliver mætte.
 Parlamentet har stået i spidsen på dette område mere end en gang.
 Så det er et hegelsk problem.
@@ -3236,11 +2840,8 @@ Vi er ikke regeringskonferencens hofpoeter.
 Ingen af disse tal giver anledning til jubel.
 Den nyomvendtes nidkærhed, uden tvivl.
 Det er også meget vigtigt at bevare sammenhængen mellem anprisninger og ernæringsprofiler.
-Vi skal ikke først reagere, når man når en grænseværdi eller en sumgrænse.
 Jeg er dog ikke enig i udeladelsen af solmoduler fra direktivet.
 Fru kommissær, det drejer sig om en ubåd.
-Buzek og alle mine andre kolleger.
-Der er også indledt et intensivt penduldiplomati.
 Menneskenes huse er sammen med deres hukommelse eroderet.
 Den omhandler obligatorisk registrering af alle ombordværende på passagerfærger.
 Forslaget gælder kun de tre første år for nyetablerede små og mellemstore virksomheder.
@@ -3252,7 +2853,6 @@ Den skal forbyde uredelige forretningsmetoder.
 Denne gamle lærdom er stadig gyldig.
 Jeg vil gerne takke ordføreren og fremhæve hendes fortrinlige timing.
 Vi skal ikke slynge hinanden alskens ubehageligheder i ansigtet.
-De skal stadig bære den middelalderlige burkha.
 Det er ikke en rar følelse.
 Taler vi om en toårig tidsramme eller en treårig?
 Det bekræftes nu også af forskellige vallonske politikere og fremtrædende økonomer.
@@ -3261,7 +2861,6 @@ Fedme betyder for store fedtdepoter i kroppen.
 Det er ikke godt nok, at vi vrider vores hænder og siger undskyld.
 Juntaen har ganske rigtigt annonceret nyvalg.
 Folk på stedet ved, hvor skoen trykker, og hvordan den kan tilpasses.
-Jeg vil dog erklære, at jeg er imod støtten til selve olivenoliedyrkningen.
 Afghanistans kvinder er blevet frarøvet deres stemme.
 Men mange bække små gør en stor å.
 Med hensyn til kvoter har vi sagt, at der bør indføres lovkrav.
@@ -3275,10 +2874,8 @@ Udviklingspolitik er ikke kun uselviskhed, det er interessepolitik.
 Enhver delforanstaltning vil skabe utilfredshed og uretfærdighed.
 Derfor har jeg stillet et lille ændringsforslag til stk.
 Det er derfor helt afgørende med et internationalt samarbejde for at kontrollere infektionssygdomme.
-Samtidig går der en kokainsmuglerrute gennem landet.
 Der findes ikke noget undskyldning for denne obskøne praksis.
 De er gået bankerot på grund af deres egne stupide ledere og politikere.
-Vi er i dag i færd med at finde massegrave og identificere ligrester.
 Jeg vil endnu en gang takke fr.
 Jeg glæder mig især over, at betænkningen i mange tilfælde irettesætter den irske regering.
 Jeg så gerne, at bestemmelserne går let henover operationelle risici.
@@ -3289,22 +2886,18 @@ Store og små bør i denne forbindelse være i samme båd.
 Her er jeg ved et ømt punkt.
 Der er mange årsager, først og fremmest den bitre nød, manglende oplysning og grunduddannelse.
 Det håber vi at kunne råde bod på med denne betænkning.
-Barcelonaprocessen bør tilføres en frisk drivkraft for at opnå optimal virkning.
 Det gælder ligeledes inert affald.
 Der er behov for handling, ikke for papir og poesi.
 Vi må ikke producere tomme hylstre, det opdager vores borgere jo for øvrigt alligevel.
 Dette formandskab udspiller sig nemlig på baggrund af en omfattende bevægelse, som er tosidet.
 Der er ligeledes blevet vedføjet en særlig protokol herom til traktaten.
-Derfor er et up to date legitimationsbevis en ubetinget nødvendighed, både visuelt og teknologisk.
 Denne subjektivitet relativerer denne rets prætention om at være universel.
 Omtrent en tredjedel blev afvist.
 Hidtil har vi kun hørt bag kulisserne, at man konstant diskuterer den øvre grænse.
 Og virus og bakterier i minimale doser bliver til vaccine.
-Udviklingen af stærkt integrerede spintroniske anordninger er et eksempel herpå.
 Vi har den hjælpeløshed og håbløshed, som vi måske var fælles om.
 Vi mener, det er vigtigt, at kvinder ikke udsættes for vold eller sexhandel.
 Her ødes der mange penge bort, som ikke bliver investeret bæredygtigt.
-Jeg synes, at den santerske rådgivningsgruppe om etik virker lidt dubiøs.
 Jernbaneselskaberne skal også være på dupperne, så de kan konkurrere med lastvognene.
 Den hidtidige lønpolitik har nemlig også forvredet branchen.
 Kraften fra de faldende ståldragere og murbrokker knuste sæderne nedenunder.
@@ -3322,16 +2915,13 @@ Kommissionen sponsorerede en analyse af kulturøkonomien, og vigtige oplysninger
 Det er en altomfattende bestemmelse, som forværrer den humanitære krise.
 De kan måske bruges til at yde kompensation for løntabet.
 Det er som et juletræ, hvor vi har hængt vores ønskeliste over dyre smykker.
-Der er ikke nogen kunstige grænser i luften, og aeromekanikkens love gælder alle vegne.
 Det kan man ikke engang bygge en faldefærdig rønne med.
 Det er imidlertid uvist, om kontrollen overalt er optimal.
 Flyrejser er ikke det samme som busrejser.
 Det er kapitalisme, dit fjols!
 Det er da næppe passende at udvælge blot et fåtal lande.
 Det ville nemlig være fuldstændig forkert og overordentlig uklogt.
-Darfur har været et åbent sår alt for længe.
 Vi må ikke sende irakere tilbage til den sikre pine og undertrykkelse.
-Storøjet tun og gulfinnet tun er truede arter, som indgår i fangsterne.
 Programmet skal i sin nuværende form finjusteres på en række områder.
 Det er på det nærmeste kommunismens sidste bastion i verden.
 Citrusfrugter, frugt og grønsager
@@ -3339,27 +2929,21 @@ Begrebet bæredygtighed behøver ikke hele tiden at blive opfundet på ny.
 De stimulerer, informerer om og henleder et bredt publikums opmærksomhed på teater.
 En anden gang kunne vi måske lade stemningen ebbe ud, inden vi genoptager afstemningen.
 Denne mødedag er viet til menneskerettigheder, og sådan har vi også villet det.
-Fayot, der vil oplyse os i forbindelse med dette vanskelige emne.
 Det afgørende er, at denne mur er en anneksion.
-Napolitanos betænkning og forslag.
 Misbrugen af internettet påkaldte sig ligeledes manges vrede.
 Til det formål er årsrapporten med den højtstående repræsentants udtalelser et godt skridt fremad.
 Vi har det mest solvente indre marked i verden.
 Europa er karakteriseret ved stor territorial mangfoldighed og polycentrisk udvikling.
 Jeg ønsker ikke, at denne uhyggelige og korrupte institution får mere kontrol.
 Vi kan ikke lade økonomisk fremgang være et figenblad for reformfjendtlige regeringer.
-Der er snesevis af rørledinger, der krydser vores have uden nogen problemer.
-Der er både positive og negative sider ved methan.
 I det store hele har kun få lande tyet til handelsprotektionisme.
 Jeg vil være taknemmelig, hvis formanden ikke bruger hammeren, før min tid er gået.
 Det er ikke overraskende, at de mest indædte diskussioner har drejet sig om budgetspørgsmålet.
-Phthalaters akutte giftpåvirkninger er ubetydelig, og de irriterer ikke slimhinder eller huden.
 Det internationale finanssystem er i sandhed amoralsk og umoralsk.
 At beskytte livet er at give håbe for børn, der lider af cystisk fibrose.
 Som en af medunderskriverne glæder jeg mig over, at hovedændringsforslaget er blevet vedtaget.
 Det er vanskelige valg, men de kan ikke opsættes længere.
 At tale om en beskyttelse af forbrugerne her er pure bedrag!
-I de nye retningslinjer blandes det sammen med lavdispersionsmateriale.
 Hele føderationen lader sig trække rundt ved næsen af krigspropaganda.
 Jeg har sagt, at alle, der stiller spørgsmål, er skurken i denne debat.
 Størstedelen af samhandelen med træprodukter er ikke genstand for mistanke om ulovligheder.
@@ -3369,10 +2953,7 @@ Jeg tror ikke, at megatopmøder af denne slags kan fungere fremover.
 Det vil også bidrage til, at der foretages uopfordrede vurderinger.
 Libyen er et land, der kræver en del arbejde.
 Det er den ene anmærkning.
-Chassez le naturel, il revient au galop.
 Vi vil gerne have, at der er sofaer, barer, luksusrestaurant og fjernsyn i togene.
-Det skal også siges, at bushmeat udgør en vigtig proteinkilde.
-Schiedermeier har arbejdet hårdt på for at få en god betænkning ud af det.
 Forbrugerne fik ganske enkelt ikke smæk for skillingen.
 Der er ikke nogen klar definition på europæiske havområder.
 Det betyder, at der raser en klassekrig.
@@ -3386,11 +2967,9 @@ Deraf den bekymrende nedgang i kødforbruget.
 Vi kan ikke bruge denne debat til at mele vores egen nationale politiske kage.
 Jeg kommer selv fra et område med små rejefiskere.
 Der er dog et par problemer tilbage, især for småfiskere og traditionelt fiskeri.
-For mælkeproduktionen har ikke en hane, vi bare kan åbne og lukke for...
 Der findes måske ingen sikre duftstoffer for nogle allergikere.
 De kan da ikke bilde mig ind, at der ikke findes retsgrundlag herfor!
 Medordførerne behandler deres eget område.
-Sumværdien er udtryk for, at der ikke må være pesticider i drikkevand.
 Den første bropille vedrører teknologisk forskning.
 Meget af det nuværende vejnet blev skabt for flere årtier siden.
 På den måde kan vi mindske emissionen af kuldioxid og syreregn.
@@ -3398,41 +2977,28 @@ Der tales om pars barnløshed, som om homoseksuelle par kan være fertile.
 Men kig en gang på manglerne, hullerne i denne nye sociale dagsorden!
 At handle smart vil sige at ramme to fluer med et smæk.
 De vil sleske for ham og være rigtig søde og rare og venlige.
-Harmoniseringen af elnettene indebærer også en harmonisering af elpriserne.
 Vi støtter den gradvise afskaffelse af salget af blyholdig benzin.
 Bilkonceptet startede godt.
-Nokia er et godt eksempel.
 Hele dette arbejde skal foregå i tæt samarbejde med fagudvalgene.
 Vi har for øvrigt agiteret herimod sammen med mange kolleger.
 Alle medlemsstaterne bør være særlig opmærksom på restauranter, cateringvirksomheder og hoteller.
 Unionen må finde instrumenter til at kontrollere eller aftvinge sanktionerne med.
-Kommerciel kommunikation er et ømfindigt område.
 Det ene er bestemt gennemførelsen og anvendelsen af det europæiske semester.
-Watson og alle, der har bidraget til udarbejdelsen af denne betænkning.
 Et andet vigtigt spørgsmål er fosfaterne.
 Derfor passes der på det som en øjesten.
-Men vi kan ikke a priori bare forbyde indførsel af most.
 Denne erklæring genlyder af dette mål, og derfor er den anløben.
-Blak om, at få dette cirkus afbrudt.
-Stubb meget taknemmelig for betænkningen og glæder sig over muligheden for en forhandling.
 Derfor er denne tvedeling bestemt en tvedeling, vi støtter fuldt ud.
-Stockholmprogrammet vil åbne op for nye muligheder.
 De ville faktisk sabotere en del af katalogiseringen og gøre det kompliceret.
-Jeg bifalder, at der i betænkningen tages højde for migrantfamilier og uledsagede mindreårige.
 Kun da vil vi være agtværdige partnere.
 Kommissionen lever i et elfenbenstårn.
 Den japanske regering reagerede på det tidspunkt med en stejl afvisning af disse krav.
-Et af de mest afgørende aspekter ved østpartnerskabet bliver visumfriheden.
 Jo flere penge en fange kunne betale, jo mindre skar kirurgen af øret.
-Folk med multipel sclerose er syge i mange år.
 Især kvinder og børn kommer i klemme, når det drejer sig om arbejdstid.
 Man vil have forbedret proceduren for bilæggelse af stridigheder.
 Uden skovbrug er der ingen træindustri.
-Kun hvis dette er et must, kan andrageren være beskyttet i sin retssikkerhed.
 Der er røde streger på vejen.
 Det er et gammelt tema, men alligevel højaktuelt.
 Ved at skrabe midler sammen på en usystematisk og uorganiseret måde?
-Økofin, finansministrene, har allerede fået kolde fødder.
 To eksempler på dette er hårtørrere i en frisørsalon eller udstyr i et motionscenter.
 Eller er det måske politikerne, der har mistet følingen med almindelige mennesker?
 Sukker kan anvendes til andet end slik.
@@ -3443,8 +3009,6 @@ I kampen for afskaffelsen af dødsstraf skal vi finde et fælles moralsk fodslag
 Virkningerne af forurening og rovdrift på naturressourcer er grænseoverskridende.
 Når man graver ud til fundament til et hus, skader man ormene.
 Molukkerne skal hurtigst muligt hjælpes.
-Bestandene inden for vores sømilegrænser kan også blive berørt af aktiviteter uden for grænserne.
-Det er ikke rigtigt at slå rasicme i hartkorn med såkaldt homofobi og islamofobi.
 Det ligger ganske enkelt i semantikken.
 Det er ikke en eksklusiv klub.
 Stivhed og bureaukrati ligger efter min mening altid på lur.
@@ -3457,50 +3021,37 @@ Så amerikansk politik er israelsk politik, og vi europæere trasker efter vores
 Chirac ved besvarelsen af spørgsmålene også anvendte denne benævnelse.
 Lovgivningen er særligt vigtig for spædbørns sundhed i forbindelse med amning.
 Det er endnu en gang mellemhandlere og de dominerende fødevarekæder, der skummer fløden.
-Better ballots than bullets , som englænderne siger, kunne man høre rundt omkring.
-Alt dette fører også til wildwestpriser, om jeg så må sige.
 Ordføreren og andre talere nævnte spørgsmålet om økomærkning.
 Der er ikke råd til nonchalance.
 På denne måde lader vi ulven vogte fårene.
 De var ikke blandt hooliganerne!
-Jeg kan nævne den svenske sexkøbslov og naturligvis den østrigske lovgivning.
-Hvad angår adgangen til gastransmissionsnet, er målene i den tredje energipakke blevet opnået.
 De bliver ved med at skøjte uden om spørgsmålene om menneskerettigheder og demokrati.
-Buttiglione diskriminerede alenemødre på den måde.
 Endelig er det påkrævet at revidere den internationale havret, der er klart utidssvarende.
-Folgorefaldskærmstropperne.
-Og længe leve ensstemmigheden!
 Den strategi, som den havde lagt, var reelt set farlig og har sået splid.
 Den mand har været min ven i meget lang tid.
 Jeg medgiver, at det er meget, og at tallet måske er arbitrært.
 Måden, hvorpå denne traktat blev markedsført, var sløset, amatøragtig og fuldstændig uintelligent.
 Jeg tror, at der er ved at ske det samme med den bærbare udvikling.
 Ethvert monetært duopol gennemgår regelmæssigt paritetstilpasninger, som ofte sker ganske pludseligt.
-Med den yderligere regulering vedrørende private equity forhindrer vi tømning af porteføljeselskaber.
 Kystområdernes udkomme er ofte afhængig af dette ene erhverv.
 Teknologi til reduktion af kvælstofoxiderne findes også allerede i dag.
 Frygt er i øjeblikket altdominerende i dette land.
 Kommissionen for sit vedkommende affinder sig udmærket med denne situation.
-Vi ved i dag, at gravide, som får zidovudin, sætter raske børn i verden.
 De har ødslet fondene væk, og de har raget arbejdstagernes penge til sig.
-Hory vil tage ordet om lidt.
 Gerningsmændene skal pågribes og stilles for en domstol.
 Dem, der holder af at se god fodbold, får helt sikkert en herlig tid.
 Hvorfor indeholder de ikke en målrettet jobindsats for unge?
 For det niende kræver den fokus på erindring, så ofrene ikke glemmes.
 Medlemmerne skal holde op med at slæbe på fødderne og ratificere konventionen hurtigst muligt.
 Synet er begrænset af et gitter af stof, svarende til et bur.
-At dette skråleri ikke kun lyder i mit land, er ikke særlig beroligende.
 Jeg kan huske, at han lå op ad rattet og angsten i mit bryst.
 Den enkelte og partnerskabsprincippet er blevet efterladt i vejkanten i denne reform.
 I stedet ævler hun løs om solidaritet.
 Den bymæssige dimension må blive obligatorisk.
-Giansily ikke kan være til stede her.
 Naturligvis er ingen af os usårlige over for overtrædelse af bestemmelser.
 Dette er næsten et mirakel, der sommetider tvinger dem til at arbejde mange nætter.
 Der er konkurrence i pipelines, det var der allerede, da monopolerne eksisterede.
 Wales producere fantastisk godt oksekød og skal kunne mærke det som walisisk.
-Den giver i det mindste nogen struktur og retssikkerhed inden for olieog gashandelen.
 Trods alle de fine ord og retorikken står vi tomhændede, hvilket er meget tragisk.
 I generationer er vin blevet modnet i træ, og vinens sundhedsmæssige virkning er uomtvistelig.
 Alle ved, hvad der skete, så det vil jeg ikke dvæle ved.
@@ -3509,15 +3060,12 @@ Vi har bevæget os fremad i snegletempo.
 Slots skal sælges ligeligt også til udenlandske selskaber.
 Virksomheder er ikke længere kun gearet til profit.
 Dette er ikke science fiction, men virkelig nødvendigt.
-Solana nævnte mange af, og traf beslutninger med et klart udsagn.
-Bæredygtig pesticidanvendelse er til gengæld en blåstempling af spreding af gift.
 Lad os altså forsvare ytringsfriheden med næb og kløer.
 I samme ånd støttede jeg den femårige udelukkelse af solpaneler fra direktivet.
 De europæiske myndigheder må afgjort betegnes som recidivister.
 Regionerne, fagforeningerne og avlerne er imod dem.
 Det sker selvfølgelig ikke, hvis ikke der eksisterer en god dagpleje.
 Pastys forklaring, og jeg skal ikke stille spørgsmålstegn ved den.
-I dag foregår der noget lignende mutatis mutandis.
 De er den rette til jobbet.
 Også for at opfordre til, at der indføres strengere krav til campingpladsers placering.
 Den zimbabwiske befolkning lider i forvejen alt for hårdt.
@@ -3527,18 +3075,14 @@ Der findes ingen udødelige diktatorer, men frihedens ånd er tidløs.
 At holde fast ved denne udgave ville være en pyrrhussejr.
 Igen kunne et regionalt samarbejde afbøde virkningerne af sådanne naturkatastrofer.
 Dette bevidner vores menneskerettighedsdialog med alle grene af de israelske myndigheder.
-Aznar, gjorde jeg det objektivt og tydeligt.
-Clarke og det britiske formandskab har i sinde at gøre.
 Vores empati er ikke tilstrækkelig.
 En fildeler får undersøgt sin computer, og alle vedkommendes private oplysninger granskes.
 Skal vi så blot slå os til tåls med dødvandet i fredsprocessen?
 Vi ønsker, at de skal blive til integrerende mørtel.
 Det system, som nu bliver foreslået, er ikke en døjt mindre kompliceret end forgængeren.
 Lækagen af information er yderst beklageligt, men det er jo sket før.
-Hahn, mine damer og herrer!
 Det samme problem gælder standardiseringen af værdier for kystvande og ferskvand.
 De fleste husmødre kender ikke forskel på en kvie og en stud.
-Jeg traf samme beslutning med hensyn til præimplantationsdiagnostik.
 Det samme gælder for hedgefonde.
 Det er forkasteligt, svigefuldt og fejt.
 Stadiet for lapværk og halve foranstaltninger er forbi.
@@ -3547,17 +3091,12 @@ Hvis de var bekendte med det, blev der brugt uvederhæftige argumenter.
 Kvinder er i størst fare inden for deres egne fire vægge.
 Ud over litterære værker vil det omfatte tekniske, juridiske, journalistiske og audiovisuelle værker.
 Det er ligesom med kolesterol, hvor der er en positiv og en negativ markør.
-Kigalierklæringen var særlig tung og afgørende.
-Beslutningen dækker midler til nødarbejde i en tremåneders periode.
 Naturkatastrofer indtræffer stedse hyppigere i kølvandet på klimaændringerne.
 Son nævnt er det blevet drøftet ved adskillige lejligheder.
-Det blev foreslået for lande, som har et currency board.
 Jeg tænker på bymiljøet, boliger og socialt boligbyggeri.
 Ordførerens redigering har altså, efter vores mening, været for afgrænsende.
-Vi må undgå den fejltagelse at gøre tænkepausen til en inaktivitetspause.
 Jeg var ved stranden, og jeg blev brun.
 Der er stadig to timer til midnat nu, men vi opbygger fremtiden.
-Rapkays betænkning er vedtaget.
 Det er, som om vi befinder os i en labyrint.
 Kommissionens forslag om reformer af vinsektoren er et skridt i den rigtige retning.
 De havde en meget vanskelig rolle, men udviste dygtighed og udholdenhed.
@@ -3565,43 +3104,30 @@ Også i denne sammenhæng gælder det, at man må krybe, før man kan gå.
 På denne måde vil vi kunne reducere den administrative segmentering.
 Dykke ned i fleksibilitetsinstrumentet?
 Nåletræerne er betydeligt blødere end løvtræerne, hvilket gør deres støv mindre risikabel.
-Bahai, fagforeningsfolk og kvinder trues af fundamentalisterne.
 Her skal der foretages et radikalt snit.
-Det drejer sig om tørret frugt, kornflager, kylling, indmad, æggehvide og gummi arabicum.
 Vi må i øvrigt sørge for, at oplysningerne er læsbare.
 Sammenklistret kød og tilsætningsstoffer må ikke sælges som bøffer ved disken.
 Reformen er bygget op om tre akser.
-Lewandowski, mine damer og herrer!
 Dette er et citat fra selve teksten.
 Min tjenestegren er ved at undersøge de to andre forsikringsselskabers krak.
-Tindemans betænkning giver anledning til at reflektere over dette.
-Maastrichttraktaten var også en beskeden optakt til den politiske union.
-Turmes var for eller imod afstemningen om uopsættelighed.
 Jeg forstår, at disse politiske argumenter fyger gennem luften.
 Det er derfor, jeg er sur.
-Superior stabat lupus longeque inferior agnus.
-Drab på syge børn med en overdosis af sedativer er en ubeskriveligt barbarisk handling.
 Skægt nok kunne jeg have forudset det uden noget besvær overhovedet.
 Det er ikke småreformer, men virkelige reformer, der er brug for.
-Sainjon virkelig et sådant koncept, hvor myndighederne kan ændre samfundet, for at være realistisk?
 Parlamentet lavede al fodarbejdet, og det udarbejdede alle kompromisforslagene.
 Vi kom ud i uføre, fordi vi ikke fokuserede på problemerne.
 Der manglede kun een stemme.
 Grækenland er forpligtet til at klø på med omfattende strukturreformer og privatiseringer.
 Kendsgerningen er, at den samlede globale ismasse stort set er konstant.
 Her må der findes en ny approach.
-Ottowakonventionens forbud mod dem er en sejr for menneskeligheden.
 Det vil samtidig betyde bedre sundhed for børn og færre problemer under opvæksten.
 Vi hører ikke længere lyden af klokker eller gøende hunde.
 At redde menneskeliv må altid komme før doktriner om intellektuel ejendomsret.
 Således kan overlapninger eller afvigende strategier undgås, og et optimalt rendement kan opnås.
-Dette direktiv er absolut nødvendigt, især for de store vejinfrastrukturprojekter.
 Jeg siger, at de ikke bare kan verfes væk med en let håndbevægelse.
-Vi har stillet forslag om rettigheder og pligter for herboende tredjelandsborgere.
 Det er dokumenteret, at andre elementer i solsystemet ligesom jorden er blevet varmere.
 Markederne for telekommunikation, post, el og togtrafik samt landbrugsmarkederne blev liberaliseret.
 Det er ganske givet nødvendigt at styrke europæiske samproduktioner.
-Hvor er det stærke engagement med hensyn til at fjerne skattelyer og offshorefinanscentre?
 Og nu må jeg tage en dyb indånding!
 Folk uden humor kunne endda opfatte det som en fornærmelse.
 Flisebelægninger på åbne områder blev synligt misfarvet af en rustfarvet substans.
@@ -3609,28 +3135,21 @@ Derefter var der endnu alvorligere problemer som følge af uroen på tilhørerpl
 Jeg mener ikke, det er plausibelt at tale om udryddelse af det tibetanske sprog.
 Jeg vil begrænse mig til spørgsmålene om frø og handel med frø.
 Dentalt kviksølv infiltrerer også atmosfæren under kommunal affaldsforbrænding.
-Schlyter for deres støtte.
 Også her gælder det om at sørge for, at disse to aktiviteter bliver synkroniseret.
 De holder den gående med narkotikahandel, tyverier og småkriminalitet.
 Kommissionen forsøger på sin vanlige facon at standardisere i stedet for at harmonisere.
 De betalte pengene tilbage, og det er sådan, klaveret spiller.
 Vi kan ikke være som de frøer, der krævede en konge.
-Bertens til lykke med hans betænkning.
-I første omgang skal data om højvolumenkemikalier indsamles og analyseres.
 Den, der fusker, mister kunder.
 Det hører egentlig til den sædvanlige forretning, og beløbet burde ikke slå os omkuld.
 Den aktuelle israelske politik er grotesk og virker mod hensigten.
 Kommissionen anmoder om, at de reducerer deres fiskeri, deres tonnage og deres fangster.
 Vi skal i ro og mag opveje plusserne og minusserne.
-Rådet lænker sig selv med enstemmighedsproceduren.
-Endvidere vil elmarkedet ikke fungere ordentligt, hvis gasmarkedet ikke fungerer ordentligt.
 Der er beretninger om, at der finder totur sted.
 Denne atavisme må overvindes hurtigst muligt.
 Dertil passer samtidig et uegennyttigt og mere afbalanceret udvalg af de regionale bistandsprojekter.
 Lad os tage tyren ved hornene i forbindelse med det, borgerne ønsker.
 Også det må vi kritisk tage på vores egen kappe.
-California is turning dramatically left.
-Nassauer, har fremsat nogle gode forslag, som vi hilser velkomne.
 Vi ved alle, hvad denne holdning i sidste ende betød for økonomierne i østblokken.
 Vi har klynket i årevis, da det eneste valg stod imellem diktaturer eller teokratier.
 Det postkommunistiske regime er blevet uudholdeligt.
@@ -3639,23 +3158,18 @@ Tyrkiet har i snart to år befundet sig i en yderst kompliceret politisk situati
 Men de småpenge, de får, kan måske lette deres trængsler.
 Disse dyr lever under skrækkelige forhold, og mange bliver flået levende.
 De franske lastbilchaufførers vejblokade
-Troende, præster, munke og høje gejstlige honeratiores chikaneres, forfølges og spærres inde.
 I praksis opmuntrer de en hæmningsløs sort økonomi.
 Dette er et sensitivt stadium i børns intellektuelle, fysiske og kognitive samt sproglige udvikling.
 Desværre er det kun amerikanske westernfilm, der ender lykkeligt.
 Tilladelser til dybvandsboringer skal kontrolleres nøje.
 Kommissionen har begået en stor fadæse her.
 Jeg ønsker ikke at give dem et urigtigt tal.
-Det skal tages med i overvejelserne om den gavnlige effekt af anvendt ikt.
 Vi kan her se deres tørst efter magt.
-Libicki, dette er et fundamentalt spørgsmål om menneskerettigheder og grundlæggende rettigheder.
 Hvordan genopretter man husfreden?
 Åbenhed er ærlige magthaveres bedste redskab til at værge sig mod egne venners pression.
 Hvad har de nye medlemsstater fundet i deres fagre nye verden?
 I den foreliggende betænkning behandler man nogle af problemerne, omend noget ensidigt.
 Jeg mener, at dette vil afsløre mange af de vigtigste patogene stoffer i cigaretter.
-Transmissible spongiforme encephalopatier
-Lukasjenko bør heller ikke kaldes for præsident her i salen.
 Det er lykkedes ham at give sobert udtryk for udvalgets holdning.
 Europol må ikke blot blive et bureaukratisk departement.
 Det er en præcisering, som har oplivet vores aften.
@@ -3668,27 +3182,21 @@ En sådan hotline bør i grunden være et permanent tilbud.
 Læs dog venligst først teksterne!
 For købmanden betyder det merudgifter og besvær, men det er til gavn for forbrugeren.
 Det er en retlig ramme, der ikke slides op af denne type afgiftsmæssige foranstaltninger.
-Jeg er også klar over, at der er problemer i bærsektoren.
 Den aktuelle krise er så dramatisk, at den retfærdiggør en sådan utraditionel indsats.
 Det, der skulle have ført til en grænseoverskridende egnsudvikling kom aldrig.
 Vi skal stille strenge krav til dæmningers sikkerhed og bæreevne.
-Det optræder ihvertfald i den skriftlige betænkning.
 Selv det vand, der indvindes fra slammet, renses for rester af cyanid.
-Det ville også være en hån mod den vestsaharanske befolknings legitime frihedskamp.
-I den nye aftale var der fastsat krav om peer review.
 Vinbøndernes interesser er indlysende, men det er folkesundhedens i lige høj grad.
 Ve os, hvis vi ikke gør dette!
 Denne udtalelse er ikke fremsat i lyset af verdensmesterskabet i ishockey.
 Jeg vil gerne fremhæve to ting, først definitionen af vodka.
 Vi må skære tingene ud i pap på en åben og tolerant måde.
-Clamydia fører i hvert tredje tilfælde til ufrugtbarhed.
 Der er ikke nok rastepladser for chauffører, der er ikke nok incitamenter til uddannelse.
 Det afvises, mens disse fester, hvor vi fremstår som ådselgribbe, tillades uden videre.
 Vi bør sørge for, at der ikke bliver leveret flere alibier.
 Hvor håner og hænger man en dukke, der skal forestille den økumeniske patriark?
 Hvis vi ønsker regionale økonomiske cyklusser, skal vi fokusere på kvalitet og ikke bøjningsgrader.
 Jeg ser imidlertid ingen grund til at boykotte ceremonien eller legene på dette grundlag.
-Der er desuden andre farvestoffer end azofarvestofferne.
 Derfor bør der tilskyndes til åbne debatter på weblogs.
 Vores bidrag i dag er baserede på to fuldførte regnskabsår i en syvårig periode.
 Vi skal undgå at blæse, mens vi har mel i munden.
@@ -3698,15 +3206,10 @@ Der er også snak om letvægtere og sværvægtere.
 Indre erosion og ørkendannelse skyldes brugen af vores land.
 Disse foranstaltninger har båret frugt.
 Der er tusinder af tons til rådighed nu, og vi øger lagrene.
-Hvordan ser situationen ud med hensyn til det europæiske lokomotivførercertifikat?
 At subsidiere nationale aktioner er i virkeligheden intet andet end at pumpe penge rundt.
-En national alenegang i forbindelse med billetafgifter og kerosinskatter er ikke formålstjenlig.
-Der bibringes nyttige præcisioner, og endelig lægges der særlig vægt på de små operatører.
 Denne manøvre forekommer os at være yderst dadelværdig set fra et juridisk synspunkt.
-En trejdedel af den algeriske befolkning er berbisk.
 Det har været en lang drægtighedsperiode.
 De kendte fordele ved at spise en portion fed fisk opvejer alle mulige risici.
-Dette folkemord havde karakter af genocidum atrox, brutalt mord, begået med ekstrem grusomhed.
 Han har afsonet sin straf og bør nu være fri.
 Svarene på disse spørgsmål er stadig meget svævende, endog slørede.
 Bahrain indtager en nøgleposition og formodentlig nøglepositionen i hele regionen.
@@ -3714,69 +3217,48 @@ Ingen blev ladt uberørt af dette valg.
 Vi mangler stadig et kæmpestort stykke arbejde, hvis vi skal opfylde målene for pasningstilbud.
 Jeg vil kort ridse op, hvad det drejer sig om.
 I øvrigt har flere talere fra samtlige fløje takket ham.
-Pujol og de andre ministerpræsidenter.
 Objektiv, fordi den er baseret på uanfægtelige beløbsopgørelser.
 Det gjorde det ikke, med mindre der henvises til æraen for ren skamløshed.
 Kallas, mine damer og herrer!
 Vi bør støtte bestræbelserne på at gøre bøger søgbare, læsbare og overførbare.
 Screeningsprogrammer ved hjælp af mammografi bør være obligatoriske i alle medlemsstater.
 Hvad det angår, begynder vi ikke på nulpunktet!
-Det er, som jeg før har sagt, den moderne version af tantaluskvalerne.
 Først og fremmest vil jeg takke vor kollega for hendes arbejde og ildhu.
-You have done some excellent work.
 Det kræver en større grad af integration og sammenkædning af energimarkedets delmarkeder.
-Vecchi får min fulde tilslutning.
 Kommissionen påtog sig dernæst hele processen internt.
 De havde helt sikkert ikke til hensigt at begå harakiri.
 Injurier er en lovovertrædelse.
 Bursenge og lignende hører ikke ingen steder hjemme i den moderne psykiatri.
 Jerusalem er en by, som appellerer til verdenssamfundet.
-Oliepriser og valutakurser er kommet på en veritabel rutsjebanetur.
 Hvordan håndhæves disse rettigheder blandt singaleserne i den nordøstlige del af øen?
 Indførelsen af elbiler på markedet kan give den europæiske industri konkurrencefordele.
 De vil ikke tolerere nogen form for tøven eller bare tegn på ufrivillig magtesløshed.
 Vi har flere fattige husstande end vi nogensinde før har haft.
-Politik er dog altid et spørgsmål om bricolage.
 Jeg har netop fået at vide, at der er en stavefejl.
-Sidst, men ikke mindst hylder jeg modet hos det østtimoresiske folk.
 Bølgerne er gået højt, og der kar været beskyldninger om åbenlys partiskhed.
-Det er blevet foreslået, at vi afskaffer tofaseforhandlingerne.
-Gaddafi afviser demokratiet til fordel for streng overholdelse af sharialovgivningen.
 Der er nok, som allerede er sivet bort.
-Teenagere er typisk korttidsansatte, deltidsansatte, uuddannede og uinformerede arbejdstagere.
 Dyrets slagtning bogføres som reduktion af mælkeproduktionen, og der inkasseres igen for dette.
 Det vil være et af omdrejningspunkterne for min indsats.
 Pludselig bliver døren rykket op, og hendes mand, børnenes far, står i døråbningen.
 Derfor må folket gå modstandens, ulydighedens og opsætsighedens vej.
 Man skal ikke af ovenstående udlede, at vores holdning er ubetinget ukritisk.
 Der er da nu sat lidt kulør på debatten.
-Tomlinson, som jeg lykønsker med arbejdet.
-Der er behov for yderligere forskning inden for føtalt alkoholsyndrom.
 Endvidere blev disse kulturers forskellighed og identitet negeret.
 Pengene skal investeres i virksomheder, der garanterer, at nyuddannede kan finde arbejde.
-Verden fortjener mere end testosteron på den ene side og hånlighed på den anden.
-På længere sigt kan dette sågar medføre præmatur ældning af lungerne.
-Forskellige gasrørledninger, havvindmølleparker og kraftværker i dusinvis er på tegnebrættet.
 Rådet har traditionelt haft to kasketter på, både den udøvende og den lovgivende.
 Mitchell allerede har været inde på.
 Som læge er jeg fuldt ud klar over de skadelige virkninger ved ludomani.
 Sarajevo kigger frem mod sin europæiske fremtid med stor entusiasme.
-Disse vacciner kan medføre uønsket cirkulation af vaccinevirusset hos uvaccinerede dyr.
-Coveney ikke vover at nævne ordet i sin betænkning, vidner herom.
 Jeg vil bede kommissæren om at tage imod denne lejlighed med kyshånd.
 At medlemmer af et erhverv fastsætter fælles salærer strider principielt mod konkurrencereglen.
 Når markedets usynlige hånd fungerer, virker dette tilnærmelsesvist.
 De afgivne tilsagn må absolut honoreres på mødet i september.
-Vi ved alle sammen, hvad der er sket med de korte hørfibre.
 I øjeblikket er denne fabrik lagt i mølpose, og de ansatte er på ventepenge.
 Det er det, vi kalder en palimpsest.
 Det er atomlobbyen, der på lumsk vis sniger sig gennem bagdøren.
 Hvad sker der, hvis hjorte, vildsvin og geder smittes?
 Hvad er den langsigtede vision for vores rumpolitik, og hvad er formålet med den?
 En atomulykke er ikke det samme som en togulykke.
-Durban var ligeledes lejligheden til at se vores fælles fortid i øjnene.
-Katyn, der viste, at man kan befri og ødelægge samtidig.
-Smeartesten har bevist sin værdi for så vidt angår livmoderhalskræft.
 Det er ikke døgnfluer, som skaber overskrifter i en dag og så forsvinder.
 Resultatet er de grimme arbejdsløshedstal, vi ser for universitetskandidater.
 Mit sidste punkt er offentlig licitation og offentlige indkøb.
@@ -3792,7 +3274,6 @@ Allierede, men ikke afrettede, som vi sagde.
 I alt for mange medlemsstater er pensionssystemer grundlæggende pyramidesystemer.
 I virkeligheden er der således kun tale om en brøkdel af det oprindelige beløb.
 Dernæst en hysterisk besættelse af den menneskeskabte globale opvarmning.
-Det inkluderer gnubbesyge.
 Hvis der ses sådanne pletter, kontrolleres de pågældende passagerer separat på stedet.
 Trods denne positive emotionelle holdning skal vi imidlertid også være åbne og ærlige.
 Alle bør have en barndom fyldt med leg, glæde, håb og lykke.
@@ -3805,25 +3286,18 @@ Vi ønsker ikke, at de også skal inspicere fedesvin og kalve.
 Europæiske partier, lad os prøve ikke at holde hinanden for nar!
 Man forbyder det, og så vasker man sine hænder.
 Hvad angår indvandring, er signalet fuldstændigt under lavmålet.
-Sundhed har noget at gøre med life science, med bioteknologi.
 Kort sagt er disse biler for lydløse i bymiljøer.
 Det etiske digebrud må forhindres.
 I det nye gasdirektiv tillægges gasmyndighederne og agenturet stor betydning.
-Tudjmans reaktion synes at tyde på en tilbagevenden mod de kommunistiske tider.
 Et andet aspekt, som jeg gerne vil have med i debatten, er dyrplageri.
 Den første var rationalisering af informationspolitikken, agenturerne og nomenklaturen.
-Jeg nævte tidligere samhørighedsbetænkningen.
-Jeg savner en hurtig udfasning af pvc og phtalater i direktivet.
 Jernet skal smedes, mens det er varmt, sammen med den nye regering.
-Needles forslag til beslutning.
 Med den blev åbningen af markederne for godstransport en realitet pr.
 Garnene blev indført i handlen, som så senere blev udvidet.
 Nu kommer turen så til ris.
 Tillad mig her at iføre mig min institutionskasket.
-Slovakiet ligger, som det har redt, efter at et ekstremistparti er kommet til magten.
 I en uge er der ikke sket nogen lovændringer eller ændringer i valgkommissionens sammensætning.
 Decharge, ledsaget af en række bønfaldelser, er ikke et sådant magtmiddel.
-En detalje kan være harmløs, men den kan ogå være betydningsfuld.
 Disse mennesker bør ikke betale prisen for, at andre har ødelagt moserne.
 Det pågældende anlæg leverede glukosesirup eller melasse til hollandske foderproducenter.
 Vi har udvist lederskab og løst den gordiske knude.
@@ -3844,57 +3318,36 @@ Lavspændingsdirektivet og maskindirektivet dækker allerede mange spørgsmål i
 Brugen af antibiotika er bestemt en torn i øjet på både dyr og mennesker.
 Den lille røde bog fik tilsyneladende kolossal betydning, enorm betydning.
 Til trods for kritikpunkterne er den generelle retning fornuftig og målsætningerne ædle.
-For os er der to primære målsætninger for denne euopæiske politik for søhavne.
 Når dens opgave er afsluttet, visner den stille bort.
 Jeg samler alle de nødvendige bidder af informationer.
 Med et forslidt udtryk vil jeg sige, at spejdertroppens moral er bedre nu.
 For det andet ønsker vi at understrege, at omplacering ikke er noget entydigt fænomen.
 Den irakiske soldat havde brækket hver eneste knogle i mandens krop.
-Pack, og vi skal sørge for, at det bliver rettet.
 Tingene er gået gruelig, gruelig galt.
-Der mangler gode årsevalueringsrapporter.
-Novo om at indgive skriftlige bemærkninger om dette spørgsmål.
 Denne strygning kan jeg ikke tilslutte mig.
-Mearbejderrepræsentanterne skal have tid til at komme med en udtalelse, inden beslutningen træffes.
 Det er den bedste og sikreste måde til at kontrollere et visums ægthed.
 Jeg nævner ingen navne for at undgå røde kinder.
 Tidligere har den ikke gjort sig den ulejlighed at søge denne støtte.
 Papirøkonomi er bobleøkonomi.
-Der findes velmenende forslag om at tage hensyn til særgrupper.
 Efter det smittede benmel vil man en dag se flyene falde ned.
 Præstation og ansvar er fremmedord for dem, slendrian hører til dagens orden.
 Burtone, for hans indsats.
-Fourniretsagen er et sørgeligt og smerteligt eksempel herpå.
-Den skotske selvstyreregerings støtte til mellemlange uddannelser på gælisk bør også roses.
 Det er jo en imponerende clairvoyance, som lover godt for projekterne.
-Ahmadinejad endnu ikke er faldet.
-Jeg tænker her på bilolieprogrammet og nu revurderingen af det femte miljøhandlingsprogram.
-Derimod vil vi blive fattigere ved at vælge etsprogethed.
-Sellafield er det mest berømte.
-Reuls betænkning indeholder de redskaber, som er nødvendige for at løse problemet.
 Hurtig kunstig opdrætning af kyllinger og kalkuner skal ophøre.
 Sådanne konflikter kan ikke løses med militære metoder eller med kugler og krudt.
 Man røber meget mindre, hvad der foregår i nabolandet.
 Jeg er fortaler for miljørigtige elpærer, men det er slet ikke nok.
-Jeg er selv tilhænger af atlantismen.
 Vi ønsker på ingen måde et nyt skisma mellem vest og øst.
 De er interesserede i det politiske outputs kvalitet og produktivitet.
 Vi måler, om vi rent faktisk har emitteret færre drivhusgasser eller ej.
 Der kan så komme to eller tre yderligere, så det bliver tolv eller tretten.
-Og lad os nu tale om safe harbor.
-Her skal især sperlingefiskeriet nævnes.
 Og den algierske befolkning vil være enig i dette.
 Men der var en tid, hvor løven og lammet faktisk levede sammen.
-I stedet blev princippet om positive comity , det vil sige positiv høflighed, indført.
 Mudderet oversvømmede med sit yderst giftige kemikalieindhold de omliggende marker og landsbyer.
 Den europæiske landbrugspolitik sluger som sagt halvdelen af vores budget.
 Men jeg blev bearbejdet ret intensivt af almindelige udøvende kunstnere.
-Men dette faux pas er gået igennem med flertal.
-Han kaldte det the gap of ambition.
 Vi ønsker ikke at give vores sovende kæmpe et gok i nødden.
 Deri findes derfor årsagen til den gennemsnitligt meget lave hastighed i myldretiderne.
-Wurtz, endelig at bryde den onde cirkel med frygt, vold og had.
-Jeg er også glad for muligheden for dyb geologisk deponering og reversibilitetsprincippet.
 Jeg tror ikke, at den europæiske rumsektor lider under øgede kompetencer, tværtimod.
 De irakiske familier er ved at have tømt fødevarelagrene.
 Alligevel er beslutningen stadig kendetegnet af at ville dirigere.
@@ -3924,15 +3377,11 @@ Jeg er bange for, at juryen voterer i øjeblikket.
 Så længe kravene til vejgreb ikke bliver overholdt, kan disse tre ændringsforslag ikke accepteres.
 København er vores store mulighed for at undgå en katastrofe, sådan som fageksperterne siger.
 Her er forvaltningen derimod vokset i flere lag uden at rette blikket mod fremtiden.
-Et af disse spørgsmål var det østlige partnerskab og alternative gasforsyningsruter.
 Dakar giver en mulighed for at nå mål, som der er international enighed om.
-Det er det socialistiske policy mix.
-De i sommer sete blåalgeblomstringer kommer ikke til at være et enestående fænomen.
 Bekæmpelse af fattigdom har været et af udviklingspolitikkens vigtigste mål i umindelige tider.
 Indtil videre har vi kun en svag gisning om, hvad det kan indebære.
 Med hensyn til spørgsmålet om rygsøjlen skal rygmarven naturligvis fjernes og destrueres.
 Det er særligt tilfældet for medhjælpende hustruer i private erhverv.
-Til sidst vil jeg absolut lige nævne diskussionen om bromerede flammehæmmere.
 Hundredtusindvis blev fordrevet eller flygtede fra optøjerne.
 Det lettede vejen for narkotikahandel, hæleri og menneskehandel.
 Derfor kan cifrene ikke blive helt nøjagtige.
@@ -3947,34 +3396,24 @@ Der er behov for risikovillig kapital for at skabe nye arbejdspladser i nystarte
 Vi ønsker ikke, på grund af nostalgi, at skrue tiden tilbage.
 Østrig har i øvrigt de skrappeste bestemmelser mod nynazisme og dens genopståen.
 Mauretanien skal også ratificere de relevante internationale fiskeriinstrumenter.
-Samarbejdspolitikken burde sætte gang i nogle samudviklingspolitikker.
 Vi er en mærkværdig, inhuman og umoralsk generation.
 Sexchikane er et ubehageligt fænomen.
 Dengang blev det foreslået at oprette en fælles markedsordning for ethanol alene.
 Alle de talere, der har talt dunder mod forskelsbehandling, har talt om princippet.
 Man må huske på, at informationskundskab er et redskab, ikke en numerisk værdi.
-Seeber for hans prisværdige behandling af dette direktiv.
 Derfor indtager millioner af europæiske borgere hver dag piller, tabletter og ampuller.
 Forenklingen af webmiljøet vil få flere til at stemme ved valget.
-Desværre forbliver vi for meget i det gamle mønster med paying but not playing.
-Det fastslås også i den ovennævnte ramme, at enhver eksisterende driftsstøtte skal aftrapppes.
 Alt for mange både, der tager alt for få fisk, bliver der råbt.
 For det tredje har vi brug for en nødbremse for videregivelsen af atomvåben.
 Dernæst udstedes et europæisk betalingspåbud, såfremt debitor ikke klager.
-Bourbon og gin behandles ikke på samme måde som whisky og cognac.
-Med hensyn til thoriumreaktorer er thorium et ikkefissilt materiale.
-Jeg har haft lejlighed til at besøge azeriske fængsler.
-På fællesskabsplan skal man kunne tage højde for medlemsstaternes klimatiske særforhold.
 Hvilken hær kan iføre sig blå hjelme og gå ud og beskytte irakerne?
 I disse og lignende tilfælde har småsparere og almindelige skatteydere tabt penge.
-Jeg vil gerne først komme ind på det omstridte spørgsmål i forbindelse med kimcellemanipulering.
 For vi må ikke stikke os selv blår i øjnene.
 Det drejer sig om steriliseret sødmælk, der kun kan tilbydes i flasker af glas.
 Vi bliver nødt til at tage skeen i den anden hånd.
 Hvis de befandt sig på kasernerne, ville tingene uden tvivl se anderledes ud.
 Det er en tidkrævende proces.
 Det er alt sammen noget, der skaber et molboagtigt bureaukrati, som skræmmer erhvervslivet væk.
-Beysen og andre sagde om vigtigheden af praktisk samarbejde.
 Mennesker behandles som skidt på togstationerne og af luftfartsselskaberne og lufthavnsmyndighederne.
 Uden at bagatellisere kogalskab efterlyser jeg sans for proportioner.
 Davies om netop at slette denne henvisning til denne spanske plan.
@@ -3982,27 +3421,18 @@ Regnskabsvæsen er et teknisk og endog esoterisk spørgsmål.
 En skærpende omstændighed var, at moderen brugte en kobberkedel til at koge vandet i.
 For titusinde år siden boede vi i huler.
 Som eksempel kan nævnes en pub i min valgkreds, som havde frokostretter på menuen.
-Hume, for jeg kan ikke gøre forskelsbehandling mellem de politiske grupper.
 Det er et eksotisk rejsemål for europæere med dets ry som silkevejen.
-Dens uafhængighed er knæsat i traktaten.
-Til trods for alle de sortseende ånder er alle økonomiske spåmænd optimistiske.
 Kommissionen har ikke været uvirksom hidtil.
 I årevis har man tudet os ørerne fulde om, at vi skal liberalisere økonomien.
 De siger det under deres medborgeres hånlatter, sarkasme og undertiden trusler.
 Det er nærmest hinsides vores kontrol.
-Derfor er vores bekymringer koncentreret om emissioner af tungmetaller, dioxiner og furaner.
 Faktisk er det spørgsmålet om tronfølgen, der stilles spørgsmålstegn ved.
-Coreper sagde, at man gik ind for at underskrive resultatet af forhandlingerne.
 Det var ikke vanskeligt at forestille sig oprør og lynchstemning.
 Jeg vil gerne give udtryk for min dybfølte taknemmelighed i denne sammenhæng.
 Det væsentlige er ikke æsken, men æskens indhold.
-Auschwitz, den forfærdende , der viste det værste, mennesket er i stand til.
 Vi er som en lus mellem to negle.
 Medlemsstaterne må afslutte nyopmålingen af deres flåder så hurtigt som muligt.
-Det er et beviseligt empirisk faktum.
-Det er et aleksandrinerversemål med en cæsur.
 Distributionen finder sted gennem ledninger under de offentlige veje.
-Galeotes tre minutter oven i min taletid.
 De har vist betrådt nye stier.
 I de fleste tilfælde forårsages skaderne ikke af nikotin, men af disse tilsætningsstoffer.
 Devisen må være, at vi skal gå i gang.
@@ -4016,32 +3446,22 @@ Den foreliggende betænkning er en etårsstatus.
 Den anden kæbe er lønmodtagernes andel i den produktive formue.
 Spørgsmålene handler om krumme agurker, snus og andre dagligdags ting.
 Vores kultur er nødt til at tilskynde mændene til at tage deres tørn.
-In vino veritas plejede de gamle romere at sige.
 Sikke noget værre rod, du har fået os viklet ind i.
 Mange spottede ham eller lo ad ham på grund af det, han sagde.
 Den var vores stolthed, vores klenodie, vores pligt.
 Dette indtryk forstærkes af de forslag, som præsenteres for at forhindre omlokaliseringer.
 Mest af alt vil det være semidemokratisk sminke til en udemokratisk institution.
-Vi taler ikke om sproglig mangfoldighed, men derimod om lesser used languages.
 Politikerne kan ikke blive mere inaktive, end de er nu, også efter hans exit.
 Jeg forstår logikken i at foreslå et forbud mod brug af palmeolie.
-Der er efter min mening ingen alternativer til afskaffelsen af ruginterventionen.
-Initiativer som move europe om virksomhedernes sundhedspolitik er naturligvis positive.
 Piratkopierede solbriller kan forvolde skade på bærerens syn.
-Teksten bør være klar, og bør ikke kompliceres af ændringsforslag i elvte time.
 Narkotika kommer ind til lands, ad søvejen og ad luftvejen.
-Vi taler om varig tab af hørelse og tinitus.
 Kopterne ændrer sig ligesom andre borgere.
-Atalanta er en kortvarig foranstaltning for at dæmpe pirateriet.
 De folkevalgte er blevet erstattet af gesandter fra paladset.
 Lægemidlerne koster ofte mere end de derboende menneskers årsindtægt.
 Som afslutning på dette tema vil jeg gerne åbne en kort parentes.
 Jeg mener, de er misinformerede, fordi man aldrig handler mod bedre vidende.
-Det, at atombrændstoftransportbeholdere sveder, indebærer faktisk en risiko for mennesker.
 Vi vil gerne takke ham for det præcise arbejde med et meget komplekst lovstof.
-Hunterston ligger i min valgkreds.
 Næsten hver dag lander bådfulde af ulovlige indvandrere på vores kyster.
-Syvpunktsplanen er heller ikke noget rapseri af fødevarer fra de europæiske landmænd.
 Findes en ko at være smittet, nedslagtes hele besætningen.
 Vi stod ikke klar med en handlingsplan oppe i ærmet.
 Hans revisorer siger, at regnskabet ikke giver et retvisende billede af hans partis aktiviteter.
@@ -4054,8 +3474,6 @@ Hos de mangeårige medlemmer dæmrer det formodentligt.
 Rådet bryster sig, fordi det er så god til at håndtere høvlen.
 Der hersker åbenbart et vist virvar de to herrer imellem.
 Vi skal oplyse dem om, at arrogance er malplaceret her.
-Der udbetales ikke kompensation i forbindelse med force majeure.
-Mavrommatis med denne betænkning.
 Skrøbelig på grund af dens store modløshed.
 Det samlede økologisk følsomme alpeområde har brug for vores støtte i henhold til alpekonventionen.
 Vi har brug for et sådant initiativ i de seks amtsområder.
@@ -4071,41 +3489,29 @@ Formuleringen i politik kan være oprørsk, opflammende eller forsonende.
 Der er alvorlige bekymringer over uidentificeret kvæg på slagterier.
 Hvordan kan bosserne i virksomhedernes bestyrelseslokaler dog holde sig selv ud?
 Det dualistiske samfund vinder frem, og det skaber udstødte og umennesker.
-Det frådsede vi også godt og grundigt i her denne uge.
 Den betænkning, som jeg har æren af at fremlægge, resumerer disse møder.
 Men der mangler konsekvens, når de samme personer begræder konsekvenserne af deres hidsige ideologi.
 Ved månedens udgang blev det palæstinensiske valg afholdt, og resultatet gav anledning til tumult.
-Dens holdning støttes af indflydelsesrige kirkelige repræsentanter og høvdingernes storråd.
-Produktionsomkostningerne for lange hørfibre er højere end for korte hørfibre og hamp.
-Formanden har givet mig toogethalvt minut, dem vil jeg gerne udnytte.
 Vi har brug for disse instrumenter i en mosaik.
 Lad fiskernes opmænd, de faglige organisationer, tage sig af ålen på tæt hold.
 De nye ministre aflægger ed i dag.
 De illegale jægere har okkuperet en stor del af landet.
-Vi skal i øvrigt også hurtigt genoprette sanmmenhængen mellem arbejde og social beskyttelse.
 Vi ærer ofrene for disse mord.
-Folias er hans ræsonnement derfor ikke i overensstemmelse med virkeligheden.
-Det er ikke tilfældet for ølsektoren og for bezintankaftalerne.
 Dog skal det lærred, der endnu ikke er afsløret, stadig for størstedelens vedkommende males.
 Jeg har dyb respekt for små virksomheder, som imod alle odds forsøger at overleve.
 De fortvivlede grækere har overtaget stafetten fra spanierne.
 Vi bejler til begge lande for at få handel.
 Norge er et godt eksempel på effektiviteten i denne fremgangsmåde.
-Wiebenga taknemmelig for, at han har tilpasset direktivet på den netop nævnte måde.
 Vi slog så at sige virkelig pjalterne samme denne gang.
 Hvorfor lader vi denne galskab fortsætte?
 Børn tilbringer hele deres skoletid i barakker.
 De fleste assyrer er nu internt fordrevet.
 Gennem andele og medejerskab bliver arbejdstagere til medarbejdere og medarbejdere til medejere.
-Dens modstand mod generalernes kupregime er forbilledligt fredelig.
 Målet var at gøre det ved hjælp af rå magt, brutalitet og hensynsløshed.
-Oostlander har også ret i, hvad han sagde derom.
 Transitspørgsmålet bør kunne løses på en anden måde eventuelt gennem en særlig pasordning.
 Her tænker jeg især på kvinder, som er ofre for sexslavehandel.
 Vejen til helvede er imidlertid brolagt med gode hensigter.
 Vi må have midler, udstyr, skibe, helikoptere og fly.
-Den grundlæggende årsag ligger stadig i problemets etnocentricitet.
-For første gang kunne vi se drusere, sunnitter, shiiter og kristne demonstrere sammen.
 Jeg vil tale om de problemer, som stadig ligger tårnhøje på vores bord.
 Rollen som smeltedigel slog fejl.
 Det fører til unødigt merarbejde for privatpersoner og virksomheder.
@@ -4114,28 +3520,22 @@ Jeg vil fremlægge det på aristotelisk vis.
 For det tredje er gensidig anerkendelse et kardinalpunkt for de liberale.
 Det er en ironi, der ville være morsom, hvis den ikke var så tragisk.
 Lad os holde op med at køre fast i tovtrækkerier om enkeltprodukter.
-Srebrenica står som et symbol på rædsel og utrøstelig sorg.
 Guatemalas øverste valgret har også bedt om vores støtte.
 Det udgjorde en risiko for andre søgående fartøjer i havnen.
 Vi var netop blevet færdige i gruppen og løb derefter hurtigt herhen.
 Det politiske establishment i landet har på sørgelig vis svigtet sit folk, navnlig ungdommen.
-I forbindelse med cyber war og cyberkriminalitet skal vi koncentrere os om tre punkter.
 Skatteopkrævningen er blevet mere effektiv, og kursen på rubelen er afbalanceret.
 Dette er altså en af grundene til de påsatte brande.
 Ryan træder i stedet for ham.
 Også andre veje bør afsøges, herunder først og fremmest eftergivelse af gælden.
 Kommissionen må her blive mere aktiv som problemløser og angribe obstruerende lande.
 Vi er nødt til at beskytte, værne om og bevare delfiner, hvaler og sæler.
-Vitorino, hvis kompetencer vi har værdsat.
-I denne sammenhæng kommer jeg til at tænke på gospelhistorien om splinten og bjælken.
 Svagheden i betænkningen er dens rigoristiske krav om kapitalistisk og nyliberal tilpasning.
 Vi aner ikke, hvor lang inkubationstiden er.
 Nogle af disse tilfælde omtales meget og ofte, mens andre hylles i tavshed.
 Måske en gevinst, som for en gennemsnitlig husholdning svarer til prisen på en pizza.
 Imens taler folk her som om, at ragnarok var ved at bryde løs.
 Det er en situation med lutter vindere.
-Egunkaria er en nyhedsavis.
-Wynn, og koordinatorerne har udført.
 Racismen suger næring af kriser og arbejdsløshed.
 Var formålet at iscenesætte et blodigt opgør?
 Der skal også kæmpes mod transfersystemets afdrift og især handlen med unge professionelle.
@@ -4147,37 +3547,23 @@ Cubas årlige bogmesse er en kulturel og informativ begivenhed med stor internat
 I den region har der altid været en interessekonflikt mellem nomader og fastboende landbrugere.
 Det gælder såvel majoritet som minoritet.
 Der anvendes ingen køller eller knipler, idet der i stedet anvendes geværer.
-Vi er ineffektive og dysfunktionelle, og vi svigter borgerne.
-Nu er det nok med lappeløsninger og rækker af aggiornamento.
-The point of no return ligger definitivt bag os.
-Corticoider og andre hormoner kombinerede eller ikke tjener til at oppuste kødet.
 Tillykke og bravo, kære kollega.
 Der skal luges ud i lovgivningen.
 Learning tilbyder nye pædagogiske modeller til undervisning og læring.
 Det ledes af fire saudiarabiske kvinder.
 Repræsentanterne for ilandene vedtog ingen konkrete forpligtelser.
-Kreml er imidlertid udmærket klar over, at der ikke kan skabes nogen juridisk præcedens.
 Læg tallene på bordet, og det hurtigt!
 Jeg ved, at den australske regering har fået meddelelse.
 Hvis de viser sig, mødes de med verbal eller endog fysisk aggression.
 De har alle været de sidste seks måneders adelsmærker.
-Buttiglione, det vigtigste er, at han fanger mus.
 Hvem pokker tror de mennesker lige, de er?
 Vil de ikke blive belånt fra starten?
 Japan hamstrer i stor stil.
-Vi beklager nok alle, at det oprindelige forslag om totredjedelsflertal ikke kunne gennemføres.
 At forhale direktivet ved at kives om urealistiske mål hjælper ikke nogen.
-Kommissionen har evalueret medlemsstaternes nationale allokeringsplaner.
 Vi så ikke bålene i fjernsynet, men på den anden side af hækken.
-Størstedelen af den tunesiske befolkning har ingen tillid til denne midlertidige uvalgte regering.
-Rugova er det i lang tid lykkedes.
 Orlando, en stor tak for kvaliteten af deres betænkninger.
-Lad os forsøge at gå videre allegro vivace, ma non troppo.
-Bemba, har, men det er ikke det hele.
 Jura skal ikke besvares large, men med jura.
-Hajdari blev udsat for et attentat.
 Der erhverves viden, opøves færdigheder og indøves social adfærd og vilje til integration.
-Rocard havde for øje, og jeg komplimenterer ham for initiativet.
 Når det gælder et så vigtigt emne, burde usle kneb ikke forekomme.
 Den første er til de specialiserede producenter af oksekød med besætninger af ammekøer.
 Efter lyrikken over til faktaene.
@@ -4186,193 +3572,132 @@ Jeg gror, at der stadig er gennemført særdeles lidt på disse tre områder.
 Skam over troldmandens lærlinge!
 Jeg mener, vi bør se nærmere på, hvordan vi kan udjævne kløften.
 Nederlandske byer er allerede blevet oversvømmet af horder af polakker, rumænere og bulgarer.
-Det er sådan nogle uroplevelser, man har med bureaukratier.
 Men nej, jeg vil ikke være med til at plukke de europæiske skatteydere.
 For dette efterlader sandelig et grumset billede.
-Roth, give sin mening til kende.
 En forøgelse af udbuddet gavner ikke per definition landbrugsindkomsterne.
 Den glemmer sit proletariat.
-Det står dog klart, at der skal holdes konstant øje med grænseværdierne for karcinogener.
 Jeg kan desværre ikke svinge en tryllestav, fordi jeg ikke har nogen.
-Derfor taler vi ikke om quid pro quo, men om et forhandlingskapitel som sådan.
-Mascarpone skal nu en gang ikke være en kur mod halsbetændelse.
 Jeg skal sørge for, at spørgeren får denne brochure.
 Dette er ikke bare alvorligt, kære venner, det er uhæderligt og meget trist.
 Jeg har i høj grad nydt at arbejde sammen med hende.
 Stalinismens tvillingebror var nazismen.
 Vi skal være retfærdige, men ikke salomoniske.
-Der skete ikke mændene noget, men pigen blev dømt for hor efter sharialoven.
 I denne sal bør den italienske præsident altid kun omtales med respekt og ærbødighed.
 Det vedrører oftest en skade på bulkskibenes skrog, som skyldes forkert lastning eller losning.
-Hutchinson og jeg selv havde den fornøjelse af besøge.
-Det udgør efter vores opfattelse et stort problem i forhold til soft law.
-Man bør naturligvis på sigt forbyde æglægningsbure.
 Det er et højpolitisk projekt, højpolitisk!
 Ingen ved, hvor råvarerne kommer fra, og hvordan de er blevet udvundet.
-Skyldes det færre pushfaktorer eller strammere indvandringskontrol i visse lande?
 Vi vil alle opleve vores nemesis, når tiden er inde dertil.
-Der foreligger dog ikke nogen sådan ansøgning p.t.
-Medlemsstaternes bidrag udgør en fyrretyvendedel af deres nationale udgifter.
 Det er i grundskolen og gymnasieskolen, der skal undervises i den nye teknologi.
 Det, der bliver tilbage, kan såmænd blive vanskeligt nok endda.
 Der er en økonomisk pol, og der er en monetær pol.
-Kuzniecovs liv være i fare, fordi han er homoseksuel.
 Dette er en usocial, om ikke endda asocial politik.
 Ustemplede æg er en gave for en svindler.
 En undertiden dvask dømmende magt og mistanker om selvcensur giver grund til bekymring.
 Emigration er et gammelkendt fænomen, som for nylig har ændret karakter.
 Der er tale om en binational debat.
-Der ligger mange skoler i området med et forøget radonniveau.
 Den er vi hoppet på for ofte.
 Jeg mener ærlig talt, at formandskabets svar ramte sømmet på hovedet.
-Errare humanum est, perseverare diabolicum.
 Vi kan besmykke fordomme, eller vi kan modvirke dem.
-At der skabes et fait accompli, undergraver chancerne for en forhandlingsløsning på konflikten.
 Under det gamle zarregime og sovjetånden har det været svært at lære reelt demokrati.
 Mange virksomheder bliver opkøbt eller modtager finansiel bistand gennem disse fonde.
 Markedsprisen fastsættes på engrosbørserne for strøm.
 Fremmedhad og racisme er uvelkomne bivirkninger af, at forskellige kulturer lever sammen.
-Vi mødte de russiske, ingusjetiske og tjetjenske ledere og medlemmer af deres regeringer.
 Jeg kunne være fræk og sige, at det er åndssvagt!
 Talibanernes magtovertagelse stiller udviklingen århundreder tilbage til den mørkeste middelalder.
-Formålet med dette forslag er at beskytte bankafregningssystemerne mod deltagernes insolvens.
-Kibakis ministre, der håbede at blive medlemmer af parlamentet, forkastet ved valghandlingen.
 Gevinsten fra en større lastvogn vil blive ædt op af den stigende transportmængde.
 Motordrevne køretøjer og påhængskøretøjer
 Allerede i går ville jeg dadle udtrykket cirkus.
-Begrænsning af markedsføring og anvendelse af pentabromodiphenylether
-Tutsierne fra niloticfolket udgør mindretallet, men de dominerer regeringen og hæren.
-Derfor er der behov for at indbygge et early warning system.
 Bygninger, der ligger øde hen, vil uvægerligt blive syge, hvis de ikke kontrolleres regelmæssigt.
 Der er forskel på, hvordan medlemsstaterne håndterer leasingaftaler.
 Vi har ment, at vi meget nemt kunne få gas fra det kaspiske område.
 Den foreskriver, hvordan man skal spise, klæde sig og endda gå på toilettet.
 At gøre noget retrospektivt og gældende for fortiden er dårligt.
 De sammenligner det med eugenikken i første halvdel af sidste århundrede.
-En sådan adfærd ville medføre en ret stor badwill.
 De maoistiske guerillaer fortsætter deres ødelæggende hærgen.
 Jeg har indtryk af, at vi køber katten i sækken.
-Sahelområdet kan kun gøres sikkert ved at forbedre befolkningens situation.
-Det har ikke noget med den ofte misforståede keynesianisme at gøre.
 Samtidig kan man absolut se et lysglimt i denne fase.
 Man frygter hyperinflation og massiv forarmelse.
 Et andet punkt, jeg vil skabe klarhed over, er diskussionen om vin, whisky etc.
 Rådet er jo ikke engang parat til at nægte denne klike indrejsevisum.
-Man har stadig ikke løst problemet med tilsætningsstoffer, aromastoffer og ekstrationsmidler.
-Et bedre resultat kan opnås med den chilenske encaja.
 I de nationale afrapporteringer mangler der for det meste en inddeling efter køn.
 Jeg ved, at ulovlig skovhugst blot en den synlige top af isbjerget.
-Det er kort sagt en ommer.
 Betyder det, at alle eksterne konsulenter er stygge?
 Busfabrikanter beviser jo allerede i dag deres store kapacitet, hvad angår sikkerheden.
-Jeg skal udtrykke mine bedste lylønskninger for det østrigske formandskab.
 De nedbrændte skove bør retableres under hensyntagen til de klimatiske og økologiske særpræg.
 Kørsel med tændte lygter i dagtimerne og brug af sikkerhedsbælter resulterer i færre trafikulykker.
 Erhvervsuddannelse skal også omfatte sprogkurser inklusive fagsprog.
 Denne nye teknologi fører også til en dataudveksling af uanet omfang.
-Jeg har derfor absolut ingen hard feelings over for nogen som helst.
-Jeg støtter ikke en etbarnspolitik!
 Tallet er betydeligt lavere end i slutningen af firserne og begyndelsen af halvfemserne.
 I de seneste år har denne type arbejde vundet frem med syvmileskridt.
 Vi tabte vores sidste søslag for hundrede år siden.
 Kasakhstan er nemlig et land, man næsten kan betegne som eksplosivt.
-Sammen med kalium danner dette et saltstof, kaliumbitartrat, der udfælder ved påvirkning af kulde.
 Vores vinfremstilling har rod i ældgamle kulturer og traditioner.
 Det gælder restauranterne, souvenirbutikkerne, modebutikkerne.
 Der fortsætter landmænds og dyrs pinsler uformindsket.
 Mit indlæg handler om den nordiske pasunion.
 Se på, hvor let det er nu om dage at downloade musik fra internettet.
-Jenin er uden tvivl et dramatisk eksempel.
-De er normalt gemt bort i budgetposterne for reserveoplysningstjenester.
 Bed ikke de europæiske institutioner om noget, som de ikke kan levere.
 Deres efterfølgere har rejst væggene, købt reoler og stillet mapper på plads.
 Et godt eksempel er magneter i legetøj.
 Det kunne måske være en god ide at tage fat på denne debat.
 Det indre marked er ikke årsag til omstruktureringerne, det er modgift mod disse.
 Denne forklaring er en kimære.
-En gletscher smelter hurtigere, end stålet til skinner størkner i støbeformen.
-Almunia er blevet mødt med.
 Det er bestemt ikke en politik, der primært er baseret på lønbegrænsninger.
 Perler er små og svære at finde.
 Det er sådanne beslutninger, der har bragt hele den fælles fiskeripolitik i vanry.
 Godt, lad os tage guderne ud af spillet.
 Taler vi egentlig om lån, hvor hver eneste øre skal betales tilbage med renter?
-Deepwater er bare et symptom på peak oil.
 Dyrlægerne får hjælp fra offentlige assistenter.
 Amsterdam er ingen fiasko, det er et lille skridt fremad.
 Skadefryd er den eneste ægte fryd, siger kynikeren.
 Det ophidsede i hvert fald fonde og forskere på sundhedsområdet.
 Mine damer og herrer, vi skal afmystificere økologisk landbrug.
 Gulliver troede dog, at han var kommet til giganternes land.
-Papadimoulis for det udmærkede arbejde, han har udført.
 Tænk, hvis hans koncept virkede lige så godt på casinoet.
-Satyagraha er en ikkevoldelig kollektiv aktion.
 Det påpeges, at vi nu skal stille krav om afmilitarisering af tre grundlæggende årsager.
-Mumias juridiske muligheder for at undgå døden er meget begrænsede.
 Dette udgangspunkt er typisk marxistisk.
-Farage for ikke at respektere det irske demokrati.
 Jeg mødte familierne til de kuwaitiske fanger.
 Tilgiv mig, men jeg har lidt mavepine.
 Vi skal alligevel ikke stikke en kæp i hjulet for vejtransporten, tværtimod.
 Cunha for at have erindret os om dette.
-Kinnocks reformplan er som helhed både visionær og realistisk.
 Vi bør ikke diskutere et så følsomt emne som britisk oksekød så lemfældigt.
 Det handler om kalorieoutput, ikke blot om kalorieinput.
 Der er dog ikke nogen af os, der har grund til at være kæphøj.
 At påpege dette er ikke at føre stereotyper til torvs.
 Det andet er at hindre udbredelsen af atomvåben og naturligvis også af spaltbare stoffer.
-Nedbringning af gasemissioner fra husholdningsaffald er en af de uudnyttede muligheder.
 Forslaget til betænkning om grønbogen er et vigtigt bidrag til spørgsmålet om byudvikling.
 Det er grunden til, at ordningen kun gælder for nyansatte.
 Såvidt min funktion som ordfører.
-Det første er forordningen om ulovligt, urapporteret og ureguleret fiskeri.
 Så er det det rene bluff for forbrugerne.
 Det var dog mere en dyr og mondæn hobby end en økonomisk aktivitet.
 Den er dog ikke alene om dette comeback.
-De hidtil usete stigninger i oliepriserne tvinger en hel erhvervsgren i knæ.
 Dette fjerner en evindelig kilde til konflikt.
 Jeg tror, at der er store potentielle muligheder i bioplast.
 Kofoed vil jeg sige, at vi fuldt ud tilslutter os hans udtalelser om kvoteringen.
-Dalitterne er nærmest ikke blevet nævnt.
-Disse mennesker har brug for mere end words.
 Selv en lille fødevarevirksomhed ved, hvilke ingredienser brød eller snacks indeholder.
-Howitt og andre har fremført.
 Det skal være en enstemmig beslutning i henhold til wienerkonventionen om traktatret mellem stater.
-Der er brug for en grundig undersøgelse af markedet for credit defalut swaps.
-Milosevic var ikke uvidende om, at det var det, der kunne blive konsekvensen.
-Vi har ikke opstillet særlige genvindingsmål for glødelamper, kun for lysstoflamper.
 Alle sprang for livet, og det var børnene, der blev hårdest ramt.
-Interessenterne inddrages aktivt i alle stadier af dette feasibilityprojekt.
-Anastassopoulos, endnu bedre!
 Syrien forbliver en etpartistat, selv om man taler om at ændre denne situation.
 Skal vi sætte en etiket på hvert enkelt riskorn?
-Vi afviser et ubremset skub i retning mod integration.
 Størstedelen af markedet er sikkerhedsudstyr til køretøjer som airbags og sikkerhedsseler.
-Vi har en proklamering af, at de ønsker at opsige rumvåbenaftalen.
 Han valgte et æsel som partisymbol.
 Som trofast europæer må jeg derfor stemme imod denne betænkning.
 Derved sættes der måske spørgsmålstegn ved det, som dr.
-Hamas vil formodentlig komme ud af konflikten militært svækket, men politisk styrket.
 To af mine sønner taler polsk.
 Også det tærer på de videnskabelige ressourcer.
 Det betyder altså, at irerne og belgierne har begået en brøler i denne sag.
 Europa har nogle fordele, der giver en vis pondus i den globale debat.
 Jernbanerne eksisterer allerede, men skal udstyres til lyntogstrafik.
 I den første fase er der tale om feber og svækkelse.
-Bautista, med hans betænkning, som har opnået enstemmighed.
 Vi er mange, der husker vores afdøde kollega.
-Den kan derfor betragtes som et passende refinansieringsinstrument.
 Påny viser det sig, at der ikke er grundlag for en positiv menneskeopfattelse.
 For det tredje skal vi lancere en stor europæisk plan imod afindustrialiseringen.
 Han gentager nu sit gamle refræn med nye ord.
 Vi må også kunne leve med denne højfornemme foranstaltnings nonsens.
-Kommissionens nye forslag indeholder en god ordning for samforbrænding af byaffald i cementovne.
 Om en time vil jeg kontrollere, om taxierne igen må køre ind.
 Desværre er listen over fobier længere end som så.
 Der er medlemsstater med moderselskaber og medlemsstater med datterselskaber.
 Alle vandlevende organismer blev udryddet i en afstand af op til flere hundrede km.
-Maat interesserer sig herfor og udarbejder en betænkning om emnet.
-Mombaur, for det fantastiske arbejde.
 Landet skal genindføre drakmen, fordi landets medlemskab af euroområdet er uholdbar.
 Hun har ikke ladet sig aflede af al ståhejen omkring sig.
 Jeg har astma, og jeg fik to anfald i denne bygning under sidste mødeperiode.
@@ -4383,51 +3708,35 @@ Vi har nu fundet det design, som forhåbentlig dur til de fleste medlemsstater.
 Gnisten går ikke engang videre til medlemmerne her i mødesalen.
 Det understreger, at man har gjort knæfald for industriens interesser her.
 Vi har tiet alt for længe i denne sag.
-Formandskabet glæder sig over, at protokollen for ueksploderet ammunition er trådt i kraft.
 Tovbaner er løbende underlagt højt specialiseret nytænkning.
 Ordføreren nævnte, at yngre og yngre mennesker rammes af forskellige former for tumorer.
 Jeg troede, at verden havde fået nok af smarte finansielle fiduser.
 Gibraltar er rent faktisk et oversøisk territorium og ikke en britisk koloni.
 Det trækker store veksler på en sådan arvs bæreevne.
-Bruegheløkonomerne har mistet troen og går nu ind for øgede udgifter.
 De var meget klogere, meget mere snedige end som så.
 Sørøveri er ved at blive en trussel for skibstrafikken på verdensplan.
 Mens vi taler om datapakker, vil jeg komme ind på spørgsmålet om netneutralitet.
 Fru kommissær, tøv ikke, gør noget ved sagen!
 Det er et orkester fra den tyske hær, der spiller.
-Es un gran placer contar con su presencia.
-Cornelissen for hans fremragende betænkning.
 Et lyssignal kan være i orden, men et lydsignal er måske lidt tvivlsomt.
 I en udateret meddelelse hedder det, at det alt sammen ikke var sådan ment.
 Heri fæstes der særlig opmærksomhed mod sexturisme.
-Dess for hans fremragende stykke arbejde.
 Hvad folkets repræsentanter har gjort, må de også kunne gøre ugjort.
 Vi nød en hyggelig sen middag sammen.
-Aviær influenza fremstilles som en yderligere rytter i åbenbaringen.
 Rutinemæssige obduktioner gennemføres af ministeriets dyrlæger på alle slagtede dyr.
-Aha, der er et øsamfund, altså er det en øregion!
 I dag er mange lægemidler, der ordineres til børn, ikke udviklet specielt til dem.
 Det sidste punkt er kuriøst.
-Kystvagten skal være søfartssikkerhedsagenturets lange arm.
-Man får ikke løfter ført ud i livet ved at tale fabelsprog.
-Belders betænkning er ingen undtagelse, men den rummer vigtige og relevante punkter.
 Og også tak for dine venlige ord.
 Diskussionen om, hvordan evalueringen skal foregå, er unyttig og desorienterende.
 Undersøgelsesudvalgets indsats har pirket til dem, der foretrak at lukke øjne og ører.
-Også egreneringsfabrikkerne er i fare.
-Dens valuta, tolaren, kan betragtes som en af de hårde europæiske valutaer.
 Det er en forkert måde at tænke på, og den er ødsel.
 Parlamentet er sprunget op som en tiger og landet som en sengeforligger.
-Alligevel støtter vi tobaksdyrkning og skærer ned på cannabisplanter.
 Trods problemerne vil vi gerne gøre vejen til fred lidt mindre ujævn fremover.
 Luftruter, færgeruter, togruter og busruter i og til disse fjerne områder udliciteres.
 Nogle synes, at en lille gruppe af de såkaldte vismænd skulle fremlægge forslag.
-Det er afgørende, at det grundlæggende kemalistiske tabu brydes.
-Lanzarote er ikke det eneste eksempel, der er mange flere.
 Yassin havde modbydelige forbrydelser på samvittigheden.
 Det andet spørgsmål er den europæiske flyindustris fremtid.
 I henhold til rapporten er det forhold, der gælder for blåhaj eller forkert.
-Selv mistænkte forbrydere har krav på en rettergang, på en fair trial.
 Som skyggeordfører for min gruppe fik jeg rollen som opmand.
 En sidste bemærkning om klisterskinke.
 Jeg fniste ikke over bemærkningen.
@@ -4437,33 +3746,25 @@ Jeg har mit tomatsikre tøj på, hvis nogen har noget i tankerne.
 Af en jomfru at være, var det en meget livlig jomfru!
 Der er en telefonlinje for nødopkald i en række lande nu.
 Mange af de velkendte antibiotika er i dag enten blevet ineffektive eller upålidelige.
-For det første spørgsmålet om price improvement.
 Først i dag reagerer vi på en af det kommunistiske diktaturs mest grufulde forbrydelser.
 Denne finkæmning lover ikke godt for fremtiden.
 Det er et uopdyrket, jomfrueligt land.
-Vi har allerede haft et kejserligt mare nostrum.
-We can work it out, we can work it out!
 Der kommer stadig større tabstal.
 Asien ligger måske langt væk, men områdets fremtid vil påvirke os alle.
 I flere medlemsstater er der et særligt tillidsforhold mellem klienten og den juridiske rådgiver.
-Prækommercielle indkøb giver mulighed for at tage denne anormalitet op.
 Den må ikke dolke de demokratiske kræfter i ryggen.
-Kasjanov, for at forberede topmødet.
 Men sejren har en bismag for mennesker i hele verden.
 Man hører snakken i krogene og venter.
 Denne fremgangsmåde lugter næsten af deling af rovet.
 Ej heller er fædrene uarbejdsdygtige som følge af fødslen.
-Under den nordlige dimensions auspicier kunne vores fælles søstrategi blive noget endnu større.
 Jensens udmærkede betænkning medtager meget af det, mit udvalg har foreslået.
 Men vi skal stadig have vedtaget mål på delområder som fiskeri, landbrug og skovbrug.
 Disse produkter bør ikke blive et dyrt nichemarked.
 Det var et uhæmmet angreb på arbejdstagerne.
 Er det politisk nærsynethed eller enfoldig hævngerrighed?
-Tværtimod er vi begyndt at gøre det for den kommende round.
 Vi har også ofte flakket omkring.
 Dette skal gøres klart, ellers bliver det bare en kakofoni om traktaten.
 Ingen dele af det menneskelige legeme, ingen celler, ikke den mindste molekyle kan patenteres.
-Fontana, har haft en personlig indflydelse på dette gode samarbejde.
 Hovmod står for fald, og vi bør nok ikke være alt for hovmodige.
 Der bruges kemiske stoffer eller teknikker til vores hudpleje, fødevarer og sundhedsprodukter.
 Kravet om stærkere finansielt fodfæste skal derfor afvises på denne baggrund.
@@ -4472,36 +3773,25 @@ For os skal der være databeskyttelse, ellers er aftalen dødfødt.
 Også blandt rektorer og i skolevæsenerne kan der herske stor usikkerhed.
 I mange år arbejdede han med sikkerheden på havgående fartøjer.
 Hussein er en uappetitlig, men åbenlyst nu også militært svækket diktator.
-Derfor kan vi ikke støtte dette gensidige rygklapperi.
 En forudgående obligatorisk briefing er derfor et mindstekrav.
 Tilskyndelser til avling har aldrig vist sig at fungere.
 Den sociale misere i storbyer er grobund for organiseret kriminalitet.
-Hvorfor så ikke frugt til saftfremstilling?
-Det kan man opnå ved at sætte grænsen ved max.
 Betænkningen lader det være usagt, hvilke motiver der ligger bag en nærmere samordning.
 Fiji risikerer at miste investorernes tillid.
 En kinesisk leverandør leverede en maling, som den ikke burde have leveret.
-Det omfatter alt fra lastbiler til jetmotorer til fly og telekommunikationsudstyr.
 Samtidig ties kvinder simpelthen ihjel i de fleste af vores partnerlandes strategiske programmer.
-I enkelte af disse lermineraler har man rent faktisk fundet forhøjede dioxinværdier.
 Altædende dyr er virkelig altædende.
-Frihandel er ikke det samme som laissez faire.
 Vi har brug for en håndværker, en altmuligmand, ikke en statsmand.
 Der var lidt uenighed hist og pist, men hvor er der ikke det?
 Det er rart at se ham rødme.
 Her fremmer jobrotation udviklingen af kvalifikationer.
-Det er årsagen til, at vi ønsker at placere byaktioner centralt i samhørighedspolitikken.
 Amerikanske arbejdstagere skifter i gennemsnit profession tre gage i løbet af deres levetid.
 Men det estiske samfund er blevet opdelt i vindere og tabere.
 Men jeg noterer mig det og vil ved først givne lejlighed indhente det forsømte.
 Der vil blive gjort forsøg på at pådutte alle investeringstraktater den fulde grønne dagsorden.
-Den, der ikke vil anerkende det, indtager et ret provinsielt sysnspunkt.
-Der er minimum behov for to beddinger til at kunne fortsætte en indbringende skibsværftsaktivitet.
-Gyanendras demokratiske sindelag har aldrig været særlig indlysende, tværtimod.
 Det er virkelig dråben, der får bægeret til at flyde over.
 Det fører til, at døtre bliver udstødt, og pigefostre bliver aborteret.
 Enkle smertestillende midler, hostemedicin og vitaminpræparater er sådanne tilfælde.
-Det andet vigtige punkt vedrører bobehandlinger ved insolvens.
 Måske er dette en meget uromantisk ting at sige på en sådan formiddag.
 For højintensive sonarer er prisen for høj.
 Fra en enmandsgruppe til en anden skal der derfor lyde et stort tillykke.
@@ -4512,9 +3802,7 @@ Der manglede jo sågar data for nogle sektorer, pikant nok også for uddannelses
 Den afgørende europæiske merværdi er tæthed på borgerne.
 Først kaster man helt tilfældigt økonomisk stærke og økonomisk svage økonomier i samme gryde.
 Det er et meget kompliceret spørgsmål om, hvordan man fræser kød af knogler.
-De europæiske institutioners politiske interventionisme udvikler sig med lynets hast.
 Det kan opjustere sine finansielle behov for at gennemføre sine nye beføjelser.
-Izquierdo taknemmelig for, at han har behandlet et bredt spektrum, der imponerer.
 Overraskelsen var, at hunden var der og ikke gøede.
 En hel vrimmel af medlemsstater samarbejder kun modvilligt.
 Det er en mulighed for at omorganisere hele den paneuropæiske og globale finansielle arkitektur.
@@ -4528,15 +3816,10 @@ Barometre kan gå i stykker eller blive utætte, så kviksølv havner i miljøet
 Normalt skal bilerne være registreret i den medlemsstat, hvori ejeren er bosat.
 Ryd op i junglen af personaletilskud!
 Alligevel oplever vi i dag en nævekamp, som ikke respekterer særlig meget.
-Fru formand, jeg vil gerne have, at min tilstedeværelse igår fremgår af protokollen.
 Vi taler ikke længere om en bue, men derimod om et frit fald.
-Sydøsteuropa er et knudepunkt for flere hovedforsyningsledninger for energi.
-Forbuddet imod tinholdige forbindelser er efter min mening forhastet.
 Så lad os ramme en pæl gennem det argument.
 Nogle mener også, at markedsordningen for sukker er en dinosaur.
 De har løjet og fundet på.
-Det er ofte også vigtigt for paftienterne.
-På lægmandssprog betyder det, at jeg kan skelne mellem en bordeauxvin og en rhinskvin.
 Etableringen af gode relationer er en tovejs proces.
 Laos er et af verdens fattigste lande.
 Det svirrede med rygter om april.
@@ -4548,10 +3831,8 @@ I nogle lufthavne behandles passagererne nærmest som ubudne gæster.
 Demokratiske nationalstater bør have enebeføjelse på dette område.
 Begge forældre skal være bærere af dette gen, ellers forekommer defekten ikke.
 Min gruppe afviser en sådan rabiat løsning.
-I det forrige århundrede lærte man fem officielle sprog i den lavere karpatiske region.
 Det er påvist, at det høje niveau af blypartikler i atmosfæren påvirker børns intelligenskvotient.
 Med hensyn til bioovervågning er vi helt enige.
-Titanic var bygget til at være et skib, der ikke kunne synke.
 Det angår også det jugoslaviske område.
 Vores frygt stammer også fra en gådefuld selvmodsigelse.
 Det er ikke lykkedes, alligevel har den afsvækket denne beslutning.
@@ -4561,32 +3842,20 @@ Men de er notorisk ineffektive i dag.
 En fed hamburger bliver jo ikke sund, fordi der tilsættes nogle vitaminer.
 Dette er et gammelt opråb, for problem har eksisteret i lang tid.
 I modsat fald skal man straks holde op med dette pjat.
-Udviklingen af opsendelsessystemer er en nødvendig forudsætning for enhver anden aktivitet i rummet.
 Det gælder ikke mindst reglerne for metylbromid.
 Fru formand, det er ved at blive ensformigt at tale om de tyrkiske grovheder.
-Hvad havinspektionerne angår, er tallene temmelig rystende.
 Der bliver europæiske skolemestre i atletik, fodbold, basketball, kampsport eller svømning.
 Turkmenistan er afgørende for sikkerheden i regionen og kampen mod narkotikahandel.
-Rådet har blokeret for adskillige planer for ansjosfiskeri.
-Jeg har endnu aldrig mødt en forbruger, der er vildt bekymret over carrageenan.
-Efter min mening er dette en meget burokratisk ændring.
-Det er min antagelse, at byggespekulanterne udnytter den skrøbelige valencianske autonomi.
 Et år senere er det nu en fuldstændig uappetitlig slimet klump.
 Vi har allerede oplevet store prisstigninger på madvarer sidste år i august.
-Fiberemballage, f.eks., kan let fremstilles af fornyelige råstoffer, der kan genvindes.
-Gayssots kommunistiske lov er i den forbindelse den første af slagsen.
 Set i bakspejlet var den sidste udvidelse, uden uddybning, overilet.
 Det tredje politiske fagområde, som jeg vil berøre, er arbejdstiderne.
 Hætteklædte demonstranter kastede med brosten mod politiet og smadrede butikker uden at blive fanget.
-Grosch i denne forbindelse.
-Dounreay er blevet lukket af nuklearinspektoratet.
 Denne agreement kan kun være en overgangsordning.
-Der skal være en diligenspligt.
 Forordningen er også vigtig for de unge, der sender en sms til deres kæreste.
 Og vandets kvalitet og renhed skal også forbedres.
 For arbejderne er der imidlertid sulteløn og evig nøjsomhed.
 Den må ikke være hullet som en si.
-Sydsudan skal støttes på alle tænkelige måder.
 Nogle kommentatorer har omtalt disse bestræbelser som politisk nekrofili.
 Rusland har også en stor betydning som brobygger mellem de europæiske og asiatiske lande.
 Tobak af høj kvalitet etcetera, og mindst mulig støtte til den.
@@ -4599,9 +3868,7 @@ Se ud over det store ocean!
 Det styres af hemmelige udvalg, brovtende ansigtsløse bureaukrater og foregivet ansvarlighed.
 De indeholder meget lidt pcb og andre farlige stoffer.
 De tilhører en svunden tid.
-Kinesiske internetbrugere skal kunne få adgang til ucensurerede informationer.
 Fremtiden er æg fra fritgående høns.
-Forfalskninger er big business.
 Og vi må ikke gøde jorden i denne sag.
 Det er jo det problem, vi i stigende grad blamerer os med!
 Sudan er stadig et urocenter, og mod nord er der den allestedsnærværende yderligtgående islamisme.
@@ -4610,73 +3877,50 @@ Jeg går helt ind for at løse anakronismer.
 Fjernsynets subkultur, sport præget af hooliganer, narkoens pseudoparadis.
 Terningen er ikke altid så smuk, fordi man kan se skillelinjerne.
 Fangsten foregår under anvendelse af en slags nylonstrømpe, som fisker hele områder tomme.
-Hadjigeorgiou, som også er til stede.
 Uangribelige regionalt fremstillede produkter sælger heller ikke længere.
 Jeg vil gerne have, at vi ikke skærer alle over en kam.
-Sidste år fortalte videnskabsmændene os, at kullerbestandene var ved at svinde ind.
 Emma er lige kommet tilbage.
 Madrid er en vanskelig part i denne sag, i sagen om regionerne.
 Det blev sammensat af finansministre, som var truet af en nedjustering af deres statsgæld.
 De ubenyttede bevillinger skal ikke hver gang overføres til efterfølgende år.
 Når en tyv bliver arresteret, bliver alle oplysninger om vedkommende offentliggjort øjeblikkeligt.
-I det konkrete tilfælde drejer det sig om sønæringsbeviser.
 Internettet har en aura af fremskridt.
 Tillid kan hverken dekreteres eller købes.
 I mange franske og engelske byer er der allerede slum, som medfører mange problemer.
-Vores topidrætsfolks sundhed og ydeevne påvirkes på afgørende måde af, hvad de spiser.
-Alle i dette lokale ved, at sådanne sanfundsprocesser tager deres tid.
 Det andet spørgsmål er specielt, og det går på beskyttelsen af den hvide haj.
-Dijkstal for deres støtte til vort år mod racisme.
 Denne del af monitoreringen er derfor også meget, meget vigtig.
 På alle tunbåde er der uddannede statslige observatører om bord.
 Direktivet begynder imidlertid at knirke, og en revision kan ikke udskydes i det uendelige.
 De sænkede bomlængden, men de øgede deres aktivitet.
 En knast, som vi stadig har tilbage, er lønnen.
-Macartney sagde, var det et offer for barbariske konservative nedskæringer.
 Et sidste element, som visse parter insisterer på, er dræn til drivhusgassen.
 Middelhavsskoven, der udgør et afskærmende bælte mod dette fænomen, ødelægges nådeløst af skovbrande.
-Hvordan forholder det sig helt konkret med loins af tun og tunkonserves?
 Glorværdig er sejren, ærværdigt er nederlaget, siger man.
-Voggenhubers advarsler til side.
 Der skal i byer, kommuner og amter ansøges om et utal af vejrettigheder.
 Det kræver en tidobling af de nye installationer snarere end andelen af energiforbruget generelt.
-De langsigtede virkninger af ecstacy er stadig ukendte.
 Amerikanerne bruger et tilsvarende beløb til vedligeholdelse af plæner!
 Takket være bioteknologien produceres insulin nu på en meget sikrere, homogen og stabil måde.
 Min hustru er formand for sognerådet.
-Det fremgik også i går på seminaret om cyber crime.
-For i vandbassinet skulle der jo også være andre isotoper end cobalt og caesium.
 Her bør vi i endnu højere grad have opmærksomheden henledt på træbyggeri.
 Økonomisk vækst og jobvækst nedbringer ikke fattigdommen.
-Borchert og de øvrige europæiske landbrugsministre har svigtet.
 Pat, vi er sultne, vi er meget sultne, og vi har appetit på forandring.
 Det er punkter, man skal bide mærke i.
 Vi er blevet legitimt rørt over de rwandiske flygtninges skæbne gennem de seneste år.
-De nye grænseværdier betyder, at sodpartikelfiltre i praksis bliver obligatoriske.
-Jeg har set, at de første bugseropmudringsfartøjer nu er sat i gang.
 Vi har tygget drøv på denne sag i årevis.
-Der er spørgsmålet om forvaltning, det, som nogle kalder gouvernance.
-Caudron, for at han kan stille et supplerende spørgsmål.
 Har han tænkt sig at spille i lotteriet eller hvad?
 Hemmelighedens dyne er løftet.
 Vi behøver ikke skabe mere papirarbejde og administrativt bøvl for de allerede betrængte landbrugere.
-Goepel hjertelig tillykke med hans afbalancerede betænkning.
 Det skal også gøres klart, i hvilket omfang nyskabelser såsom elmotorer faktisk dækkes.
-Men også dette argument gendrives og væltes af den bestemmelse, der indfører tværnationale medlemmer.
 Kommissionen skal her kort før jul roses for nogle gode og upåklagelige forslag!
 Derved bliver udviklingen af nye former for uægte selvstændighed sandsynligvis fremmet.
-Whitehead for deres konstruktive bidrag til direktivets forbedring.
-Kouchners indflydelse, måske ikke har haft den effekt, som vi alle kunne ønske.
 Jeg vil give endnu et svar på spørgsmålet om en ny standard for akustik.
 Danmark har mistet sin selvstændige veterinære status.
 Der er myg over det hele, og stanken er uudholdelig.
 Mælkeoverskuddet skal opdæmmes på nationalt plan ved at indføre europæiske krav.
-Mindretal som uigurer og mongoler begrænses i deres rettigheder og mister kulturel identitet.
 Altså ingen skænderier om parmaskinke og svenske modeller.
 Jeg har ikke været ude for sure miner.
 Jeg tilslutter mig andres lykønskninger til ordføreren for en så bredt favnende betænkning.
 Markedsmisbrug og insiderhandel har givet mange småaktionærer tab.
-Men champagnen, med eller uden zero rate , kan vi godt lade blive hjemme.
 Sikke noget sludder og hvilken geskæftighed!
 Først det teologiske problem.
 Kalveboksene skal være indrettet således, at kalvene har et tørt areal at ligge på.
@@ -4687,44 +3931,31 @@ Det er simpelthen uspiseligt.
 Set fra mit synspunkt skal denne nye procedure finpudses.
 Visse byregioner, især i forstæderne, har behov for støtte.
 Disse læskedrikke sælges frit på steder såsom skoler, sportsklubber eller diskoteker.
-Rajoelinas regering overtræder menneskerettighederne og undertrykker sine egne borgere.
 Maoriernes børn klarede sig væsentligt dårligere i skolen.
-Opmærksomheden har især været rettet mod hijab, det muslimske hovedtørklæde.
-Timor er mærket af skadernes og voldens omfang og den særlige politiske situation.
 Det er forskellen på at bruge træspåner og træfade.
 Det findes lande, hvor grundvandet hører til jorden og dermed totalt ejes af private.
-Vi ser de kinesiske uldhåndskrabber.
-Ferreira med deres betænkninger.
 Men de er naturlige stoffer og ikke farlige, syntetiske cocktails.
-Man har måske også gjort fremskridt med henblik på chaptaliseringens religionskrig.
 På tre år er omfanget af bedrageri blevet syvdoblet.
 Det ville resultere i ghettodannelse.
-Tejkowskis neonazistiske gruppe er synlig, ifølge avisen, men hvor er vi?
-Det er den grønne nevrose og optagetheden af nitrogenoxid, svovldioxid og drivhuseffekten.
 De steder, hvor situationen er vanskelig, kan man benytte definitionen af bylufthavnen som middel.
-Halogenholdige kulbrinter er meget farlige.
 Det er et kompliceret svar, og derfor er det også vanskeligt at kapere.
 Vi gider ikke høre på den slags historier!
 Dette ligner en nykolonial tankegang.
-Det er det, han kalder riot guns eller sådan noget.
 Det er en farisæisme, som hurtigst muligt må bringes til ophør.
 Gerningsmændene efterlod deres offer liggende på jorden smurt ind i blod.
 Vi hverken fremstiller eller sælger infanteriminer.
 Vi kan ikke høre tolkningen tydeligt på grund af det stærke ekko i salen.
-Gollnisch var formand for.
 På den anden side vil matroser igen blive brugt som syndebukke.
 Lønkløften har også individuelle dimensioner.
 Projektet bør opgives eller omarbejdes, så det beskytter vores nationale monumenter.
 Der har lydt et nej fra alle sider.
 Deres bekymringer over kvoteoverførslerne er ikke gået ubemærket hen.
-Rengøringspersonalet var før i tiden altid tidligt på færde.
 Udviklingen af samhandel på subregionalt plan bør ledsages af et større subregionalt samarbejde.
 Dette er vigtigt for unge søtunger, fordi denne art har en temmelig stor overlevelseschance.
 Her til morgen kikkede jeg på det websted, som rådsformanden nævnte.
 Ingen er så døv, som den, der ikke vil høre.
 Der kan ikke oprettes et bæredygtigt netværk, hvis dets knudepunkter er ramt af ælde.
 Hvilken atlet vil bevidst skade sit hjerte, lever, nyrer eller reproduktive organer?
-I de seneste tre år har en enkelt person administreret webstedet www.bankovnipoplatky.com.
 Nu bliver kødsektoren kontrolleret.
 Sker dette ikke, kan der også være behov for lovindgreb her.
 Den eneste hage er, at det ser anderledes ud i den virkelige verden.
@@ -4738,7 +3969,6 @@ Det er så sikkert som amen i kirken.
 Det var denne grundtanke, der optog mig i interviewet.
 Helmer tager ganske enkelt fejl.
 Euroområdet har givet klippefast makroøkonomisk stabilitet.
-Jeg vil også omtale de lejre, som man på mit sprog kalder for omgrupperingslejre.
 Hvis alle udvalg havde udfyldt skemaet, ville evalueringen have været mere omfattende.
 Ingen behøver frygte for deres urtete.
 De to andre nye features er tilføjelser til proceduren.
@@ -4755,9 +3985,6 @@ De har glemt de rødhårede!
 Trods visse oratoriske forholdsregler er denne tekst faktisk ikke afbalanceret og retfærdig.
 Disse problemer skyldes en hedonistisk og utilitaristisk holdning til det enkelte menneske.
 Den importerer bauxit til produktion af aluminium.
-Oxfam har erklæret, at uhæmmet liberalisering vil skade de mest sårbare.
-Moscovicis velvillige indstilling.
-Der er naturligvis stadig nogle uafdækkede områder, som for enhver pris skal belyses.
 Selv afgrøderne skal affugtes.
 I fægtekunsten er undvigemanøvrer effektive.
 Det er stadigvæk ost, og dette er stadigvæk tang.
@@ -4768,22 +3995,18 @@ Med andre ord kræver det dunkelhed og hemmelighed.
 Akin, vi beder dig blive rask igen!
 Hvorledes forklarer vi det til husbyggerne i medlemslandene?
 Ankaras politikker kan fungere som model for de arabiske lande i regionen.
-Sassolis ord, og han burde retfærdigvis være en af mine politiske modstandere.
 De små nærbutikker er en del af de samfund, som de betjener.
 Han var galant og venlig i sine lykønskninger.
 Mere end et halvt århundrede senere har arvingerne til den revolution stadigvæk magten.
 Vi kunne også få nejflertal i andre lande, hvis man turde tage en folkeafstemning.
 De er værgeløse, uspolerede og søger tryghed.
 Dette vil bringe den europæiske dækindustri på forkant med teknologien på verdensplan.
-Bolkesteins holdning i det tilfælde, og jeg skal forklare hvorfor.
 Ud over specialfremstillede varer køber de almindelige fødevarer, som normalt ikke indeholder gluten.
 Under alle omstændigheder stemte jeg imod denne betænkning igen med fynd og klem.
 Hvor er åbenheden henne til at vedstå, at reformer gør ondt af og til?
 Perry, at han ønsker, at disse foranstaltninger skal være absolut faste og grumme.
 Disse symbolske gebærder kan få gamle sår mellem mennesker til at bryde op igen.
-Seguro, for deres fremragende betænkning.
 Der skal skabes ligevægt med femogtyve.
-Suharto og andre skal tage sig i agt.
 Syrerne saver på den måde muligvis den gren over, de selv sidder på.
 Vi må udbasunere de gode nyhedshistorier, når vi hjælper borgerne.
 Lokalerne er ikke nødvendigvis uhumske, underjordiske fangehuller med fugtigt halm.
@@ -4792,11 +4015,9 @@ I fase to optræder der anfald og krampetrækninger.
 Landene forvaltede naturligvis den nyfundne frihed i overensstemmelse med gammel skik og gamle vaner.
 Erika kostede ingen menneskeliv, men kan have ødelagt mange menneskers levebrød.
 Vi kan selvfølgelig allerede tilbyde biler med nuludledning.
-To own the hearth, the stool and all!
 Den skal heller ikke have mulighed for at foretage uanmeldt kontrol på stedet.
 Nonprofitorganisationer blev også involveret.
 I sig selv beriger ozon som bekendt ilten, hvilket er sundt.
-Initiativet kommer sydfra, men det er vigtigt for vores overordnede naboskabspolitik.
 Abrikosen i bollen, schnitzelen i paneringen, frikadellen i paprikaen.
 Der er for det første de lavfrekvente stråler fra højspændingsledninger og heraf afledte frekvenser.
 Valgresultaterne var et nødråb.
@@ -4805,15 +4026,10 @@ Stipendierne er lave og fører allerede på den måde til social udvælgelse.
 De har ikke behov for encifrede procentvise forøgelser af indkomsten, mens de er arbejdsløse.
 Endelig skal der findes en løsning på spørgsmålet om offentlige abonnentfortegnelser.
 Jeg finder det uhørt, at fagforeningerne lokkede folk hertil med falske argumenter.
-Derimod er der en meget stærk sammenhæng mellem asbest og mesotheliom.
 Mere gennemskuelighed alene er imidlertid ikke nok, hvis vi vil have øget nærdemokrati.
 Det virker så enkelt ved første øjekast.
-Vi ved f.eks., at en meget stor smittekilde for salmonella aruba er brasiliansk soja.
-Det er konsekvenserne af førudvidelsen.
-Vi bekræftede også behovet for at holde fast ved amibitionsniveauet i forbindelse med konferencen.
 Der findes også ludfattige mennesker.
 Statistisk blændværk har også andel i dette.
-Fasthed betyder ikke rigiditet.
 Det er en af de mest katastrofale og kluntede episoder i diplomatiets historie.
 Denne ækle handel får ikke tilstrækkelig opmærksomhed.
 Det fik vi først i vores dueslag i løbet af formiddagen.
@@ -4824,7 +4040,6 @@ Jeg er adræt nok til at gå ned fra sjette eller syvende sal.
 Han har givet ugedagene nye navne.
 Der kan konstateres en særlig aversion mod de slaviske sprog og kulturer.
 Om saksen er en smule polstret eller ej, kreperer dyret ynkeligt i den!
-Der er også behov for handling i tobisfiskeriet.
 Detaljerede ord og hensigtserklæringer om årsdagen i dag er ikke nok.
 Blyniveauet i kosten ligger et godt stykke inden for sikkerhedsgrænserne.
 Andre anvendelsesområder, herunder energiproduktion eller anvendelse som humus, berøres ikke.
@@ -4833,12 +4048,10 @@ Skal vi fjerne de store krucifikser på bjergtoppe, der knejser over byer og dal
 Det er vores opgave at føre klicheen ud i livet.
 Oplysningerne skal være letforståelige.
 Man reagerer sjældent så muntert, som det var tilfældet på det tidspunkt.
-Sygdomme som tyfus og kolera truer, malaria, denguefeber.
 Det gøres helt klart i denne betænkning, og det tager jeg hatten af for.
 Det er sofisternes metode.
 Alle alternativer hertil er blot udsigt til en farligere og mere kværulantisk fremtid.
 Hvad angår adgangen til markedet, så er dette noget lettere inden for busbefordring.
-Der findes aylstatistikker.
 Journalisterne på ugebladet er også blevet dømt for ærekrænkelse.
 Gloser, mine damer og herrer!
 Vi strides om peanuts , hvor det egentlig bør dreje sig om store udgifter!
@@ -4848,16 +4061,11 @@ Erasmus er bestemt det mest populære program.
 Da de er biokumulative, ophobes de i miljøet og i de levende væsners organisme.
 Men jeg skal ikke repetere forslaget.
 Vi har subarktiske temperaturer om vinteren.
-Faktisk udviste den ivorianske befolkning stor politisk modenhed ved det seneste valg.
 Men dette bryllup er nødvendigt.
-Cherry picking skaber ingen europæisk merværdi, men cementerer tværtimod nationale enegange.
 I den forbindelse bør vi ikke rippe op i gamle sår.
 Især dette vil ved at snylte på universiteter bremse aktiviteter og ikke fremme dem.
 Rack har bedt om ordet angående en bemærkning til forretningsordenen.
-Pronk sagde tidligere, at vi ikke altid kan støtte socialdemokratiske forslag.
-Schmid, og af koordinatorerne.
 Og jeg mener, at vi har fået et godt greb om nælden i dag.
-Fordi løsgængeren mellem aben og den politiske homo sapiens er menneskehedens manglende led.
 Det vil hjælpe millioner af gamle europæere til at få en solrig pensionisttilværelse.
 At nå de mål, jeg har beskrevet, vil kræve et langsigtet udsyn og engagement.
 Nykommunisterne i vores land skyr ingen midler.
@@ -4869,22 +4077,14 @@ Dækproducenterne er lige så hårdt ramt.
 For det andet er overvågningen fortsat akilleshælen ved denne lovgivning.
 Men jeg vil først, som en god gourmet, vide, hvad menuen står på.
 Ellers må man uddele gratis detektorer til falske sedler til de småhandlende.
-Vi går nur over til afstemningen.
 Her må man nænsomt vejledes af eksperter.
-Det er det, der menes med udtrykket close to zero.
-Der er heller ikke sket fremskridt, hvad indførelsen af tingbøger for risdyrkningsområder angår.
 Nikkel kan, hvis det kommer i berøring med menneskers hud, fremkalde allergiske reaktioner.
 Det europæiske demokratis fremtid hviler tungt på irlændernes skuldre.
-Opel er jo ikke fabrikant af store køretøjer, men af energieffektive køretøjer.
 Vi har altså i årtier spillet russisk roulette med vores sundhed og miljøet.
 Jeg vil imidlertid være helt klar i mælet i denne sag.
 Det er let at være bagklog.
 Problemet er blot, at det ikke engang har spande til at øse vand med.
-Vage, ubestemte, uverificerbare begreber.
-Vi fokuserer derfor på teknologien til at reducere svolvindholdet i skibsbrændstoffer.
-Fruteau, fordi de har håndteret et yderst kontroversielt og vanskeligt spørgsmål så godt.
 Europa fører an inden for satellitteknologi og i teknologien for bemandede rumraketter.
-Den giver i nonfoodproduktionen mulighed for at producere nyt biobrændsel, plastic osv.
 Regeringskonferencen risikerer, som den tager sig ud, at være et stort pulterkammer.
 I dag forårsager økonomiens afkøling imidlertid sociale spændinger, også i de nye medlemsstater.
 Men stramninger og især bevidstløse stramninger og ensporede udgiftsnedskæringer kan vi godt undgå.
@@ -4898,68 +4098,41 @@ Imidlertid findes der også uoplyste forbrugere.
 Dette sammenfattes ved den kradsen i overfladen, som kendetegnes af den genforhandlede konvention.
 Endelig er vi i dag ved at komme ud af denne ubegrundede dvaletilstand.
 De sættes ofte i bås som kriminelle.
-Mållandsprincippet skal også håndhæves konsekvent.
 Denne støtte til frø eksisterer allerede for ris, kikærter og linser.
-Anvendelse af strukturfonde er hæmmet af metodens byrokrati og indviklethed.
 Deres slægtninge kæmper med et rystende bureaukrati, som de skal pløje sig igennem.
 Derimod er tatoveringer langt mindre tilfredsstillende.
 Sådan en rapport er ude på at trække det politiske primat gennem pløret.
 Så vidt så godt, men så kommer den giftige pil.
 Vi kender endnu ikke de enkelte medlemsstaters holdning til spørgsmålet om genhusning af indsatte.
-Alt dette vil øge konkurrenceevnen for vandvejstransporten og dens aktraktivitet.
 Srilankanerne nusser stadig rundt med papirer, mens befolkningen bor i telte.
-For det første er der forsigtighedsprincippet, det som vi kalder precautionary principle.
 Hele forslaget stinker af skjult protektionisme.
 I rigtigt mange lande er rørsystemet til drikkevand på nuværende tidspunkt af kobber.
 Disse køretøjer er særligt velegnede til bykørsel.
-Det er nødvendigt med særforanstaltninger for at håndtere de fribytteragtige forhold.
 Et andet eksempel er kravet om løbende målinger af ammoniakindholdet i røggas.
-Jeg vil kalde det et swedish paradox.
-Unionen er bedrøveligt uinspirerende.
-Con questo si conclude il turno di votazioni.
 Gerningsmændene frifindes, og undertiden rejses der ikke en gang sigtelse mod dem.
-Chichester, i, at der opstår et overdrevet bureaukrati.
 Det samme gælder de sibiriske skove.
-Letaliteten af nogle vira er enormt høj og kræver en anden fremgangsmåde i fremtiden.
 Det sidste håb består i, at den turkmenske statspræsident benåder dem.
-Jugendamt favoriserer i sagsbehandlingen forældre af tysk afstamning.
 Jeg har ikke noget imod calvinistisk afkaldsetik.
-Endelig vil også forsøgsfiskeriet blive fremmet, og det bliver udvidet til cephalopoder og muslinger.
 De har nu selv anlagt sag imod den franske skiorganisation.
 Tålmodighed i alle spørgsmål er en dyd, ikke mindst i udenrigspolitik.
 Jeg vil endnu en gang takke begge formænd for deres ukuelige personlige engagement.
 Hvad skete der rent faktisk med de italienske handicappede fans?
-Toubon for det meget flotte stykke arbejde, som han har udført.
-Piecyk taknemmelig for at have fremsat dette ændringsforslag.
-Skibsrederne mener ikke, at en black box har noget med sikkerheden at gøre.
 En lampe er tændt, men den er endnu ikke rød.
 Love skal da være den svages våben mod de mægtiges ubillige krav!
-Ecowas er aktiv som en regional organisation i kampen mod børnearbejde.
-Moorhouse meldt sig angående dagsordenen.
-De bryder sig ikke om quota hopping ved hjælp af flagskiftfiduser.
 Vi har brugt lang tid på at smøle og komme med undskyldninger.
 Viola for de betænkninger, de har udarbejdet.
-Det hjæper ikke at fordele fattigdommen, sådan som denne betænkning lægger op til.
 Offentligheden er vant til, at enhver organisation har et logo.
 Desværre kan vi konstatere, at denne farlige tankegang stadig er meget gængs.
-Obamaregeringen blev tvunget til indrømmelser som følge af katastrofens omfang.
 Vi må gardere os imod at blande tingene sammen.
-Jeg forstår ikke blåøjetheden i visse ændringsforslag.
-Souladakis, at stabilitet i denne sag ikke er en reel støtte til demokratiet.
-Hele betænkningen er ukreativ, og jeg vil endda vove at kalde den ubrugelig.
 De har en nybegynder i sædet.
 Det er den gamle teori om et skjold.
-Flourholdige gasser er meget stærke drivhusgasser.
-Buckfast vin bør angiveligt forbydes, fordi den indeholder både alkohol og koffein.
 For vi er sobre, fordi vi er ambitiøse.
 Men fordi vi havde et konvent, fik vi minsandten en.
 Men under de nuværende forhold presses de knugende af den amerikanske filmindustri.
 Hajer, skildpadder og delfiner risikerer at blive omringet og indgå i fangsterne.
 Kerneenergi og kul er således en del af mixet.
-Pollackbetænkningen er indrettet på luftforurening, som er en trussel mod borgernes sundhed.
 Det flertal, valgresultatet viste, angav, at præsidenten så absolut var valgt.
 Ingen dikkedarer må ikke være ensbetydende med ingen bekymring.
-Kadima og arbejderpartiet kan være en mulighed.
 Heller ikke den sømand, der vasker dækket, og heller ikke lederen af bjærgningsselskabet.
 Det fik sin ilddåb med denne krævende sag.
 Disse politiske numre er nemme at gennemskue, men det gør dem ikke acceptable.
@@ -4969,15 +4142,11 @@ Fru formand, lad mig indledningsvis takke samtlige ordførere for et gedigent ar
 At det så også medfører en økologisk bieffekt, er så meget desto bedre.
 Nu har begge kamre godkendt ratificeringen.
 De er ikke så almægtige, som de giver udtryk for.
-Amadeo, at vi må begrænse bestrålingerne.
 Vibrationer på arbejdspladsen kan ikke betragtes som direkte grænseoverskridende.
-Hele historien om storgodsejere, af capituleros, strækker sig over en meget længere periode.
-You can get it if you really want!
 Pedanteri om nogle detaljer vil jeg derfor ikke komme nærmere ind på.
 Takket være deres kvindelige intuition beriger de vores forståelse af verden.
 Haider og det, han står for nu.
 Jeg vil stille kommissæren et præcist spørgsmål om rapid alert system.
-Sakharovprisen er ikke tilstrækkelig.
 Pyt med konsekvenserne for realøkonomien og folket.
 Hvem bærer nu egentlig ansvaret for alt, hvad der er blevet ustyrligt?
 Dog kræver omklassificeringen øgede offentlige og private investeringer.
@@ -4988,45 +4157,26 @@ Siden da har polakkerne været udsat for et uskønt pres.
 Tjernobyl må og skal lukkes.
 Det er imidlertid også ønskværdigt, at vi støtter yderligere bikommunale projekter på øen.
 For det andet bør vi overveje faktorer vedrørende spillere af egen avl.
-Det er en førmoderne opfattelse, som stadig er fremherskende hos de europæiske ledere.
 Men nu får vi at vide, at tiden med junkfood er forbi.
-Huhne ved, fornuftige krav.
 Tallene for spanske operatører er på kun en tohundrededel af de sikre grænseværdier.
-I dag køres coccidiestatika ud med gødningen på markerne.
 Man snublede lidt i starten.
 Det er et spørgsmål om at smadre en rude for derefter at stikke af.
 Rådet har derfor ingen kompetence med hensyn til eutanasi.
-Det generede ham absolut ikke at have en gulag med millioner af fanger.
-Kommissionen vil således fremstå som et svækket organ med national præjudice.
-Den interne revisionstjeneste er kommet godt fra start med sine undersøgelser af counterpartmidlerne.
-Bellacruz er desværre ikke noget enkeltstående tilfælde, snarere toppen af isbjerget.
 I dag er vi nødt til at være hudløst ærlige omkring dette spørgsmål.
 Så kommer vandet til kemisk rensning, som om det var en beskidt jakke.
 Bander af unge mennesker brød ind i butikker og stjal alt.
 Vi gør for lidt for at udvikle ren kulenergi.
 Den pågældende skal kunne påklage beslutningen.
-Equal, og det er min deciderede hensigt, skal leve op til sit navn.
 Man behøver altså ikke omsmelte mønter så ofte og slå dem på ny.
-Arafat forlader den politiske scene samtidig.
 Tillad mig at tilføje et fjerde e, nemlig e for empati.
-For det andet er der to potentielle problemer i forbindelse med hulrum i letmetalvægge.
 Det ville være odiøst, hvis det ikke var så grotesk.
-Elektrisk modstand, eller ohmsk modstand, som er vigtig ved overførsel af elektrisk energi.
-Den opfattelse er efter min mening arrogant og antropocentrisk.
 Flere egne, landsbyer, bydele, bykvarterer og veje er blevet ødelagt af jordskælvet.
 Retssikkerheden vil lide ubodelig skade.
-For det tredje de veterinære og fytosanitære standarder.
-Bianco siger, at der ikke er tale om krig for serberne.
-Venezia vuole vivere e deve vivere!
 Det er naturligvis både for dem og mig aksiomatisk.
-Pimenta konstaterede lige før, at aftalen er dårlig.
 Alt dette bliver budt meget velkommen.
-Danesin med det fremragende arbejde, han har udført.
 Rio, det spørgsmål stiller jeg mig selv, var det stor ståhej for ingenting?
 De rokker for meget ved den oprindelige ligevægt.
 Oppe i logen sidder der nogle gæster og lytter til os.
-De må ikke overbevises af produkter, der sælges med udokumenterede anprisninger.
-Anliggender, hvor mænd står stærkt efter traditionelle ehrvervsvalg.
 Han nævnte urfuglen og den iberiske los.
 Der er også en anden salamitaktik.
 Den britiske eller sågar den amerikanske hund logrer med den europæiske hund.
@@ -5037,30 +4187,22 @@ Sektoren har et stort vækstpotentiale, hvad angår økoturisme, kulturarv, spor
 Spørgsmålet om menneskerettigheder er relevant under enhver form for samkvem med tredjelande.
 Jeg vil komme ind på to punkter, tøjring og genteknologi.
 Derfor er nytten af en hundrede og syttende hensigtserklæring ret begrænset.
-Det svejtsiske system kaldes også ofte statsunion.
-But if you try, sometimes you may find that you get what you need!
 Det drejer sig for det meste om sintret eller komprimeret farligt affald.
 I krydsede da af i den forkerte rubrik, ikke?
 Ved at fjerne nogle af disse fridage kunne vi skabe omkring tusinde arbejdspladser.
-Shalits sag må ikke blive et forhandlingsobjekt.
 Det er tydeligt, at nerverne sidder uden på tøjet i dag.
 Med henblik på en ønsket afpolitisering af samfundet er det derimod et probat middel.
 Bærerne af en misantropisk ideologi er fortsat en trussel mod os.
 Bytrafikken spiller en afgørende rolle, når vi taler om klimaændringer.
-Zapatas død er ikke et enkeltstående tilfælde.
 Den, der ikke kan indse det, er uhjælpelig fortabt!
 Der vil ikke være nogen hokuspokus.
 Rådet nåede til enighed om emissionslofter efter lange og seje forhandlinger.
 Sidst, men ikke mindst er der handelen med sælprodukter.
 For bær, surkirsebær og svampe er skærpede krisestyringsforanstaltninger berettigede.
-Savimbis bevæbnede bande, der lever af profitten fra diamanterne.
 Der er trods alt tale om rigtige mennesker, ikke zombier.
 Sådanne købere skal vi vie særlig opmærksomhed, for disse interessenter findes faktisk.
 Men som vagabonderende smådele er det et problem.
 Et nyt orgie af spekulation, hvor lånesatserne når historiske højder.
-Liberal markedsøkonomi er ikke noget fripas til kortsigtethed.
-Det er her, vi skal bekæmpe de ideologiske rødder til wahabitternes fundamentalisme.
-På mange måder er kompromiset imdlertid en fortsættelse af de samme gamle ting.
 Så lad mig se tilbage på noget af den omtumlede historie.
 Den særlige forenklede registreringsprocedure begrænses til oral indgift eller udvortes brug.
 Kære kolleger, jeg har ikke tænkt mig at adlyde.
@@ -5068,29 +4210,18 @@ Men vores kansler er nu heller ikke kendt som landmændenes ven!
 Reetableringsordninger er allerede gennemført i mindst fem medlemsstater.
 Det lyder ret usmageligt i mine ører.
 Vi kan ikke durkdrevent skubbe det til side.
-Det var især betænkningen om markedsføring af plantebeskyttelsesprodukter, der bragte sindene i kog.
 Områderne kan ikke beskyttes, hvis de er ubeboede.
-Flynn, det skyldes ikke, at jeg er ordstyrer.
 For de voksne ål forholder det sig ikke meget bedre.
 Der sås ingen svindel eller vold.
 Som landmand er jeg overbevist om, at fiskemel ikke hører hjemme i drøvtyggeres trug.
-Nobilia for hans betænkning.
 Heroverfor tager de små highlights sig kummerlige ud.
 De svarer teoretisk og upersonligt.
 For det første er der målvirksomhedernes størrelse.
-Cabrol har stillet, sikrer, at disse sikkerhedskrav opretholdes.
-Rapporten om shortsea shipping påviste dette.
-Deutsch, der udarbejdede betænkningen.
 Den nuværende måde at holde burhøns på kan absolut forbedres eller skiftes ud.
 Jeg mener, at de transatlantiske forbindelsers duelighed løbende bliver sat på prøve.
 Under demonstrationen kom tre demonstranter med bannere ind i mødesalen.
 Skal vi anvende ukvalificerede arbejdere for at opnå bedre resultater?
-Pactio olisipiensis censenda est!
 De ubeføjede klager er faktisk meget vigtige, og vi vil forsøge at reducere dem.
-Gorostiagas venner sender dem til.
-Det er derfor, det er så vigtigt at etablere et europæisk økobeskatningssystem.
-Det er endvidere nødvendigt med flere særaktioner for at ændre mentaliteten.
-Det er flere gange blevet sagt, at justice delayed is justice denied.
 Hacking truer private og offentlige net.
 Sikkerhedsnettet inden for kontrol af lægemidler er finmasket.
 Landet isolerede sig og blev isoleret, da hegnene omkring det blev højere og højere.
@@ -5098,56 +4229,39 @@ Vi bevæger os på en meget smal sti i denne diskussion.
 Euroens indførelse udelukker enhver letkøbt politik.
 Daphne er en hjælpeforanstaltning, som gør det muligt for os at kæmpe mod problemet.
 Emnet ægdonationer omfatter nogle meget komplekse moralske overvejelser.
-Kuhne for deres omfattende rapporter.
-Nordmændene dyrker laks ved udmundinger af de elve, som har naturlaksebestande.
 Af denne grund synes vi, at denne lakune skal udfyldes.
 Tingene vil ikke gå godt med de nuværende målprocenter.
-Den metode, vi har, er best practice.
-Pacta sunt servanda er ikke noget carte blanche til et efterfølgende spil tarok!
 Hvorfor er samfundet så sygt?
 Det drejer sig først og fremmest om beskyttelse af småinvestorer.
 Som ordfører har jeg foreslået at firdoble det beløb, der skal afsættes på fællesskabsbudgettet.
-Det spreder usømmelighed og vulgaritet.
 Efter denne husransagning har det belgiske politi egentlig ikke fremsat konkrete anklager.
 Ja, jeg ved, at det er et oxymoron.
 Det gælder virkelig om at have antennerne ude.
 De tror, at det også betyder, at kedlen er sikker.
-Det forklarer, hvorfor man ikke finder femhundredeurosedler blandt de forfalskede sedler.
 Europa er ved at blive gammel og gråhåret.
 Desuden har flere programmer lidt under manglende målopfyldelse.
-For det tredje at beskytte miljøet og spare energiressourcer, fordi omfanget af tomkørsel mindskes.
 Som vi har hørt her, er der også behov for isforstærkning i visse havområder.
-Den sygdomsfremkaldende faktor har været af idemæssig art.
 Standarderne har været gældende for alle personbiler uafhængigt af deres cylindervolumen.
 Først om lørdagen får vi så den lækre steg af rigtigt kød.
 Vi krævede ikke, at de blev kendt ugyldige, vi krævede ikke et omvalg.
 Det er en indsats, der fortjener vores fulde opmærksomhed, energi og snilde.
 Det europæiske område er derfor det ideelle udklækningssted.
 Mange kenyanere er bortdrevet fra deres hjem, som efterfølgende er blevet brændt ned.
-Dette er næste afsnit af the never ending story om posttjenesten.
-Gaulieder anonymt er truet, det er alt sammen meget ubehagelige og kedelige ting.
 Svælget i levestandard mellem by og land vokser, og den miljømæssige belastning øges.
-Leadership opstår ikke af sig selv, men gennem overbevisning.
-Papoutsis, men at der endnu ikke er truffet afgørelser i disse sager.
 Hovedproblemet er, at retningslinjerne er ukendte, og ikke webdesigneres eventuelle uvilje.
 For øjeblikket opererer vi i et meget godartet økonomisk miljø.
 Modstand alene og egocentrisk forsvar af ens eget territorium er ikke tilstrækkeligt.
 Her er det snarere burindustriens interesser, der ligger bag.
 Vi var hurtigt ude med at opdele landet i provestlige og proøstlige.
 I praksis støder mange kvinder stadig hovedet knaldhårdt mod det såkaldte glasloft.
-Beaupuy for den glimrende betænkning.
 Beograd skal omgående tage kontrollerbare skridt til en løsning af konflikten.
 Vi støtter demilitarisering og overholdelse af folkerettens principper.
 Urteekstrakter, aminosyrer og vigtige fedtsyrer anvendes også i kosttilskud.
 Derved kan menneskene blive ufølsomme over for humane antibiotika.
-Det såkaldte one man start up er et meget vigtigt anliggende.
-Jeg mener principielt, at der er brug for flere elementer for at inddæmme terorrismen.
 Sådan skaber man ikke fred, kun hadske fjender.
 Niveauet af kommerciel erfaring her i salen er jammerligt.
 Imiteret ost, kød med klister og vaniljeyoghurt uden vanilje er blot et par eksempler.
 Det er ikke et udtryk for vrangvillighed, men er situationen.
-Det er meget kontroversielt i medlemsstaterne, meget få støtter en sådan nødmekanisme.
-For toethalvt år siden begyndte arbejdet med dette.
 Det skal skabes, det kan ikke beordres.
 Forsimplet oppiskning af stemningen, ja tak.
 Hvad er meningen med beslutningsforslagene i morgen, hvis det ikke er politisk rænkespil?
@@ -5155,33 +4269,22 @@ Google vil åbenbart være mindre ond fremover.
 Jeg smigrer ikke, jeg mener det faktisk!
 Hvordan skal man kontrollere, om denne logbog er korrekt?
 Jeg håber så sandelig, at samtlige kysstater bakker op om initiativet.
-Betænkningen anbefaler, at tørvindustrien tilføjes til denne cluster.
 Oldtidens grækere var allerede klar over betydningen af opdragelse til statsborgerskab.
 Den omfattende uddeling af brochurer trykt på glittet papir har ikke kunnet udligne det.
-Lissabontraktaten kan ikke være et mantra.
-Batom blev slæbt ud af sin bil og gennembanket alvorligt.
 Birgitta er også en svensk skytshelgen.
 Dette direktiv har, som en række kolleger har sagt, en meget langsom lunte.
 Sådan ser det ud efter en første præliminær beslutning.
 Vi fanger flere millioner ton sandål og renser havbunden, og torsk æder sandål.
 Derfor brugte jeg et adjektiv, som måske er lidt stærkt.
-Disse initiativer kan naturligvis ikke i sig selv løse det specifikke problem med alcopops.
 Men desværre bliver højt begavede piger allerede meget tidligt overset.
-Er ibrugtagningen af de nye domænenavne .bytes, .info og .pro blevet forsinket?
 Derfor er en udifferentieret løsning uanvendelig.
-Chesnot, og deres syriske chauffør samt de to italienske hjælpearbejdere, frk.
-They are ready to renationalize.
 Demonstranterne brugte i den forbindelse enorme lydanlæg, nærmere bestemt højttalere.
-Lad os ikke forveksle behovet for en fælles ramme med egalitarisme.
-Cashman med denne betænkning, som jeg med glæde støttede i dag.
 Piloterne, teknikerne og de øvrige fagmænd besidder uundværlige erfaringer på området.
 Mange irske bataljoner har gjort tjeneste i de europæiske stormagters hærstyrker gennem årene.
 Her bliver det tydeligt, at det er ren makulatur, et tågestrejf.
 De er vigtige for en bys attraktion.
 Dette bringer den nordiske pasfrihed i fare.
-Krahmer, det er selvmodsigende at sige, at de ikke også må modtage statslige midler.
 Men da vi var rejst, blev befolkningen alligevel jaget af proindonesiske militser.
-Pittella har udført som ordførere for budgettet.
 Ligeledes bør grunduddannelsen bidrage til at øge alsidigheden i kvindernes fagkundskaber.
 Denne proces omfatter halvkriminelle i ledtog med landets politikere, der snyder iværksættere.
 Det er det rene og skære vås.
@@ -5191,41 +4294,28 @@ Energieffektivitet i dækfremstillingen må ikke få lov at gå ud over sikkerhe
 Jeg håber, at disse bål ikke længere vil være nødvendige i fremtiden.
 Vi viger heller ikke tilbage fra at vaske vores skidne linned i andres påsyn.
 Forskning i optimering og fordeling af dividenden er et andet vigtigt spørgsmål.
-Lamy, er hverken sko eller skruer.
 Der er ikke talt om simpelt gætværk.
 Den pyrenæiske bjergged er forsvundet for altid.
 Hvad skal sømænd, piloter, chauffører, vagtlæger og ansatte på tankstationer så sige?
 I praksis våger medlemsstaterne jaloux over den nationale og regionale kultursuverænitet.
 Vi har ikke brug for dråben, der får bægret til at flyde over.
-Superkreditter, indfasningsperioder og pooling udvander en allerede i forvejen svag grænse.
-Eisma understregede var vigtige for deres stillingtagen, og jeg nævner dem.
-Ingen indgreb i menneskets germinallinje.
 Det gælder både østover og sydover.
 Der må dog tilføjes et stænk realisme.
-Rahed er dybt fortvivlet og befinder sig i det center, vi besøgte.
 Der manglede kun englevinger og harpeklang for at gøre det perfekt.
 Det vil sige den neoliberale dagsorden fuld af almindeligheder og sød tale.
 Det har visse omkostninger at sikre en grundlæggende standard for fodtøj.
 Jeg spørger mig selv om, hvad der er i gære?
 De er umoderne og afspejler ikke længere virkeligheden i sektoren for finansielle tjenesteydelser.
 Kommissionen bærer virkelig det afgørende ansvar for, at denne bommert er blevet begået.
-Der er således arbejde nok til en space advise group.
 Vi bør altså selv smøge ærmerne op og forbedre vores behandling af dette emne.
-For det første er der den globale sundhedsfond mod aids, tb og malaria.
-Jospin sagde sidste uge meget rigtigt, at denne multilaterale investeringsaftale ikke kan reformeres.
 Rådets føromtalte fælles holdning giver den britiske regering medhold.
 Computervirusser, spammail, phishing og trojanere er reelle trusler i de virtuelle datas verden.
-Denne adventive kontaminering kan finde sted under dyrkning, høst, transport, oplagring og forædling.
-Endelig, lykkelige magtesløshed, felix culpa , der sparede os for en sådan fornedrelse!
 Det er vigtigt, at regeringen arbejder på at opbygge en ægte upolitisk statsforvaltning.
 Lad os vogte os for særheder, som er på grænsen til at være fornærmende.
-Kolima, , som viste, hvad den grusomste politiske ideologi er i stand til.
 Corrie og andre, som har nævnt denne misforståelse.
-Dette kan have en særdeles positiv virkning på short sea shipping.
 Den vigtigste kilde til indtægter forventes at blive royalties fra ophavsrettigheder.
 Der er ikke nok brød og marmelade til dem alle.
 Kommissionen må ikke smyge ansvaret af sig.
-De eneste, som stønner over europæiske sucesser, er europæerne selv.
 De ændres under gæringsprocessen og udskilles eller filtreres fra på naturlig vis.
 Disse måneder har været indholdsrige i det internationale panorama.
 Disse små og mellemstore virksomheder skal vi hæge om, fordi de sikrer innovation.
@@ -5234,64 +4324,45 @@ På hvilket grundlag betragtes de som sikre til drift i tætbefolket bymæssig b
 Produktionen af organisk gødning, gylle og slam falder endvidere ikke ind under dette direktiv.
 Vi er det eneste politiske niveau, der har et nulbudget.
 Det er ulykkeligvis især utallige kvinder, som er ofre for denne gemene handel.
-Brazzaville har i de sidste seks dage oplevet rædsler.
 En anden følge for østater er, at flyveomkostningerne kunne stige.
 Med dem ved roret styrer vi direkte mod afgrunden.
 Det er en skam, at der først skulle være en sky.
-Denne reform har primært været til gavn for den store vinindustri samt nogle importører...
 Man skal også være forsigtig med kalcium, og det skal folk som mig vide.
 Der foreslås en europæisk kampagne for at fremme anvendelsen af træ og trævarer.
-Kan vi stadig bruge deca på en fornuftig og seriøs måde?
 Det er vist den korrekte fagterm, der skal benyttes på det sted.
 Det er blevet genstand for sladder, det må ikke få et dårligt ry.
-Wohlfart, som jeg gerne ville have ønsket en god jul og et godt nytår.
 Papæsker og kartoner indsamles og genbruges ofte lokalt for at undgå mange unødvendige transporter.
 Unionens landbrugsudgifter står i tider med slunkne kasser stærkere i folks bevidsthed.
 Det er derfor vores generations fælles opgave at kvæle antisemitismen i dens vorden.
 Myrdende, brændende og deporterende har militserne efterladt landet i et udplyndret og udbrændt kaos.
-Roszkowskis bemærkninger op og fremlægge nogle få kendsgerninger og tal.
 Den aktuelle trussel om en muteret fugleinfluenza viser, hvilken rolle industrien skal spille.
 Ja, vi har brug for kvinder i topjob, men vi må ikke glemme fattigdom.
 Republikkens præsident kan absolut ikke deltage i udfærdigelsen af procedurer og lovdekreter.
 Vi har naturligvis også et par bønner.
 Og det viser hans fleksibilitet, hans politiske tæft.
 De gør det ikke af godgørenhed.
-Christodoulous kvalitetsbetænkninger.
-Det vil jeg gerne kort begrunde endu en gang.
-Madolie ses som et problem efter de seneste års dioxinskandaler.
 Der er børn, der tilbringer flere timer om dagen med at surfe på internettet.
-Giscards forfatningsudkast kan ses som et stort flyttefirma.
 Den samfundsmæssige situation er uklar, og udviklingen af demokratiet går pinagtig langsomt.
 Fodringen af planteædere med kødmel skal principielt forbydes.
 Uregulerede markeder har fået ufiltreret sponsoreret adgang til formelle handelscentre.
-Kashmir tilhører først og fremmest det kashmiriske folk.
 Man sætter lås for sin mund og skyder sig i foden.
 Har ankomstlandet infrastrukturen til at lægge et skib i tørdok osv.
 Disse svenskere synes at være lidt pylrede, lidt hypokondriske og overfølsomme.
 Det pinte mig imidlertid, at forslaget blev forkastet, men det overraskede mig ikke.
 Vi har også satset på evolution frem for revolution.
 Darwin kaldte det naturlig udvælgelse.
-Duisenberg vil dementere pressemeddelelser om, at hans løn skal behandles som en statshemmelighed.
-Casaca, med denne udmærkede betænkning.
 Seychellernes økonomi bygger hovedsageligt på turisme og fiskeri.
 Vedtagelsen af teksten med akklamation har en særlig betydning.
-Her skal man lede længe efter bottom up governance.
 De anholdes, afhøres og idømmes fængselsstraffe.
 Forvirringen i geledderne er stor.
-Forvirring og malthusianisme kører showet.
 Jeg beklager, hvis jeg var lakonisk.
 Unge landmænd er landbrugserhvervets fremtid og vitale for bysamfundene.
 Vi kan ikke nøjes med at stirre på billedet af nutiden.
 Rusland blev regeret af zaren.
 Folkenes selvbestemmelse er et ubrydeligt princip.
 En regnskabsmæssig dumhed i min valgkreds har straffet mine landmænd urimeligt.
-Det er ikke noget, som er udtænkt i en machiavellisk kommissærs hjerne.
-Ssidstnævnte er principielt meget væsentligt.
-Hughes, at spørgsmålet om hjemmearbejdspladser vil være behandlet heri.
-Abyeis status er fortsat usikker.
 Rådet er døvt over for befolkningernes forventninger.
 Det er en cadeau til formandskabet.
-Asturisk og aragonsk anerkendes slet ikke.
 Det får os til at frygte, at hans cirrhose er forværret.
 Alt, hvad jeg kan sige til det, er bvadr.
 Alligevel er midaldrende og ældre kvinder fortsat mere plaget af sundhedsmæssige problemer end mænd.
@@ -5302,21 +4373,15 @@ Hæren og militæret kastede sig ud i den mest sadistiske form for brutalitet.
 Kodeksen er, når alt kommer til alt, det parlamentariske demokratis abc.
 Her fanger vi bare rotter og mosegrise frem for vilde dyr med smukke pelse.
 Derfor er vi nu nødt til at lovgive om lægemidler til pædiatrisk brug.
-Det btyder, at vi helt klart stemmer nej til de to fremlagte betænkninger!
 Med nye testformer er tarmkræft et nyt screeningsområde.
 Det er jeg revnende ligeglad med.
-Techkowskis udtalelse viser, hvor langt ultranationalistiske forvanskninger af virkeligheden kan gå.
 Ikke desto mindre bruger de fleste af dem limousiner med privatchauffører og undgår sporvognen.
 Det er virkelig pindehuggeri.
 De befolkninger, som ilede til hjælp, må ikke tillade, at det sker.
 Vorherre bliver spurgt, om det er passende at betale skat til den romerske kejser.
 De ved alt om de beslutninger, vi træffer bag deres ryg.
 Det betyder, at klyngedannelse, en koncentration af virksomheder i topregioner, er udmærket.
-Cox igennem fem år har vist os.
-Kommissionen foeslår ligeledes, at medlemsstaterne samarbejder om disse ting.
-For det tredje er der spørgsmålet om trihalomethaner.
 Dette er ikke ensbetydende med en omgørelse af afskaffelsen af de nationale grænser.
-Alle har skullet givr indrømmelser.
 Derfor opfordrer jeg alle til at give udvalget et rap over fingrene.
 Isklassificeringen skal også tages i betragtning i den sammenhæng.
 Vi konstaterer også, at byzonerne i nærheden af lufthavnene udvides.
@@ -5324,22 +4389,14 @@ Men for osts vedkommende har prispolitikken via restitutionstilpasninger medfør
 Vi bør derfor bevare en agnostisk, kritisk holdning.
 De vil sikre, at madaffald omdannes til energi gennem anaerob nedbrydning.
 En del af siruppen havnede hos sodavandsproducenter.
-Fava og undertegnede har stillet.
 Når man shopper, går tingene ikke altid, som de skal.
 Vi stemmer imod denne nye ode til liberalismen.
 Af praktiske årsager er det nødvendigt, at vi også fremover kan anvende russiske togvogne.
 En krage hakker ikke øjet ud på en anden krage.
-Arbejdstagerne vedtager ved urafstemning de forhold, som de ønsker at arbejde under.
 Der er også et presserende behov for en grundlæggende omvurdering af den politiske situation.
 Det drejer sig om løsarbejde med usikre ansættelsesvilkår.
-Der vil være yderligere halvanden mia mennesker på jorden om tredive år fra nu.
-Leopardi siger i sin fremragende betænkning, et sted i beslutningsforslaget.
-Sådan som det ser ud nu, har jeg stadigvæk problemer med caching.
-Der er talt meget om en såkaldt steering committee.
 Det virker adlende at befinde sig blandt de bedste.
-Elttrafik bør spille en nøglerolle i fremtiden.
 Bæredygtigt skovbrug vil gøre det muligt at producere energi på grundlag af træaffald.
-Vi skal sørge for, at netmaskerne justeres efter disse mindstestørrelser.
 Vi ved alle, at der findes forestillinger, hvor der anvendes falke og andre rovfugle.
 I dag holdes barnet så at sige over dåben.
 Hvis det er tilfældet, er det på høje tid, at der iværksættes en rigsretssag.
@@ -5348,67 +4405,45 @@ Krigsherrerne er de nye lensherrer.
 Nu da prisen på en tønde olie er steget, bør der være betydelige ressourcer.
 Det er ikke så mærkeligt, at menneskesmuglerne ler hele vejen til banken.
 Hvilke lyksaligheder er der for øvrigt tale om?
-Pinheiro, at han foretrækker andre samlivsformer end ægteskabet.
 Tadsjikistan har stadigvæk træk, der ikke hører hjemme i en demokratisk retsstat.
-De vil kun bemyndige nogle konkrete godkendte organer til at foretage nyvurderingsaktiviteterne.
-Cravinhos seneste besøg fortalte vi, hvornår de næste betalinger kan forventes.
 Ståstedet, det er midlerne.
 Hendes evaluering giver indtryk af, at situationen er noget broget.
-Aznar tilsyneladende er kommet med, sotto voce, men for åben mikrofon, om dette møde.
 De døde lå på gårdspladserne, og til slut blev de i deres hytter.
 Uddelingen af foldere er vel ikke for meget forlangt.
 De europæiske borgere bør ikke betale prisen for erhvervsmæssig og politisk gambling.
-Opiater såsom heroin er den egentlige årsag til de fleste narkotikarelaterede dødsfald.
 De er en delløsning, men de bør aldrig betragtes som hele løsningen.
 Jeg vil gerne udtrykke min respekt for mine medkandidater, som stiller op som gruppeformænd.
 Efter min mening har den egyptiske regering en vattet holdning.
 Der skal naturligvis stå kaptajnens, ellers bliver det noget vås.
 Men som årene er gået, er de sunket dybere ned i ulovlighedens sump.
-Der findes direktiver, som har til hensigt at forbedre dyrvelfærd under transport.
 Kvinder er uerfarne som iværksættere og mangler oplysninger om finansieringsmulighederne.
 Æbler, pærer, ferskner og nektariner
 Vi kan ikke lukke kulkraftværker eller kulminer fra den ene dag til den anden.
-Audy, der har gjort det fremragende.
 Et tredje vigtigt ændringsforslag vedrører byjeeps.
 For det andet skal vi samle rumindustrien.
-Dengang var det indførelsen af sharia i flere nordlige stater, som var detonator.
 Jeg mener, at vi står over for en kulturrevolution, der bevirker dette omslag.
 I virkeligheden var den en gammel krikke.
 Undersøgelsesudvalget fandt, at overvågningssystemet inden for forsendelsessektoren var arkaisk.
-Do not pick the winners and let the winners pick.
 Selv om mange frøer kvækker, så er det stadigvæk kvækken.
-Symmetry skal derfor iværksættes så hurtigt som muligt.
-I flere år er antallet af nysmittede steget med alarmerende hastighed.
 Havde denne fasan måske spist defekt korn, eller var det genetisk modificeret majs?
 Det kan jeg kun beskrive som satire ført ud i det virkelige liv.
-Men det var ikke kun et nødråb fra nogle få poujadister.
 Nogen siger, at regeringskonferencens deltagere aldrig vil blive enige om dette eller hint.
-Fohandlingen er afsluttet.
 Under disse omstændigheder var fristelsen til at give løssluppen kapitalisme frie tøjler for stor.
 Deres gæster vil vide, at de er velrepræsenteret.
 Parlamentet stiller sig tilfreds med en kødløs og nytteløs beslutning.
 Også den næste traktat rummer reminiscenser fra de gode gamle nationalstater.
-Kyprianou, går det meget langsomt med opbygningen.
-Vi skal bruge det imod udvanding fra velmenende godhedsapostle.
 En sådan opdragelse fremmer udviklingen af narcissisme og selvoptagethed.
 Det er jo ikke uden grund, at dyr opdeles i brugsdyr, avlsdyr eller kæledyr.
 Vi skal stræbe efter at opnå national udsoning.
 Ingen af disse medlemsstater kan fortælle os, hvor øksen skal falde.
 Vi foretager ikke omafstemninger.
 Ville variabel geometri ikke være en mere passende løsning?
-Lieses vedholdende indsats.
 Vores samfund blev skabt under indflydelse af de jakobinske stater.
-En sådan systematisk followup er nødvendig.
-Dengang ville det have været business as usual.
-Der er altså udarbejdet et framework , det vil sige nogle generelle rammer.
 Man har ganske vist indrømmet nogle fejl, men den klare vedgåelse mangler stadig.
 Gældende ugandisk lovgivning kriminaliserer allerede homoseksualitet.
-Hutuerne var under deres kontrol.
 Det er for små drenge, som sammenligner deres muskler, men ikke for borgerne.
 Han mente, at vi er lidt for fikserede og enøjede.
 Vi ville ikke have lucerne, som indgår i kvægfoder.
-Oettinger, mine damer og herrer!
-Her drejer det sig imidlertid om andre dyspraxi.
 Knessets godkendelse er en positiv handling.
 Vores store problem er immobilitet.
 Jeg ville være dum, hvis jeg rakkede ned på denne holdning hos nogen.
@@ -5416,150 +4451,100 @@ Hele den fælles landbrugspolitik er et absurd påfund og skal afskaffes.
 Parlamentets årsberetning er dog speget.
 Det har anrettet store skader på miljø, turisme og landbrug.
 Det portugisiske formandskab er lige begyndt, men har allerede afsat et uudsletteligt mærke.
-Edinburghaftalen, som er en international aftale, er også en del af referencegrundlaget.
 Jeg vil også gerne takke ordføreren i den bayriske dragt.
-Becsey, for hans indsats i forbindelse med spørgsmålet om merværdiafgift og de relevante dokumenter.
 Desuden modsætter vi os en udvidelse af direktivets anvendelse til andre vandaktiviteter end badning.
 Maldiverne kommer delvis til at forsvinde, hvis vi ikke kan løse klimaproblematikken.
 Kultur er altid et tveægget sværd, og det er det, der er særligt interessant.
 Det førte til ugelange ophedede offentlige debatter.
 Kan vi følge denne hastige udvikling, når økonomerne spår os store vanskeligheder?
-Hæmovigilansnetværkene er et vigtigt værktøj for en maksimal sikkerhed i blodtransfusionskæden.
-Der bør heller ikke medtages henvisninger til opfedningsmetoder.
 Jeg vil ikke være apokalyptisk, og jeg vil heller ikke være demagogisk.
-Virgin for hans betænkning, hvis tanker og synspunkter jeg er absolut enig i.
 Unionstoget buldrer af sted uden hensyn til terrænet.
 Europa som gruppe må ikke lade sig kue af medlemsstaterne.
 Bestemmelser om hønsehold på friland mangler helt.
 Jeg vil gerne indrømme, at det ærede medlem har et udsøgt kendskab til vine.
 Vi sigter mod at få andragender, der har substans og er apolitiske.
-Vi hinker altid bagefter begivenhederne i vores naboskabspolitik.
 Europæiske kunstnere lever selv i de bedste tider ofte under beskedne kår.
 Derfor bliver de økonomiske partnerskabsaftaler også så usymmetriske og fremadskridende som muligt.
-På samme måde skal der tages henyn til forbrugernes ængstelse.
 Og det er blandt sådanne skarer af rodløse, at det islamiske parti trives.
 Men der bør mere eftertrykkeligt sættes ind over for hvervning af personer til jihad.
 Ariane er et støtteprogram for bøger og læsning.
 Menneskehandel er en af de hæsligste og alvorligste forbrydelser.
 Dog er der over for kreditsiden en debetside.
-Samhørighedspolitikken er afgørende for samfundene i de underudviklede regioner og delregioner.
 Jeg får endog at vide, at dette er kutyme.
 Samme dag angriber kampvogne hospitalet og ødelægger iltapparatet.
 Endelig sætter vi fødderne på det forjættede land.
-Jasminrevolutionen handlede i høj grad om værdighed og lighed.
 Udnyttelsen af kul kan også omfatte ukonventionelle metoder til underjordisk kulforgasning.
 Bosættelserne skal rømmes.
 Dette direktiv omhandler især strålekilder såsom lasere og infrarøde lamper.
 Men ak, de mange ekstremister opbygger forhindringer.
 Det er virkelig kun en rigtig snue, ikke en politisk snue.
 Et af problemerne er rydning af maki.
-Breyer også understregede.
 Det glæder mig, at vi kan sige velkommen til en ny kvinde på podiet.
-Vi ønsker ikke at leve under et dikatur, heller ikke under et teknokratdiktatur.
-Denne ublu hæmningsløshed er ikke kun permanent, den får faktisk større og større omfang.
-Ahtisaaris bestræbelser uforbeholdent.
 Fernandes har redegjort godt for denne.
-Zaleski lyttede ordentligt til mig i går.
 Men vi har altså vores to pygmæer.
 Den har først og fremmest ramt roeproducenterne og de ansatte på sukkerfabrikkerne.
 Nye arbejdskoncepter blev introduceret abrupt, koncernen blev overcentraliseret.
-Projekterne skal også være tilgængelige på de eksisterende søruter.
-For det første afkobling, decoupling.
-Kirker blev skændet, og vejsidekors og helgenstatuer blev beskudt.
 De to største grupper foretrækker langt et topartisystem.
-Local work for local people using local resources betyder først og fremmest tjenesteydelser.
 Alt for mange instanser er involveret, og nogen skal tage teten.
 Khartoum har protesteret mod denne overførsel og råbt op om et vestligt komplot.
 Kompromissystemet vil ikke gøre det muligt at spore det enkelte fårs bevægelser.
 Det var mere en meget generel udveksling af synspunkter, en slags brainstorming.
 Landbrugsgeneraldirektoratet trænger ganske givet til en ordentlig udluftning.
 Tysklands medlemsindbetaling falder på årsplan med ca.
-Deployeringen af tropperne fortsætter efter planen.
 Ufine metoder tåler ikke dagens lys.
 Formand, jeg finder dette uelegant.
 Blanke eller udgyldige stemmer tages ikke i betragtning ved stemmeoptællingen.
-Jinnah ville være blevet chokeret, hvis han havde levet i dag.
-Buddhismen og jainismen udgør begge en del af den indiske tradition.
-Dette er helt uholdbart, hvis vi skal have en fælles øresundsregion.
-Cappatos retorik lyder altså fuldstændigt falsk.
 Denne omfatter incest, børns vold mod deres forældre og omvendt.
-Antonione for deres indsats.
 Hvem skal have det næste hug?
 Vi ved også, at de mobbede er mere udsatte for stress end andre.
 Hvis det var mænd, der blev gravide, ville abort være et sakramente.
 Cigaretter med et lavt tjæreindhold er lige så skadelige som andre cigaretter.
 Særlig de, der taler urbefolkningens og de fattige samfunds sag, løber en stor risiko.
 Det ville have vakt furore.
-Men her har også altid være medlemmer af det andet bøhmiske folk, sudetertyskerne.
 De ender som fyld i ravioli eller som bouillonterninger.
 Vores kontorer har ingen temperaturstyring eller individuel indstilling af varme og aircondition.
 Der bliver tale om en treleddet repræsentation, som også påpeget af ordføreren.
 Som jeg sagde, er vi ikke gode feer.
 Den emmer af opgivenhed og mangel på entusiasme.
-Vi deler mange synpunkter om dette spørgsmål, og det er et godt udgangspunkt.
 Det er tragisk, at der findes så megen olie i jorden omkring ækvator.
-Tiden er ikke inde til at lege med ægproducenterne.
-Man har vedtaget, at sønderrivning af sener, ledbånd og væv altsammen er acceptabelt.
 Hvordan kan voksne mennesker behandle børn som forbrydere, inden de overhovedet har nået puberteten?
 De dulmer symptomerne, men helbreder ikke sygdommen.
-Fleckenstein, og hendes projekt har vundet en europæisk pris.
-I den sammenhæng synes jeg, at henvisningerne til økokonditionalitet er meget interessante.
 Men hvordan ser det ud med formidlingen af erhvervskvaliteter til unge kirgisere?
 Vi vil drage et lettelsens suk efter otte års tilbagegang.
-Dauls beslutningsforslag, og det vil jeg gerne takke ham for.
-De største risici er rabies, echinococcose og sygdomme, der overføres via mider og flåter.
-Vi husker stutteriforeningerne og golfklubberne og alt det, der følger med.
-Der er stor forskel på transgenese og cisgenese.
 Kommissionen har kvajet sig i denne sag.
 Kvæget brændes efter slagtningen, hvorefter asken henkastes på lossepladser.
 Vi skubber store beløb frem for os som med en stor sneplov.
-Hr.formand, jeg har kun tre kommentarer til denne debat.
 Vi har andre strande, der endnu ikke har fået denne akkolade.
 Trotskisterne blev, om ikke voksne, så dog ældre.
-Endog ikke den amerikanske udenrigsministers mægligsforsøg har kunnet åbne patstillingen.
 Svage foreninger får flere lodder og har dermed større chancer end topklubber.
 De forsøger simpelthen at anbringe en firkantet pæl i et rundt hul.
 Billeder af sultende mennesker og døende børn går dagligt verden over.
 Det betyder rent ud sagt, at alt for øjeblikket kører i tomgang.
 Det er logisk, at dette paradoks beskæftiger de tyske gemytter meget.
-Gangesdeltaet stiger som følge af alluviale dannelser.
-Grænseværdier for benzen og carbonmonoxid
-Praeterea censeo constitutionum esse repudiendam.
 Bomberne splintrer de flere cm tykke armerede plader på de fleste moderne kampvogne.
-Sakchai er en ny skotte og en ny shetlænder.
 Vi er ikke en fanklub i dag.
 Uddannelse, mobilitet og muligheder på arbejdsmarkedet danner i stadig højere grad en kausal kæde.
 Hitler blev gudskelov besejret og måtte aflevere sit bytte.
 Pengene ville være blevet frataget fodbolden, hvis der var blevet ikendt en større bøde.
 Medierne bugner med detaljer om dette vidt forgrenede elektroniske overvågningsnetværk.
 Køberen, forbrugeren af sådanne sjofle ting skal også kunne forfølges strafferetligt.
-First things first, siger man på engelsk.
-Janjaweed er ikke blevet afvæbnet.
 Denne bestemmelse er den eneste måde at håndhæve forbuddet mod store pelagiske drivgarn på.
 Tilskyndes de til at blive blikkenslagere og tømrere?
-Jeg kan blot nævne køomkostningerne som eksempel.
-Pasqua og adskillige andre talere var inde på.
 Det er let at fastslå, om en person er smittet med syfilis.
-Sasi bekræfte, at formandskabet vil udarbejde en sådan formulering?
-De ved, der i denne sammenhæng er fortsatte vanskeligheder med pashtunerne.
 Jeg har nævnt nødhavne og sikre kajpladser i en af mine tidligere betænkninger.
 En fjerdedel af skolerne har ikke vand inden for gåafstand.
 Der er også meget alvorlige miljømæssige følger mv.
 Olssons og mine synspunkter på dette område.
-Lehtinen og skyggeordførerne for det gode samarbejde gennem de seneste måneder.
 Vore bestræbelser i den henseende ænses knap nok i de internationale medier.
 Først og fremmest er årsregnskabet for tredje år i træk blevet påtegnet uden forbehold.
 Kommissionen taler om, at produktionen skal sættes ned, så overproduktion og kødbjerge undgås.
 Det var drømmen om et samfund, hvor hudfarven ikke medførte nogen diskrimination.
-Souchet, som nævnte halvledere.
-Jeg vil imidlertid også gerne bede om, at vi angriber alle disse problemstillinger udogmatisk.
 Jeg bifalder hans afpudsning af det franske forslag.
 Dette er imidlertid en jastemme med et klart forbehold.
 Euroens troværdighed og internationale rolle, navnlig over for dollaren og yennen, afhænger heraf.
 Tidligere hang klasseskel sammen med mængden af ejendom eller penge.
 I de sidste enogtyve år gennemførtes der kun tre europæiske direktiver om samarbejdsudvalg.
 De burde egentlig hives i retten for dette.
-Prissætningen på elektricitet, hvor engrospriserne for el fastsættes af elbørser, bør revurderes.
 Vi taler derfor om valnødder, hasselnødder, mandler, pistacienødder og kastanjer.
 Han insisterede på selv at give hende løkken om halsen.
 I byerne skjuler der sig forfald, misrøgt og fattigdom bag de monumentale facader.
@@ -5567,65 +4552,41 @@ Men nu er ærtedyrkningen i tilbagegang.
 Dette er snarere guf for satirikere end for politikere.
 Der er navnlig tale om madæbler.
 Plantningen af roer forberedte jorden og gjorde den bedre egnet til korn.
-Havulykker udgør imidlertid en del af den fælles havpolitik.
-Helkropsvibrationer kan føre til lænderygsmerter, diskusprolaps og tidlig degeneration af rygsøjlen.
 Det er endnu mere vigtigt, da de forsøger at gyde olie på vandene.
-Osvaldo selv er på fri fod, og hans familie chikaneres dagligt.
 Godt halvdelen af verdens befolkning i dag lever i områder med seismisk aktivitet.
 Columbia er en strategisk partner for os.
 Dagens forbruger presses til at lave maden hurtigt.
-Via denne vil større selektivitet i fiskeriet og beskyttelse af ungfisk blive sikret.
-Den anden betænkning, som jeg her præsenterer, hænger sammen med denne frøhandelslov.
 Den økonomiske afmatning forværrer de kommende perspektiver for de unge, navnlig dimittenderne.
 De døde på grund af dehydrering.
-Djakourmas løslades hurtigst muligt.
 I nogle tilfælde er der tale om tocifrede procentvise nedskæringer.
 Ukontrollable kropsfunktioner kan være en meget ubehagelig oplevelse i en rumdragt!
 Jeg mener, det er meget godt, at politikken på denne måde bliver lutret.
 Det væsentlige er for mig, at chaufførerne og læssepersonalet omgås roligt med dyrene.
 Agenturerne skyder imidlertid op som paddehatte.
-Målet er, at de små og mellemstore virksomheder skal vies særlig opmærksomhed.
-Den fælles markedsordning for råtobak
 Der er fem års balsamering for alle, der er færdige i deres eget land.
-Ungureanu med betænkningen.
-Der bliver endda argumenteret med schæchtning.
 Udvidelsen øger dette kravs aktualitet tifold.
 Jeg ville have adgang til mine mails.
 For disse lande blev krisen det sidste søm i kisten.
-Paasilinna udtrykke min anerkendelse af hans betænkning.
 Dette emne har livsvigtig betydning for de vælgere, der har sendt os herned.
-Fru formand, i går kommenterede jeg det kamarahold, der havde fået adgang til mødesalen.
 Netop inden for budgetpolitik gælder det om at udfylde disse tre grundprincipper med lødighed.
 Der er faktisk ikke berammet en dato for retssagen.
 Det er lykkedes ham at sy et holdbart kompromis sammen imod alle odds.
-Kom og se en cricketkamp og mød nogle almindelige mennesker!
 Skal de bare stuves ind blandt de millioner af arbejdsløse?
-I denne gruppe finder vi også de såkaldte au pairer.
 Sådan er det ofte med historiske nybrud.
 Denne betænkning dækker over et intellektuelt fupnummer.
 Flodens overflade er dækket af et tykt lag skum.
 Vi ønsker ikke smånusseri, men direkte handling så luftfartsindustrien kan overleve.
 På den måde kan misdæderne få løn som forskyldt.
 Der er en lang række hændelser og fejder.
-Det hedder ikke onthaalcentrum , men opvangcentrum på godt nederlandsk.
-Gazprom er ikke noget privat selskab.
-Bhopals indbyggere forsøgte at flygte fra den giftige sky.
 At gøre handel mindre usmidig er at gøre det økonomiske system mere effektivt.
 Han kan blive den nye vektor for fremskridt sammen med det arabiske fredsinitiativ.
 Den skal optjenes på en måde, som offentligheden kan acceptere.
 Uformel betyder på fransk misformet og ugraciøs.
-Lenins metode byggede på ligegyldighed, men resultatet var det samme.
-Suominen er fremkommet med.
 Uanset hvor fantastisk maleriet er, kan der aldrig blive røget på denne pibe.
-Der er andre udvalg, som har stemt imod ownership unbundling.
-Azambuja er jo et enkelt tilfælde, men det er repræsentativt.
 Dette oldnordiske papirnusseri koster både tid og penge.
 Derfor accepterer vi ikke, at forbrænding af usorteret husholdningsaffald skal have støtte.
 En udglatning af vores uoverensstemmelser vil være et vigtigt bidrag til begge økonomier.
 Det er kun lidt bedre end et ublodigt statskup.
-Finis forslag om at give stemmeret til tredjelandsstatsborgere.
-Ingen brain drain, men brain gain.
-Doorns indlæg, hvor der især blev lagt vægt på statsstøtten i de nye medlemsstater.
 Hvad der er endnu værre, er, at det er de diegivende moderfår, der forsvinder.
 Det samme gælder de franske og de socialister, der førte an i deres heppekor.
 Yd hjælp og fjern ikke børnene fra deres familier.
@@ -5633,37 +4594,25 @@ Men tjenere og barpersonale har også ret til livet og til sundhedsbeskyttelse!
 Er der måske en ny alarm om nye baciller, som spreder sig her?
 Babel vil utvivlsomt bygge sit tårn.
 Ja, det skal fordømmes, men enhver nyslået politiker kunne have forudset denne udvikling.
-Ordføreren har heller ikke fundet bevis på fumus persecutionis.
-Der er heller ikke angivet nogen scenarier for den sandsynlige fremtidige udvikling på bærmarkedet.
 I ordbogen betyder dette ord fuldstændig forvrængning.
 Følgerne af forbuddet mod subleasing må ikke undervurderes.
-Det vigtige i forbindelse med tildeling af lån er spørgsmålet om cash flow.
 Den keltiske tiger har længe repræsenteret fordelene ved konkurrencedygtighed og økonomisk disciplin.
-Nec spe, nec metu eller uden håb eller frygt.
 Vi har i de seneste år konstant hørt det omkvæd, at forvaltningen skal forbedres.
 Grækenland snød sig til euroen.
 Denne adskillelse skal bevares, og de to ting må ikke flettes ind i hinanden.
-Lax, som bidragede særlig aktivt til denne betænkning.
 Der er risiko for, at formandskaberne bliver toptunge overbygninger.
 Vi kan ikke sætte pigtrådshegn op.
 Forbrugerblade læses af mange, og de indeholder nyttige tip.
 Denne forordning rejser to hovedspørgsmål og en række bispørgsmål.
 Ingen levende organismer, fra mikrober til oddere, er blevet skånet.
-Pakningen skal indeholde korrekte oplysninger om thrombin, og mærkningen skal være tydelig.
-Det er efter min mening et ueuropæisk forslag.
 Der er kun nuller og ettaller.
 Denne århundreder gamle nation må da have andre fremtidsudsigter end sådan en trist diaspora.
 Det er i det mindste et mere interessant og righoldigt ideal.
-Flautre sagde, det, vi kan gøre, er en hjælp, men behovene er kolossale.
 Balfe samme dag gav tilladelse til medlemmernes medarbejdere til at gøre dette.
 Det foretrækker klikket fra en riffel frem for klikket fra et kamera.
-Nærkysttrafik skal derfor gøres enklere, billigere og mere transporteffektiv.
-Den bolsjevitiske ideologi benyttede metoder, der ikke på nogen måde kan berettiges.
 Jeg vil foreslå, at det ikke skal være mere end en gennemsnitlig årsløn.
-Orban, disse testprocedurer godt.
 Ønsker vi blot at jagte haren, eller vil vi gerne fange den?
 Jeg er imidlertid ikke enig i, at uldvarer skal gøres til genstand for overvågning.
-Coillte er et halvoffentligt selskab, som har til opgave at udvikle skovbruget.
 Hvor er de store mængder ubearbejdet mel, der er potentielt forurenet?
 Måske er denne reform også den sidste slurk af flasken.
 Kvinder bliver degraderet til råstofleverandører af ægceller.
@@ -5680,19 +4629,13 @@ Jeg bor på en halvø, så jeg forstår godt øboere.
 I øjeblikket rasler medlemsstaterne til en vis grad stadig med sablerne.
 Pasko har gjort det, som de institutioner, jeg nævnte, hele tiden taler om.
 Israel pulveriserer nu også disse stakkels mennesker med eksperimentelle våben.
-Det var nærmest en karbonkopitale.
 Det er denne usentimentale holdning, jeg har anlagt med hensyn til budgettet.
 Man vil måske kun indynde sig og blande sig lidt i folks hverdag.
 De må eje deres egen jord, deres hjem og deres gård.
-Hvad med dialogen mellem teistiske, ikketeistiske og ateistiske overbevisninger?
-Antwerpen fik ikke en chance trods mange forsøg på at finde en køber.
-Er der indsigelser mod forslaget om at gøre det en bloc?
 Sætningen er grammatisk forkert.
 Hendes snæversynede racistiske bemærkninger vedrørende adoption vil være svære at hamle op med.
-Algarve, der i år beskæres med ca.
 Det betyder, at amalgamfyldningerne står for den allerstørste del af udslippet til kloakkerne.
 Pigerne chatter, indgår i fællesskaber og sender tekstbeskeder, mens drengene spiller computerspil.
-Den arabiske verden har på ny hentet det økonomiske boycotvåben frem.
 Alkalisk hydrolyse er en af disse metoder.
 Spencer for at have fremført noget, der er soleklart for alle.
 Dette er ikke nogen kvasijuridisk kommentar.
@@ -5705,32 +4648,23 @@ Når dejen er klar, skal den formes for at blive til et godt brød.
 Man kan ikke få både i pose og sæk.
 Det betyder derfor, at disse områder hægtes af.
 Det er også en måde at forynge vores økonomier på.
-Lebedev, kan vi ikke have et godt og normalt partnerskab.
 Jeg stod og ventede et stykke tid og blev iskold.
-Det kan betyde, at ampicillin går tabt for altid som terapeutikum.
 Den bedste affaldsforebyggelse, kære kolleger, findes i disse produkters økodesign, som ændres.
-Scholz, har gjort for at nå frem til en aftale om dette forslag.
 Så går jeg over til at behandle gasolie og lette brændstoffer.
-Baldarelli, om for lidt siden.
-Det er de italienske myndigheders opgave at finde den opimale løsning på problemet.
 Sneen dalede ned i store fnug.
 Man kan ikke finde rundt i virvaret af overstregede budgetposter og fupoverskrifter.
 Man anerkender også modkandidatens sejr, når vurderingen af selve valgene er positiv.
 Man kan kalde denne tilgang for neoimperialistisk og revanchistisk.
-Linzer, for deres store indsats.
 For det andet spurgte jeg direkte om dialogen mellem kristne, muhamedanere og jøder.
-Vi ved, at relætolkningen nogle gange kan være et problem.
 Jeg er homoseksuel og opvokset hos en almindelig mand og kvinde.
 Han ville lytte til fuglenes og cikadernes koncert.
 Bonn har i sidste øjeblik givet det politiske signal, som var nødvendigt.
 Vi er meget optaget af geotermisk energi såvel som af andre vedvarende energikilder.
-Jeg håer, vi kan fortsætte på den måde.
 Hverken flertalsafgørelser eller kompensationer i huj og hast gør en uretfærdig behandling retfærdig.
 Vi endte rent faktisk med en niårig periode.
 De har ikke de samme nautiske kvaliteter.
 Man har set seniormedlemmer give sig af med dette, og ligefrem en tidligere formand.
 Det forekommer som om, at man nu taler om piratvirksomhed med en overdreven lethed.
-Det er da dårekistepolitik.
 Jesus siger, at sandheden gør os frie.
 Det er klart, at en diktator ikke kan kues af aggressive holdninger alene.
 Disse utaknemmelige opgaver overlader man så gerne til andre.
@@ -5741,7 +4675,6 @@ Vi skal ikke hoppe på limpinden.
 Vi taler således ikke kun om lytning og pleje, men også om egentlig praksis.
 D for demokrati og dialog.
 Forud for høringerne inden det seneste valg var ordet gennemsigtighed på alles læber.
-Wuermeling vedkommende, fordi han har forklaret dette komplicerede forslag i vores gruppe.
 De centrale aspekter i vores forslag er trefoldige.
 Albanerne var tilbagestående landmænd og hyrder, som ingen ville tage hensyn til.
 Det er unavngivne civile, der tilbageholdes af russerne.
@@ -5750,34 +4683,21 @@ Til gengæld vil jeg gerne skose de holdninger, der gennemsyrer dem.
 Jeg kommer nu tilbage til mine kuverter.
 Tillad mig som østriger at komme med et surt opstød.
 Fyr den næste, der lyver, i stedet for at fyre whistleblowere.
-Kinesisk ginsengrod eller indisk tetræsolie, mange borgere sværger til naturprodukter.
 Meddelelsen er også en guide til nye støttemåder, særlig budgetstøtte.
-Mange af disse mennesker ender desværre i hænderne på beduinske menneskehandlere.
 Bylden kunne være blevet tømt med det samme.
-Grundvandet er en vigtig naturressource, der bruges som drikkevand, i industrien og i ndbruget.
-Ikke desto mindre udelukkes de af uforklarlige åsager fra processen.
 Hvis jeg sammenligner denne forskningsrapport med den foregående, kan man ane en svag udvikling.
 Hov, jeg kan se, at jeg allerede har talt i fem minutter.
-Der planlægges en udvejsstrategi, så vi ikke længere behøver døje med genopretningsstrategien.
 Køretøjerne har kameraovervågning og klimaanlæg, og dyrene læsses med lift.
 Symbolets form er naturligvis statuerne, som også tjener som afguder.
-Cercas, for hans udmærkede betænkning.
 Men helten i den fortælling, som var en rigtig gnier, undergik en forvandling.
 Bristen lå i tilgangen til de mindre hårde safarigitre.
-Indien støttede kaftigt denne holdning.
-Desuden har vi en poloniumsag.
-Det anvendelsesområde, som vi havde foreslået, bliver desuden reduceret med cooperations.
-Det har intet, overhovedet intet, med staying loyal to principles at gøre!
-Carswell, andrageren i denne sag.
 Romtraktaten indeholdt allerede beføjelser hertil.
 Jeg repræsenterer et randområde, der ofte kaldes en ødemark.
 Det er en udfordring at sikre, at en europæisk bystrategi tages alvorligt.
 Det er føget med komplimenter her.
 Disse lige betingelser angår arbejdstider, hviletid, betalt ferie, lønramme, status og sikkerhed.
 Disse ændringsforslag omfattede imidlertid ikke tilføjelsen af egespån.
-Det er også vigtigt at understrege integritetsaspektet, som brugen af dna kræver.
 Krarup sagde, mangler disse forslag under alle omstændigheder proportionalitet.
-Baissespekulation bør også forbydes.
 Jeg tænker her på vores babyer, vores sutteflasker osv.
 Budgettet er det nav, hvorpå alle det europæiske hjuls eger samles.
 Folk bliver lokket med pertentlig mikroforvaltning, og ingen tør delegere beslutningstagningen nedad.
@@ -5785,47 +4705,23 @@ Tbilisi er ansvarlig for den uforståelige beslutning om at involvere sig milit�
 Spørgsmålet er, hvem der bærer skylden for, at hunden åd pølsen.
 Det behøver ikke at være en tyk bog.
 Wien er dog ikke altid gået ram forbi.
-De giver mulighed for fortolkninger, der går længere end enabling clause.
 Da passageren ikke adlød, blev han koldblodigt henrettet i passagerområdet.
-Ispa er det, vi kan stille til rådighed af finansielle midler.
 Til afstemningen skal udpeges fire stemmetællere ved lodtrækning.
 Jeg mener ikke, at vi bør nøle med dette transitspørgsmål.
-Meciar mistede folkets tillid, men hans parti er stadigvæk det største.
 Men den mælk, som dette yver indeholder, er, om jeg så må sige, forgiftet.
-Belsat er en fremragende start, men godt tv har sin pris.
-Det er faktisk mit kontor, som har offentliggjort læservenlige udgaver på adressen www.euabc.com.
 Den omfatter odderen, ulven, bæveren og lossen.
 Jeg tror, at vi alle sammen følte et behageligt sus under formiddagens møde.
-Det er desuden ikke noget onesize direktiv.
 Og jeg tror ikke, at vikingeskibene producerede drivhusgasser.
 De har slugt den toldfrie industris argumenter råt.
-Muchas gracias, muito obrigado!
-Clarke, at der ikke kun er nejer til forfatningen, men derimod mange jaer.
 De usikre elementer skal holdes nede på et minimum i denne økonomiske malstrøm.
-Alitalia er godt eksempel på dette.
 Vi bør alle synge efter samme nodeblad i denne sag.
-Liberaliseringen er et paradeeksempel på job creator.
-I morgen vil genetiske sygdomme som cystisk fibrose eller fenylketonuri være udryddet.
-Sund kost er et essentielt apekt af livskvaliteten.
-Det er fortåeligt, da vores tilpasningsevne jo ikke er uuendelig.
 For det første anerkender det ikke typologier.
-Shell har, så vidt jeg ved, trukket sig tilbage.
 Vores vaner og bosteder er blevet stive.
-Jeg peger på anomalien i lufttrafikkens fritagelse for afgift på kerosen.
 Det er at lade ræven vogte gæs.
 Og så til det sidste punkt, nemlig spørgsmålet om iderigdom.
-Den seneste bølge af pøbelvold fandt sted i december.
-Pelinkas tilfælde, er langtfra resultatet af et sammentræf eller en tilfældighed.
-Cecilia, og andre af dem har også været her i lang tid, f.eks.
 Han bebrejdede verden, at den tav ligesom første gang.
-Parlamentet har valgt kompromiset og har ikke givet efter for sortseernes sirenerøster.
-Nulfejlstolerance er dog noget, vi snart skal til at tage fat på.
-Elkabler og offshorevindenergi fortjener naturligvis de ekstra penge.
-Octa forarbejdes hovedsageligt i kontorudstyr af plastik og i dele af husholdningsapparater.
 På den anden side har vi komparative fordele med hensyn til tunopdræt.
 Jeg vil derfor kommentere den mulige opdukken af en ny økonomi i euroområdet.
-Guellec gjort på en udmærket måde.
-Dette ville betyde en ende på udsendelser på ungarsk, ruthensk og ukrainsk.
 Mit sexliv er blevet bedømt.
 Man skal ikke lade hø mugne, for så bliver det rent ud sagt farligt.
 Den komplicerede og tidrøvende håndtering koster ikke blot meget tid, men også mange penge.
@@ -5833,31 +4729,16 @@ Vi har derfor brug for disse fora for internationale koproduktioner.
 Vi er ikke kun den ydende part.
 Zaire er, som vi ved, indbegrebet af udnyttelse og plyndring.
 Lad os nu sammen arbejde på et ærbart kompromis, som gavner alle.
-Når de når hjem til sig selv, forvandler denne vægelsindethed sig til sand modvilje.
 Det er rigtigt, at vi foretog en simulationsøvelse for kopper i sidste uge.
-Fidesz fik et mandat på to tredjedeles flertal til at gøre dette.
-Simcyp går forrest i udviklingen af alternativer.
-En boboer på et plejehjem hører i dag ind under det sociale område.
 Dels på grund af krig og ufred og dels på grund af naturkatastrofer.
 Vi kan ikke konfrontere de nye medlemsstater med en ufærdig asylpolitik.
-Nu ledes vi af kommunister, kollaboratører og quislinger.
 De bidrager også til skabelsen af ozon og smog om sommeren.
 Ønsketænkning blokerer for en bare nogenlunde ædruelig realisme.
 Populistisk hugst, som om man går til en botanisk have med en økse.
-Det er mennesker, der lever her, ikke robocops!
-Reach er altså det rene humbug.
-Resten er eucalyptus til papirfremstilling, og så det usædvanlige træ korkegen.
 Klimaspørgsmålene er varme emner, og det er yderst sexet at stemme grønt.
 Hvert tilfælde af et kriseramt bydistrikt har naturligvis sine egne karakteristika.
-Albertini så udmærket siger det i sin betænkning, innovative foranstaltninger og instrumenter.
-Azzoloni for hans arbejde og for den imødekommenhed, som han har udvist.
-Poignant for hans samarbejde ved udarbejdelsen af min betænkning.
-Vi har brug gennemsigtighed og etstedsbetjening.
 Vi skal også undgå at duplikere lovgivningen.
 Vil parlamentsbetjentene venligst eskortere dem, der forlader forhandlingen, ud af salen.
-Det drejer sig om korrekturer af destillationsbestemmelserne, af nyplantningsrettighederne.
-Jonckheer mindede os om, er krisen i den europæiske bilindustri ikke noget nyt.
-Se blot på pneumokokfremkaldt sygdom.
 Men til rumfart og fusion og slige mærkværdigheder bruges der masser af penge!
 Snørklet og hemmelighedsfuld er bogen i sin søgen efter læsere.
 Chokoladeelskere, nyd nu endelig religiøst jeres forestående påskeæg!
@@ -5865,123 +4746,81 @@ Derfor har jeg også fundet nogle få regeringer med fingrene i denne møgbunke.
 Det er udelukkende af neokoloniale grunde, og det accepterer vi ikke!
 Nu vil jeg gå videre til spørgsmålet om sælmassakren.
 Kairo indrømmede, at de havde modtaget ham ved hjælp af ekstraordinære procedurer.
-Kommissisonen afventer i øjeblikket svar fra de gabonesiske myndigheder på dette tilbud.
 Jeg tror ikke, han er logget på og lytter.
 Jeg vil til sidst pege på en solooptræden, som er betænkelig.
 For det første skal de betale mere for hotelværelser end turister, der rejser parvis.
 Var det korrekt at informere butikkerne om, at de ikke skulle trække risene tilbage?
 I påkommende tilfælde, hvornår skete det så?
-Jeg støtter helt sikkert alle dele af belutningsforslaget fra alle de berørte grupper.
-En stat er selvstændig, når den overholder princippet om uti possidetis, grænsernes ukrænkelighed.
 Jeg har stadig visse forbehold med hensyn til udnævnelsen af en europæisk netforvalter.
-Johannesburg var som ventet en ny skuffelse.
 Måske skulle vi gøre os klar til at tænde bavnene!
-Desværre kan vi ikke afgifte betænkningen om proteinunderskud fra angrebet på nultolerance for gmo.
 Vi bør være bekymrede for de søgående fartøjers sødygtighed.
-Endelig har man i den seneste tid talt meget om fast track, om hasteproceduren.
 Menneskeheden er gået fra træalder til kulalder og derefter til oliealder.
-Kommissionen er faldet tilbage i en førdemokratisk tænkemåde.
 Andre iranske sagførere har også været udsat for undertrykkelse.
-Hvis vi ikke snart begynder at arbejde på dette, kan euroen ende som matadorpenge.
-De respektive forfattere er ansvarlige for inholdet af disse dokumenter.
-Wathelet skal i en ansvarsprocedure have mulighed for at forsvare sig.
 Den synes i stigende grad at fungere som skohorn for globaliseringen.
 Einstein sagde, at iderigdom er vigtigere end viden.
-De bedes virkelig undersøge, hvem der har underskrevet seddelen!
 Vi observerer desværre, at meget landbrugsjord ikke er opdyrket og derfor forringes.
 Faktisk gled den mere og mere i baggrunden.
 Og det har også været et slag med en kødhammer i samvittighederne.
 De taler om hallucinationer.
 Hvad kan vi håbe på at få ud af den uelastiske konservatisme i stabilitetspagten?
 Men selv de smukkeste roser er usynlige, hvis de bliver overgroet af ukrudt.
-Retinalmønstre er et meget effektivt middel til entydigt at identificere bilejere.
-Idag bør vi fejre vores evne til at forene.
 Befolkningerne blæser i trompeterne rundt omkring bymurene.
 Delphi er i denne forbindelse et dybt sår i mit land.
 Det var en tid, hvor man virkelig var åndrig i denne type debat.
-De ser tegn herpå nærmest overalt, som spåkvinden, der ser lykken i kaffegrumsen.
 Vi kan ikke bare fortsætte den ubegrænsede vækst i lufttrafikken og opofre alt andet.
-Det beviste vi fremragende i forbindelse med leghole traps, fælderne i forbindelse med dyrepelsene.
 Hvis de får lov, må vi acceptere, at verden enten er ond eller gal.
-Csibi allerede har sagt, baner direktivet vej for et frivilligt initiativ fra erhvervslivets side.
 Det er en livgivende naturgas!
 Noget tilsvarende skal finde sted med hensyn til bly og tin.
 Vi skal bruge vores kulreserver bedre.
 Anvendelsen af bindsler til søer og gylte vil blive definitivt forbudt.
 Eller betragt søpindsvinets pigge under mikroskop.
-Den kom og frifandt phatalaterne.
-Fujimori regerede sågar uden hensyntagen til det parlamentariske demokrati og vælgernes ønsker.
-Byrne ikke større kompetence end enhver anden fagmand, som ikke har kendskab til prioner.
 Kommissionen har på forskellig vis forsøgt at torpedere denne aftale.
 Cyprioterne er ikke en slags andenklasses borgere i en osmannisk eller en anden koloni.
-Bloom til at komme med en undskyldning.
-Helpline skal sættes i gang så hurtigt som muligt.
 Som det senere fremgik af afstemningen, var det endelige resultat marginalt i kandidatens favør.
 Vi danner en ny hær af nyfattige!
 Folk sælger fødevarer i pund og ounces.
-Giegold, er yderligere bevis herpå.
-Farvel koruna, velkommen euro.
-Freitas tillykke med hans fremragende betænkning.
 De er forblevet under skæppen.
 Dette er ikke den fortabte søns hjemkomst.
 Den europæiske tunindustri er ikke truet.
-Busquins stærke støtte til garantifonden for blot at nævne nogle få.
-Set fra forbrugerens synspunkt viste oprindelseslandsprincippet sig at være et pingpongspil.
 Og dette pokerspil er nu gået galt.
-Hoedt løslades uden tiltale.
 Elkøretøjer omfatter tog, sporvogne, busser, biler og cykler.
 Rådet og medlemsstaterne er lysår væk fra denne holdning.
 Aftalen indeholder heldigvis også stærke incitamenter vedrørende elektriske biler eller hybridbiler.
-Gaubert tydeligt understreget i sin betænkning.
 Har landet ikke baseret sit fremskridt på negrenes pinsler og slaveri?
-Hun kom hjem igen i weeekenden.
 Efter sultestrejken blev han anklaget for at gennemføre en uautoriseret protest.
 Men deres protester er blevet affejet med en håndbevægelse som forhastet teknokratisk argumentation.
 Under pres tyede ordføreren til et groft proceduremæssigt trick.
 Vi fosøger at anvende et klassisk, parlamentarisk instrument til at kontrollere den udøvende magt.
 Kisterne blev gravet op, og kirkegården blev uden nogen form for ærbødighed vanhelliget.
-Denne angivelige statssuverænitet er helt usuveræn og helt inhuman.
-Hvem skal betale for vådterrænerne, biodiversiteten osv.?
 Før i tiden kunne elektrolyse, tandlægevidenskaben og juvelerer ikke klare sig uden.
 Kommissionen vier en stor del af meddelelsen til de fremtidige demografiske forandringer.
 Vi bliver i virkeligheden bedt om så at sige at købe koen i sækken.
 Men man kan ikke behandle kræft med aspirin.
-Dehaene, deltog i konferencen.
 Man finder allerede det blå flag på alle pengesedler og bilnummerplader.
 Sågar algoritmer i computerprogrammer skal ikke længere stå til fri rådighed.
 Det er en reminiscens af en zars besøg i en undergivet provins.
-For det tredje fordi det fastsætter en uacceptabel undtagelse for uemballeret cement.
-Chountis for at henlede opmærksomheden på dette emne, der vil blive afklaret meget snart.
 Selv dværgene burde kunne rejse sig i deres fulde højde.
 Malmø bys initiativer inden for energibesparelser og brug af miljøvenlig transport er lovende.
 Jeg støtter i stedet demilitarisering og nuloprustning.
-Jeg har forståelse for de frustrationer og yderligere omkostninger, som påløber i dette område.
 Det bygger på sand og er en kolos på lerfødder.
 Jeg tænker konkret på den portugisiske regerings holdning over for de andalusiske fiskere.
-Ja, de overvejer det, ja, de har modtaget adskillige årberetninger om beskyttelse af persondata.
 Varme somre er på vej, og vi bør redde byboernes liv.
-Det betyder, at der er behov for reformer over hele linien.
 Dette er en moderne form for feudalisme.
 De giver alt væk, rub og stub, deres formue og deres håb.
 Vi skal fortsætte med den frivillige etos.
 Med projekttilgangen skydes der for tilfældigt fra hoften.
 En foranstaltning som denne kan måske finansiere et fartøjs turomkostninger og faste omkostninger.
 Den samme hulhed gælder for de erklæringer, der offentliggøres efter vores egne europæiske topmøder.
-Alt dette sker i koherens med de tidligere udnyttelsesprocenter.
 Det kapitulerer over for sukkerindustriens interesser og sødladne måde at lobbye på.
 Det ville føre til en ny steppebrand.
 Møderne sluttede alle i de årle morgentimer.
-Det tilsætningsstof, jeg tænker på i denne sag, er ethylhydroxyethylcellulose.
 Direktivet om byspildevand er et eksempel på denne dårlige gennemførelse.
 Hans eneste fejl er, at han har fordømt regimets slingrende kurs.
-Det er det, der gør dreamlineren til det mest støttede fly i verden.
-Denne remailing er dybest set illoyal konkurrence og skal stoppes.
 Det ligner sommetider en kombination af en argentinsk tango og en brasiliansk samba.
 De mange lækager og forskellige oplysninger såede tvivl om de offentliggjorte valgresultater.
 I al sin nøgenhed ser vi, hvilken høst kommunismens dragefrø resulterer i.
 De er det roterende formandskab.
 Det er i syddelen, vi finder dem, der afviser den.
-Vi mener desuden, at rammedirektiver skal have en slags sunset clause, en frist.
 For det andet er den i betænkningen foreslåede biregionale solidaritetsfond ikke ønskværdig.
 Lomas, at jeg som formand havde udtrykt mig helt klart.
 Hvad ville han imidlertid have været uden et bigband?
@@ -5989,7 +4828,6 @@ Det er med rette, at vi klør på.
 I dette tilfælde blev bagmændene fanget.
 Vi er ikke nogen cd, som man sætter i gang igen og igen.
 Det har ikke en birolle i processen.
-Det skal ske med pull and push foranstaltninger.
 Har vi den mindste brøkdel af denne algeriske løjtnants mod?
 Disse billeder udgør en indtrængen på en persons private enemærker.
 Såvel de nye medlemmer som eksisterende medlemsstater drog fordel af dem.
@@ -5999,10 +4837,7 @@ Råhuset står færdigt, lad os gøre det beboeligt.
 Vi ville simpelthen ende med kun at have sport, amerikanske film og talkshows.
 Da jeg sagde, at jeg ikke bærer nag, tænkte jeg på visse kolleger.
 På et vist tidspunkt vil det så tippe over til en anden tilstand.
-Colajannis ensidige beslutningsforslag opfylder ikke dette udgangspunkt.
 På denne måde øves der produktivt pres.
-Flere gange har man også talt om et sionistisk komplot.
-Titfords forsøg på at ødelægge vores gode humør sådan en dag.
 Det vigtigste stridspunkt er imidlertid spørgsmålet om, hvilke typer havari der skal omfattes.
 For det første, hvorfor har vi brug for en risreform?
 Et sejlskib, som udvides, men ikke gøres dybere, kæntrer let.
@@ -6010,132 +4845,80 @@ Vi skal være særligt opmærksomme på vejprojekter for at undgå dårligt hån
 En væsentlig manko er ganske givet den præcision, der stadig mangler mange steder.
 Dette hverv har jeg altid uøvet med meget stor glæde.
 Dette er særligt relevant i min østirske valgkreds.
-Vi har imidlertid først og fremmest brug for class budgeting eller budgettering efter samfundsgruppe.
-Notfiskeriet truer ikke den biologiske overlevelse af de udnyttede bestande.
 Så jeg købte endnu en god ovn.
-Tabajdi for hans fremragende betænkning.
 Jeg foreslår derfor, at man i stedet taler om optælling af sædprøver.
 Moldova er et land, hvor fællesskabet, hvor samfundet har abdiceret på en række områder.
 Kakao, chokolade, kaffe og cikorie
 Der bliver ikke krøbet uden om.
-Mettenbetænkningen siger ja.
 Det kan vælge mellem at være en urostifter eller en konstruktiv partner.
 Jeg har kun sagt goddag til de to store matadorer i denne debat.
 Der er ikke gjort noget seriøst for at få has på problemet.
-Det er derfor øknomisk fornuftigt at ramme en balance nu.
 Dette er kapitalismens grimme fjæs.
-Juncker, mine damer og herrer!
 De frygter, at de igen kommer til at befinde sig mellem hammer og ambolt.
 At udbrede sådanne handlinger er et angreb på familien, og det fører til abnormiteter.
-Ferber taknemmelig for hans venlige bemærkninger om min præcise ankomst.
 I praksis er hæren i dag et bolværk mod den islamiske religion.
 Ved en fjerdedel af træerne blev der konstateret alvorlige tab af nåle eller løv.
-Alså ikke nogen dramatisk forskel.
-En sidste bemærkning til det prekære tema double use eller kun civil anvendelse.
 Kaput er kaput på alle sprog!
-De nævner de særlige omstændigheder, især ved finansieringen af open broadcasting network.
 Spørgsmålet om sikkerhed ved nethandel bør ikke blandes med de juridiske krav ved merværdiafgifterne.
 Undskyld mig, men det er både præhistorisk tænkning og bondefangeri.
-Padania er det sidste eksempel herpå!
 Kun i to lande findes der et endnu større løngab.
-Ja, vi må tage spørgsmålet om szeklerfolkets territoriale selvstyre op.
-Killilea på ny ønsker ordet.
 Ønsker vi at skyde fra boven?
 Der er ikke brug for didaktik, men berettiget kritik.
 Vi har allerede haft nogle homeriske diskussioner om mærkning af alkoholholdige drikkevarer.
 De risikerer at dø en særdeles pinefuld død af enten dehydrering eller iltmangel.
-Bowes bemærkning om behovet for at reducere, genbruge og genanvende affald.
 Man må vænne sig til referencer af nærmest klerikal art.
-Kerr om at huske tilbage til afstemningsdagen.
-Den ligger igen primært inden for lånyderens ansvar.
 Hvorfor er vi nødt til at finansiere skiundervisning i skolerne denne uge?
-Hvis vi skal kunne gribe ind, har vi brug for et kort med geohenvisninger.
-Men vi kan ikke skabe fred ved at bibeholde disse bantustans eller denne apartheid.
 I forbindelse med rumopvarmning har vi således været uafhængige af prisudsving på verdensmarkedet.
 De skal opvarmes af en brand, for at de kan gro.
-Kozloduy illustrerer et vigtigt aspekt af dette problem.
 Det kræver ikke nye magiske remedier.
 Hvad så, er tiøren nu faldet?
 Drabet af den apostolske nuntius er et af de seneste eksempler på meningsløs vold.
 Ordføreren kan påregne den grønne gruppes støtte i forbindelse med denne sag.
-Castro bliver ved med at være umedgørlig.
 Hvirveldyr og primater nyder særlig beskyttelse.
 Er fastsættelsen af forpligtelser i strid med den nuværende økonomiske og teknologiske situation?s
-Vondra tilføje noget om, hvordan denne pakke bliver forberedt til junitopmødet.
 Oprindeligt bidrog det kun til at udarbejde den europæiske fælles akt.
-Lige så vigtigt ville det være at diskutere natmøderne bedre.
 Barton forsøger at torpedere enhver strengere regulering.
 En uskreven aftale er ikke nok og garanterer ikke dataenes sammenlignelighed og fuldstændighed.
 Fordi så længe aftalen ikke er på plads, er der unødvendig omkørselstrafik.
-Jeg er blevet valgt på et mandat for at kæmpe mod politisk pilfingerering.
 Ah, det var da slet ikke så slemt!
 De vil få lov til at smage et sødt løg.
-Wuori, understreger, men det går fremad.
 Der anvendes rug af meget høj kvalitet til produktion af funktionel mad.
-Det drejer sig om de brandfarlige drivgasser butan, isobutan og propan.
-Haagerkonferencens høringsrunde, som begyndte for syv år siden, nærmer sig en afslutning.
 Bypartnerskaber er et godt middel til at bidrage til dette.
 Bibliotekernes kundskaber vil udgøre en særlig vigtig del som arrangør af netdata.
-Det er absolut nødvendigt for at udgå afartede forhold og beskytte den menneskelige værdighed.
 De fleste af de lande, som vi kommer fra, har et tokammersystem.
 Desuden forbrændes der allerede meget biomasse i kulcentraler.
 Situationen kan derfor risikere atter at gå i hårknude.
-Hyde, for jeg er helt enig med dr.
 Åger gør ciselering rusten, gør kunst og kunstneren rusten.
-Giusto, du har lavet en dum fejl.
 For øjeblikket er vi ved at udforme flunkende nye måder at lave energi på.
 Det betyder, at en zinkkiste er påkrævet, hvilket er meget dyrt.
 Burundi har brug for vores hjælp.
-Sakellariou, der er ingen, der har foreslået, at man stemmer imod denne betænkning.
 Vi mener sågar, at dette er et ret stort vrængbillede.
 De skrev aldrig hjem om, at den rhodesiske befolkning måtte sulte.
 Ingen medlemsstat må få lov til at sno sig ud af sine forpligtelser.
-Maritim transport er hjørnestenen i den irske industri, som er en øbaseret økonomi.
 Denne ene procent er alt, hvad vi har at rutte med.
-Han insisterer også på, at alle selvstændige chauffører skal have et takometer.
 Dette tilsagn bør ikke omfatte kosmetisk ommærkning af midler til infrastrukturen.
-De kvæulerer om den fuldstændige rædsel?
 Dette had opstod under zardømmet og fortsatte under stalinismen og er endnu ikke udryddet.
-Det måske vigtigste fremskridt er, at den usigelige kørekortturisme stoppes.
-Efter den første toenhalvtimesdebat havde hver minister tre minutters taletid.
-Tomczak var inde på det generelle med hensyn til finanskrisen.
 Der er fortsat nulafgift på visse produkter.
 Erlæggelsen af visse sundhedsydelser er ringe i de fleste af de nye medlemsstater.
-Den engelske tekst skal helt rigtigt oversættes med without delay.
 Der er tale om et rusmiddel, der skal behandles som sådant.
 Beslutningsforslagets tekst, dok.
-Wijkman, som ikke er til stede.
 De stopper uden grund på etager, bliver overfyldt og går i stå.
 Med hensyn til ost fremstillet af råmælk, har vi også stadig knap et år.
-Selvom benzinmotorer er den primære benzenkilde, er metallurgiske koksværker også berørt.
 Det handler om dagblade, ugeaviser og andre pakkeforsendelser.
 Problemet er de høje blyværdier i den maling, der anvendes til det pågældende legetøj.
-Mladenov har præsenteret med hjælp fra sine kolleger.
 Jeans er en måde at undgå voldtægt på.
 Der er også mindre bærende ting i bogordningen.
-Men det bliver vi også nødt til at henføre til detaildebatterne, til fagdebatterne.
-Veraldis betænkning omhandler alle disse punkter, og af den grund stemte jeg for betænkningen.
 Danskerne regner ikke med nogen omkostninger, de har øjensynligt ingen blyrør.
 Det var angiveligt et rovmord begået af unge.
-Alt i alt er det altså ikke en tabula rasa , vi vil.
 Det skal gælde for alle , som er lovligt bosiddende hos os.
 Vi kan heller ikke lægge bekæmpelsen af ulovlig indvandring over på fiskerfartøjernes skippere.
-Det er ikke, hvad vi forstår ved taking into account.
 Vin er et fermenteret produkt, ikke et blandet produkt.
-Få uger før ikræfttrædelsen af det tredje trin skal dette vigtige spørgsmål løses endeligt.
 Det forsøger at lokke ayatollaherne ud af deres nukleare ambitioner.
 Dette er sandsynligvis ikke tilfældet for de andre rumbaser.
-Khanbhai undskylder meget for ikke at være til stede for at fremlægge sin betænkning.
-Den næste lejlighed bliver udenrigsministrenes troika i november.
 Man kan ikke være beslutsom i ord, men vankelmodig i handling.
 Sulfit er et af de stoffer, der er medvirkende årsag hertil.
 Til gengæld bliver spørgsmålet om lande, som eventuelt bliver uden for emuen, uløst.
-Wittgenstein har sagt, at det at vælge et sprog er at vælge en livsform.
 Hongkong planlægger også et forbud.
-Kuckelkorn, for deres betænkninger og det arbejde, de har gjort.
-Gualtieri med dagens betænkning.
-Det tilsigtede modal shift kommer herved ud på et skråplan.
-Men det er også centrum for pædofile, bondefangere og de mest usofistikerede udenlandske agenter.
 Et meget vigtigt initiativ på dette område blev søsat tidligere på året.
 Det var nærmest bogværker, som af og til blev for meget for mig.
 Kun personer, der har en uplettet straffeattest har tilladelse til at arbejde med børn.
@@ -6144,100 +4927,63 @@ Vanskeligt kontrollerbare sygdomme såsom ebola har spredt sig til mennesker.
 Vi kan holde alle de skåltaler, vi vil, om dette kombinerede transportprojekt.
 Den fungerer som bustjeneste.
 Men desværre betyder denne udelukkelse ikke, at solteknologier støttes.
-Udvalgets tredje prioritet er integration af indvandrere og bekæmpelse af rascisme og fremmedhad.
-Wiersma og flere andre meget klart.
 Forhandlingens vaghed sikrer ikke nationernes frihed, sådan som man gerne vil give udtryk for.
 Her handler det om en asset inflation i verdensformat.
 Således trak den en enorm mængde rubler ud af landets offentlige pengeomløb.
 Nicaragua er et advarende eksempel på, at den slags herskere ikke ændrer sig.
 Senere fandt man spor af sarin i atmosfæren.
 Fondsmodellen er blevet foreslået, men anpartsmodellen kan være et andet alternativ.
-Etymologerne provokerer os.
 Jeg insinuerer ikke, at nederlænderne er æreløse, heller ikke svenskerne.
 Udnyttelsen af rummet er ganske umærkeligt blevet en del af dagligdagen.
-Det catalanske, occitanske og bretonske sprog er rodspirerne til det franske kulturelle træ.
-Bolognaprocessen er den mest radikale reform af de videregående uddannelser i de senere år.
 Togo er på vej ud af en vanskelig politisk og økonomisk situation.
 Grækenland fortjener anerkendelse og støtte, ikke at få på puklen.
 Europas stemme skal lyde som et enstemmigt kor, ikke disharmonisk og ude af takt.
 Myndigheden i det eksporterende tredjeland skal udtrykkeligt give tilladelse til reeksporten.
-Denne meget realistiske betænkning vidner unægteligt om en åbnhed.
 I virkeligheden rider dette direktiv med på modebølgen og den nemme dydighed.
 Det vil romantiske amatørers dagdrømme ikke ændre på.
-Men på dette tdispunkt kan forhandlingen dårligt fortsættes.
 Desuden minder ofringen af menneskeligt liv for at kunne bedre andres liv om kannibalisme.
-Lad mig straks sige, at religiøs forfølgelse er uislamisk.
 Efter min mening er det lykkedes helt for os at skille avnerne fra kernerne.
 Åbenheden i gasbranchen skal øges, og forsyningsruter og leverandører skal diversificeres.
 Bendtsen, for hans nøjagtige betænkning.
-Saddams biologiske våben omfatter anthrax eller miltbrand.
-Indiens geostrategiske og geoøkonomiske betydning er åbenlys.
 Jeg har endnu aldrig set en ko stå ved grøftekanten og spejde efter fisk.
-Cushnahan, talte om kløften mellem retorik og virkelighed.
-Kommissionen burde sætte en stopper for den systematiske og forsætlige lækning til pressen.
 Jeg blev for nylig opereret for at få fjernet min galdeblære.
-Det er aldrig før blvet tilladt i denne forbindelse.
 Vi skal alle sammen være en del af den sydvestlige region.
 De er vidner til, at demonstranter arresteres, og at journalister chikaneres og tæves.
 Godmorgen, mine damer og herrer!
 Det er forældet at ensrette menneskers liv til efter ensartet ugeplan.
 Man kan tilmed hyre institutioner til at gøre arbejdet.
-Ortuondo ordet, hvis han mener, at dette vedrører ham.
-Pegase burde fornuftigvis sættes i kraft i morgen.
-Marianne, du har gjort et meget efficient, professionelt og effektivt arbejde.
 Ecuen havde således en vis stabilitet.
 Vi må ikke flå dette hjertestykke ud, og vi bør udrydde misforståelserne i offentligheden.
 Anna er imidlertid ikke det eneste offer.
 Han opførte klinikker, hvor han opererede kvinder, der led af fistler efter vanskelige fødsler.
 Derfor er jeg bestemt ikke tilhænger af, at rismarkederne åbnes for alle verdens markeder.
-Først og fremmest foreslås et tilsætningsstof kaldet natriumalginat til brug i revne gulerødder.
 Spyware giver en tredjepart adgang til samme data som brugeren.
 Det er almindelig tuns virkelige problem.
 Derfor står dette direktiv på gyngende grund.
-Foie gras er en national specialitet i mange lande.
 For transport, for byarkitektur og særlige politikker for arbejdsmarkedet og for uddannelse.
 Jeg kan ikke selv se løsningen i denne form for temmelig kortsigtet ideologisk skvalder.
 Vi må gøre en ende på det monopol, som krigens bipolarisering har besiddet.
-Silesien er det område, der er hårdest ramt.
 Haglbygerne og naturkræfterne var så voldsomme, at de ødelagde adskillige afgrøder.
 Vi ynder at fastsætte betingelser i forbindelse med vores støttepakker.
 Lisi, for hans hårde arbejde på denne betænkning, og jeg støtter hans bemærkninger.
-Birdal, som deltog meget aktivt i mødet.
-Fiat nægter at holde møder, debatter eller forhandlinger med fagforeningsrepræsentanterne.
 Jeg ønsker ikke endnu et svar i kancellistil.
-Det er den institutionaliserede bodfærdighed.
 Det er da ikke noget scoop.
-Inglewood med henblik på den bemærkning, han netop havde.
-We want to be players, not only payers.
-Ispir trods rumænske mediers påstande om hans indblanding i korruption.
-Vores gruppe har stillet et ændringsforslag om en jorudtagningssats på nul.
 Hvis man betaler med lire, skal jeg så give tilbage i euro?
 Et ormstukkent æble kan udmærket være sundere end et dejligt rundt, skinnende æble.
 Vi har brug for at gå fremad, ikke baglæns ligesom krabber.
 Tværtimod knokler arbejdstagerne under forfærdelige forhold og får næsten ingenting for det.
 De tyrkiske myndigheder klassificerede affaldet som farligt på grund af dets indhold af krom.
-Beka mistede en del af sit kranium, og der er fortsat granatkardæsk derinde.
 Vi er loyale partnere og ikke lakajer.
-Turchi, for det frugtbare samarbejde.
 Sygdomme som kolera, polio og gulsot er mangedoblet.
-There is no culture without agriculture!
-Mens alt dette finder sted, fortsætter varroamiden sit ødelæggende arbejde, og bierne dør.
 På begge punkter er problemet, at man sjældent når, men snarere kløjs i målene.
 Her handler det ikke blot om gennemskueligheden af talopsætninger, tabeller eller grafer.
-Mercosur har alt det, det behøver.
 Glem ikke den venstre vinge.
 Under recessions kølige vinde har investorerne søgt ly under euroens vinger.
 Der er andet arbejde nok, så vi behøver ikke at udføre et sådant sisyfosarbejde.
 Derfor er mærkningen alt for ofte blevet brugt i flæng og uberettiget.
-Togbilletter til fjerne destinationer er man ofte nødt til at købe uden for afrejselandet.
 Afstraffelsen skyldtes øldrikning.
 Emiren indgav altså lovforslaget i ferieperioden.
 Monnet lagde fundamentet til dette foretagende.
-En proaktiv politik bør indebære, at ukvoterede sorter hurtigst muligt kvoteres.
-Parlamentsmedlemmerne ved, at man ikke kan reregulere et marked.
-Kirilovs betænkning, velkommen.
-Endnu en gang er den megen kokkereren ikke ensbetydende med god mad.
-Jeg vil også gerne kunne se nødudgangsskilte.
 Er det bare et teknisk fif eller en udvikling af gennemsigtigheden i selve beslutningstagningen?
 Vi burde holde os for gode til at kolportere rygter på plenarforsamlingen.
 Ih, hvor dejligt, der kommer hun jo!
@@ -6252,40 +4998,23 @@ Formanden udtog stemmetællerne ved lodtrækning
 Disse ændringsforslag vil slibe reformen til, således at den bliver god for landmændene.
 Mange generationer før os har higet efter dette.
 Jackson har forstået dette godt og taget hensyn til aspektet i sin betænkning.
-Han har nemlig på engelsk talt om et clear and rational document.
 Det må ikke være sådan, at verdens landmænd er afhængige af nogle multinationale frøproducenter.
 Nogle mennesker har endog en fupstatus som selvstændige.
 Vatikanet har i mellemtiden truffet foranstaltninger og iværksat en undersøgelse.
-Swietokrzyskie er et eksempel herpå.
 Man kan ikke se bort fra menneskerettigheder for nemheds skyld på et bestemt tidspunkt.
-Sædtallene falder, mens antallet af tilfælde af testikelkræft og brystkræft stiger.
 Der er brug for en tydelig specificering og prioritering af byniveau.
-Også små børn skal fremvise en hivtest for at få et russisk langtidsvisum osv.
-Jeg vil altså ikke sige mea culpa.
 Måske kunne en anden trehed være leve, rejse og elske.
 Vi skal hejse et klart signal.
 Hvis epilepsi ikke behandles, lider folk mere, end når der er passende behandling.
-For mælken og yoghurten eller for kartonet eller bægeret?
-Med andre ord forbliver omkostningerne de samme for eloperatørerne.
 Vi ved jo, hvem der oftest bliver ramt af sygdommen tinnitus.
 Næsten alle regeringer murrer over tjenestemændenes eller dommernes lønninger.
 Vi havde vores hyr med definitionen på vodka.
-Kohl til at gøre en indsats til fordel for beskæftigelsen!
 Men vi må lade vores iver løbe af med os.
-Sexarbejdere skal have adgang til retshjælp til en overkommelig pris for at øge domfældelsesraten.
-Caldeira, mine damer og herrer!
-Famagusta var en populær turistdestination.
 Regeringskonferencen er i bakgear.
 De opsvulmede åer og floder rev alt det med, som stillede sig i vejen.
 Vi må forberede os på en lang og sej kamp.
-Teverson for en modig og upartisk betænkning samt for en fordomsfri behandling af emnet.
-Mbekis opgave bliver at skabe betingelser for frie og retfærdige valg.
 Men de skal tale ærligt, ikke tale med to tunger eller med kløvet tunge.
-Mayer sagde om retsgrundlaget.
 Dette har især ramt den samiske befolkning.
-Cepol skal ikke desto mindre gøre en større indsats.
-Så hvad med nødgenbosættelse?
-Hizbollah er en politisk, men også en militær organisation.
 Den er kogt ned til kun at indeholde specifikke politikker.
 Foranstaltningerne er palliative.
 Hvis vi vil gøre noget mod flylarmen, skal de tekniske forbedringer gennemføres hurtigere.
@@ -6293,11 +5022,9 @@ Dens morderiske angreb har ikke forbedret deres situation en tøddel.
 Lazarus slår virkelig til igen.
 Det ville være et brohoved for indsatsen for at sikre ytringsfrihed.
 Mange tophoveder fra dengang er i dag ikke længere nogen fryd for øjet.
-Laeken stillede de rigtige spørgsmål.
 Lyskurven lyser efter min mening gult her.
 Denne undersøgelseskommission skal i så fald dække hele det store søområde.
 Leksikonets konklusion var, at menneskeheden aldrig ville kunne ødelægge denne art.
-Vi har hørt en meget omfattende opremsning af forskellige muciner.
 Man nævner nemlig hunde, katte, akvariefisk, amfibier, reptiler, fugle og pattedyr.
 Vi ønsker ikke amerikanske tilstande, hvor lovgivning udarbejdes alt efter dagens misopfattelser.
 Dette litra bør efter vores mening helt slettes.
@@ -6317,33 +5044,23 @@ Det er en uskik, når det gælder databeskyttelse.
 Det er den tvungne skyldighed, den moralske inkvisition og den konstante psykiske bearbejdning.
 Man ved, at denne praksis med fjernelse af hajfinner truer adskillige hajarters overlevelse.
 Det er naturligvis igen den grønne gruppe med dens ævl om miljøet, ikke sandt?
-Csangoerne, som også lever i yderste fattigdom i et enkelt område?
 Samtidig har issmeltningen medført nogle uforudsete ændringer i havstrømmene.
-Vi har såldes en ny traktat.
 Der er heller ikke nogen mening med at plukke kirsebær på nuværende tidspunkt.
 Vi vil ikke underskrive nogen bodserklæring til imperialisterne.
 Men hvem sørger for nyvindinger inden for teknologien?
-Alle ved, at den næste skandale bliver salpeterforurenede grøntsager.
 Den kan undertiden være snoet, og den er altid krævende.
 Min egen bror, engelsk som jeg selv, var teknisk tegner.
 Forarbejdningsindustrien og forhandlerne vil æde det hele op.
 Iskapper forsvinder, havoverfladen stiger, og der er snart ingen vej tilbage.
-Vi skal ikke blandes ind i for mange interne micromanagementbeslutninger.
 De har karakter af grundlæggende rettigheder, men er ikke just frodige i deres formuleringer.
 Det hele er tillige blevet spundet ind i en bestikkelsesskandale i den sydafrikanske regering.
-Wojciechowski sagde for et øjeblik siden, er dette et eksempel på europæisk solidaritet.
 Det lærer man ikke vores kære små poder.
 Denne prøve er dog en forudsætning for optagelse på de fleste angloamerikanske universiteter.
 Koordinering af den økonomiske politik må ikke være et fyord i disse haller.
-Desuden kræves det, at der træffes de nødvendige foranstaltninger til at opfylde elindustriens behov.
 Jeg husker stadig, at mange dengang drillede hende med, at hun så spøgelser.
 Lærer du ham at fiske, er han mæt resten af livet.
-Life is very short and there is no time.
-Kompensationen er til sukkerroeavlere, inulinsirupproducenter og cikorieavlere.
 I vores øjne van denne strategi mangelfuld på to vigtige punkter.
-Stauners ændringsforslag om observatoriet skal vedtages.
 Den krig, der har været spået om, er ved at være en realitet.
-Grech for deres positive måde at lede denne budgetprocedure på.
 Alexander, særlig når det gælder spørgsmålet om den juridiske status af erklæringen.
 Væk er de ubehagelige sprøjter, de ildelugtende piber og den afslørende røglugt.
 Lad os holde op med at lege kispus med landbruget.
@@ -6351,7 +5068,6 @@ Nicole, som en ven takker jeg dig af hele mit hjerte.
 Investering i mennesker børe være omdrejningspunktet, når det gælder strukturelle reformer.
 Denne bonus bør vi ikke klatte væk, ærede kolleger.
 Der laves piratkopier af musik og film på cd og dvd.
-Men hvad bliver der så tilbage af susidiaritetsprincippet?
 Mange liv anhænger af disse foranstaltninger.
 Emnets aktuelle status er ynkværdig.
 Pasning og bearbejdning af træmasse og tørv kræver arbejde.
@@ -6362,30 +5078,19 @@ Monfils, for deres aktive deltagelse i denne procedure.
 Tobak er en gift og en rusgift.
 Hestene står i vand til bugen, men de drikker alligevel ikke.
 Hvis euroen er en svag valuta, så var marken helt bestemt anæmisk.
-Se cierra el turno de votaciones.
-På denne måde banes vejen for flere forbrydelser til søs i lighed med m.fl.
 De gotiske domkirker blev til gennem mange generationer.
 Det, de afviste, var ikke åbningen af verden, men den globaliserede merkantilisme.
-Det langtovervejende flertal af befolkningen fordømmer fabrikslandbrug og buræglægningssystemet.
-I øjeblikket kan medlemsstaterne selv definere begrebet natperiode.
 Denne formulering kan forekomme en smule ukultiveret og behøver en smule forklaring.
-Bardong, vil komme med en kort kommentar.
 Det vil hjælpe med til at mindske nepalesernes sårbarhed over for de maoistiske rebeller.
 Trods de seneste dages feststemning handler disse tanker mere om problemer end om ovationer.
-Aceh var en stor søfarernation og har også haft en religiøs indflydelse på regionen.
 Vi har efter min opfattelse reageret alt for vegt i denne sag indtil nu.
 Javist er der mangler, men de kan korrigeres.
-I de sidste seks år har hun som bekendt forsøgt at blive cand.jur.
 Meget højtydende rapsfrø vokser lige ved siden af en eksisterende petrokemisk industri.
 Hensigten at gå på kompromis med sikkerheden for ikke at tirre den kinesiske regering?
-Feira satte spørgsmålet på regeringskonferencens dagsorden.
-Challenger sprang i luften trods teknologerne.
-Zimmerling netop har sagt.
 Kommissionen har dog været dumdristig nok til at se gennem fingrene med det.
 Jeg tror, at de baltiske lande har fået de allerværste knubs.
 Der foregår storstilet jagt på krondyr, vildsvin og elg i de polske skove.
 Og så spiste jeg nogle glimrende hotdogs!
-Casparys ord om, at der er en lang række menneskerettighedsproblemer og andre problemer.
 Det trænger sig derfor på at gøre status over forbindelserne med vores alpine nabo.
 Accepterer vi, at forskningen identificeres med drømmen om et nyt økonomisk eldorado?
 Blodbadene fra disse robåde er alt for hyppige.
@@ -6396,52 +5101,35 @@ Som det understreges i betænkningen og meddelelsen, er valghandlinger ikke enda
 Man er ved at forberede en bistandspakke, der skal søsættes snarest muligt.
 Jeg husker tydeligt de enorme ligbål med brændende dyr.
 Det er en kårde, der rammer lige i hjertet.
-Desuden ville vi udsætte os for at blive bebrejdet, at novel foodforordningen er etiketsvindel.
 De skader, den forårsager, truer mange dambrugeres og fiskeres eksistens.
 Før bogtrykkeriet var der reelt ikke noget, der hed intellektuel ejendomsret.
-Horror vacui , det lærte vi i gymnasiet i de klassiske fag.
-Tjah, men vi løsgængere har kontorer uden toiletter, uden vand!
 Mulighederne herfor stækkes til stadighed.
-Denne aggressive bakterie synes ustoppelig.
 Næste gang går midlerne utvivlsomt til snerydning.
-Elchlepp havde til hensigt at stemme for forslaget.
-Det tredje emne er krydsoverensstemmelse, cross compliance.
 De forventede indtægter varierer naturligvis på grundlag af disse to koefficienter.
 Skilsmisse er en alvorlig sag, der ganske ofte involverer smadrede tallerkener og bodeling.
 Mødre, børn og familier er en treenighed, som fremtiden skal bygges på.
-Glyphosat betragtes som kræftfremkaldende, og det har indflydelse på forplantningen.
 Bajonetter kan, som bekendt, bruges til meget.
-Afrikansk trypanosomiasis, bedre kendt under navnet sovesyge, er et godt eksempel herpå.
-Tavares med deres forhandlinger og deres indsats.
 Den newzealandske delegation består af fem medlemmer af parlamentet.
 Den øger mulighederne for jobformidling og styrker derudover også selvtilliden.
 Det var så alvorligt, at oprydningsholdet var iklædt rumdragter, som næsten begyndte at smelte.
-Borgerinitiativet www.oneseat.eu fortsætter.
 Det drejer sig i grunden om at addere ettaller og nuller.
 Vi har her i salen flere arvtagere til denne tankegang.
-Andesbjergenes isgletsjere er tæt på helt at forsvinde.
 Jeg vil også gerne fremhæve, at enhver henvisning til højtydende rifler er unødvendig.
 De herrer har åbenbart også fået den udenrigspolitiske paella i den gale hals.
 Der svæver således et gigantisk damoklessværd over den europæiske kulturpolitik.
 Jeg vil gerne nævne noget, de sicilianske fiskere sagde.
 De ved nok, at det finske sprog har alt for mange vokaler.
-Også dyrebeskyttelsen og bekæmpelsen af epizootier tildeler vi stor betydning.
 Hvad betyder i denne sammenhæng farven på væggene eller trykket i cisternerne?
 Vold af denne art er foragtelig og umenneskelig og derfor også umandig.
 Det er vigtigt i forbindelse med ulykker og navnlig eneulykker.
 I øjeblikket deponerer syv lande mere end halvdelen af deres dagrenovation.
 Kurserne faldt så meget, at bærrene ikke engang blev plukket.
 Det er allerede blevet nævnt, at mange børn med dysleksi er endog højt begavede.
-Soares ikke i dag lejlighed til at spise os af med pæne ord.
 Euro skal blive den tredje internationale reservevaluta ved siden af dollar og yen.
 Det er meget gode nyheder for døvblinde.
 Dette problem kom ikke som et lyn fra en klar himmel.
-Også en hotelvirksomhed har best available technology for spildevandet.
 Alt var altid meget vagt og uldent.
-Måske bare med en simpel ordassocieringsprøve.
 Der er for meget krigsretorik og tamtam.
-Rådets esktraordinære samling
-Poos vil sige mere om det senere.
 Mine damer og herrer, det er på tide, vi vågner op fra vores rus.
 Formålet med vinreformen er at fremme produktionen af acceptable vine af god kvalitet.
 Narkotikaproblemet kæver en pragmatisk tilgang og et åbent sind.

--- a/server/data/da/europarl-v7-da.txt
+++ b/server/data/da/europarl-v7-da.txt
@@ -1,0 +1,6448 @@
+Helt rimeligt går bekymringen herover ud over nationale grænser og ideologiske forskelle.
+Kommissionen har allerede påbegyndt denne evaluering og håber at gøre mere i fremtiden.
+Jeg tror, at flertallet kan acceptere dette.
+Det må ikke få lov at fortsætte.
+Kritikere af dette direktiv vil sikkert forsøge at finde nye veje.
+Jeg er overrasket over, at jeg er den første, der nævner det.
+Det er alt sammen det, vi har forsøg at gøre på europæisk plan.
+Realisme med resultater er bedre end utopier uden historie.
+Dette skal være vores indfaldsvinkel, når vi kigger frem imod de kommende uger.
+Dette forhold påpeges til dels i beslutningsforslaget, men jeg finder, det bør understreges.
+Resultatet af denne kamp er meget ringe.
+Som ordføreren fremhæver, er det på grund af opgavernes kompleksitet.
+En anden ting er definitionen af information og høring.
+Den socialdemokratiske holdning er langt mere kompleks.
+Er flere penge og kravet om flere penge virkelig fornuftigt her?
+Lederskab handler om at tage chancer, løbe risici og gå forrest.
+Hvor store er disse bøder?
+Jeg stiftede igen bekendtskab med mange repræsentanter for flygtningene.
+Det er en af de pointer, jeg i særlig grad gerne vil understrege.
+Vi udtrykte stor bekymring over den fortsatte lukning af vigtige grænseovergange.
+De skulle selv have identificeret disse svagheder på et tidligt tidspunkt.
+Det er naturligvis forkert!
+Jeg vil dog kort sige, hvad jeg mener.
+Om motiverne for dette direktiv behøver jeg ikke at sige mere.
+Vi skal mobilisere den politiske vilje til virkelig at gøre det.
+Et sådant budget vil gøre de tilbagestående lande til nettobidragydere.
+Ellers vil resultatet af det kommende valg være svigagtigt og langtfra demokratisk.
+Kampen for gennemsigtighed skal derfor fortsætte!
+Det er fasen for forhåndsregistrering af stoffer.
+Det bliver en vidunderlig kontrol!
+Udvidelser, som er imod borgernes ønske, bør undgås.
+Vi har til gode at se, hvad der menes med genopbygning.
+Et andet vigtigt punkt er transportørvalg og transportørforvalg.
+Lovgivningen, som vi udtaler os om i dag, byder på mange muligheder.
+I dialogen med de indonesiske myndigheder påpeges også nødvendigheden af frie og fair valg.
+Det er noget, vi er nødt til at tage meget, meget alvorligt.
+Det er juridiske og administrative hindringer, og det er navnlig sektortænkningen i forvaltningen!
+Man kan ikke motivere indskrænkninger i demokratiet med, at man tjener en god sag.
+Rådet har jævnligt mindet medlemsstaterne om betydningen af det.
+Parlamentet har indtil videre under ordførernes ledelse gjort et godt stykke arbejde.
+Dette forslag er ikke medtaget, fordi retsgrundlaget i øjeblikket mangler.
+Terrorismen kan ikke altid gribes an på samme måde.
+Vi bør holde os denne risiko for øje.
+Forhandlingen er afsluttet.
+Jeg vil runde af med en afsluttende pointe.
+Afstemningen finder sted tirsdag.
+Det siger den foreliggende betænkning så udmærket.
+Vi kan se, at der er en mangel på sammenhæng flere steder i teksten.
+Hele regelsættet er der således.
+Hvordan måler vi denne succes?
+Det er naturligvis et internt iransk anliggende.
+Vi skal fra nu af indsætte de mulige joint action teams.
+I økonomisk gode tider har man jo ikke nedbragt budgetunderskuddet.
+Den umenneskelige udvisningsfængsling nævnes ikke med et eneste ord.
+Kommissionen regner med netop denne støtte til at udarbejde en pointtavle.
+I øjeblikket optræder der organisationer på vores liste, som ikke findes længere.
+Burmas generaler gør virkelig alt for at blive ved magten.
+Fejlen fik tragiske konsekvenser, og det er korrekt af os at fordømme den.
+Jeg troede, at dette ville koste nogle få tusinde pund.
+Derfor undlod vi at stemme.
+Hvad angår fugleinfluenza, vil vi få flere udbrud.
+Den pludselige nedbør kan ikke forklare ødelæggelsernes omfang.
+Det er ikke den procedure, som vi følger.
+De har allerede tilbragt en hel uge i lufthavnen.
+Nu ser jeg så, at det står at læse i protokollen.
+Ofrene skal have beskyttelse, også retlig beskyttelse.
+Nu er reformen udsat og synes at være langt væk.
+Hvert land arbejder hårdt på hvert område og forbedrer dermed også kvindernes situation.
+Dette spørgsmål om humanitet må ikke glemmes og vil aldrig blive glemt af formandskabet.
+Manglende specifikke midler vil desværre give sig udtryk i manglende handling.
+Vi bør derfor ikke udvande vores krav på nuværende tidspunkt.
+Derfor må vi beslutte at sende en fredsstyrke nu, det er blevet uundgåeligt.
+Men kan man se, kan man identificere de forskellige mål med idrætsudøvelsen?
+Den bureaukratiske byrde for virksomhederne skal reduceres, og de retlige rammer skal forenkles.
+Jeg formoder, det var en finne.
+Vi må være helt klar over følgerne af det, der bliver foreslået.
+Vi ser tidens tegn, hvis vi vedtager den tredje jernbanepakke.
+Det er trods alt den nyttigste måde at anvende pengene på.
+De er tæt forbundet til dem og afhængige af dem.
+Vi bekymrer os over menneskerettighederne, og jeg vil rejse to spørgsmål.
+Det er et andet meget foruroligende element.
+Som man kan se, blev de resterende aflytninger tydeligvis brugt til andre formål.
+Ordførerens opfordring til, at en række ting koordineres på europæisk plan, er forståelig.
+Lighed og ligebehandling er de eneste holdbare byggesten i ethvert civiliseret samfund.
+Større forståelse er blevet nævnt.
+Det irakiske folk vil ganske givet ikke begræde tabet af denne diktator.
+Ødelæggelserne og belejringen fortsætter.
+Jeg ønsker ikke at drøfte enkeltpersoner.
+Dette forklarer det store antal børn på børnehjem.
+Parlamentet har et meget stort ansvar i denne proces.
+Dette spørgsmål er som allerede nævnt ikke blot ungarsk.
+Alle kommissærer, ministre og parlamentsmedlemmer vil gerne kunne tilslutte sig disse ord.
+Kontrollen skal udføres i henhold til den nationale svenske lovgivning.
+Jeg så på nogle tal forleden.
+Jeg mener det er urimeligt.
+Sådanne oplysninger findes for mange traditionelle plantelægemidler.
+Dette slogan er altså forløjet.
+Det ville føre til mindre sikkerhed kun at udføre kontroller efter hændelsen.
+Dog må man i ærlighedens og realismens navn tilføje et forbehold.
+Der er ikke foretaget nogen stresstest endnu.
+Betænkningen pålægger ikke de formidlende banker oplysningspligt.
+Derfor er en foranstaltningspakke påkrævet så hurtigt som muligt.
+Af denne årsag stemte jeg imod.
+Det var den ene mulighed, nemlig at anvende kriteriet objektivt dårligt stillede regioner.
+Vi må forenkle fremtiden og lægge fortiden bag os.
+I dag er disse ord blevet latterlige.
+For selvservicering kommer der nu ikke noget obligatorisk tilladelsessystem.
+Jeg mener, at det er på høje tid at opgive den historiske tilgang.
+Lad os tale åbent om dette spørgsmål.
+Derfor mine lykønskninger.
+Jeg har fulgt landet i årevis, og fremskridtene er uomtvistelige på mange områder.
+Jeg kan heller ikke godtage, at vi med denne mekanisme skaber præcedens.
+Derfor er adgang til viden også ensbetydende med adgang til social retfærdighed.
+De samme regeringer ønsker også mindre fleksibilitet.
+Det er klart, at en energiskat ikke løser problemet.
+Men der er også nogle store udfordringer, hvad angår vores image udadtil.
+Kommissionens forslag om at fastsætte nogle maksimumstakster er det spørgsmål, vi nu drøfter.
+Jeg synes, at det er udtryk for en misforståelse.
+Privatisering skaber ikke nye arbejdspladser, tværtimod.
+Vi evaluerer, hvor vi står, og hvilket potentiale vi har.
+Den slår til lyd for en offensiv, ekspansionistisk politik.
+Så kom det indre marked og den fælles europæiske mønt imidlertid.
+Det var også min holdning.
+Jeg håber, at det fører til, at sagen hurtigt bliver taget op igen.
+Jeg vil navnlig gerne her fokusere på en styrkelse af flerniveaustyring.
+Vi ønsker en prioritering af multilaterale tiltag til løsning af internationale problemer.
+Jeg ønsker at takke kommissæren.
+Fører vores helt sikkert gode hensigter stadig til de rigtige resultater?
+Globaliseringen fører, det ved vi alle, til verdensomspændende konkurrence.
+Sund handel kan også føre til fredeligere løsninger på globale konflikter.
+Det var måske nødvendigt med en sådan finansforordning, som vi har nu.
+Der er kun aktionærerne, der skal bestemme, hvordan de organiserer deres ejerskab.
+Dette er også den officielle opfattelse, den svenske regering har.
+Derfor må vi udnytte de muligheder, som stordriftsfordele giver gennem fusioner og overtagelser.
+For det første hvad angår nødforanstaltninger.
+Hvis de ikke er det, er det egentlig forkert.
+Ofrene skal have al den støtte, som de kan tilbydes i denne proces.
+De skal kun opfylde det, vi selv opfylder i dag.
+Yderst effektiv er naturligvis forbrugerafgørelsen.
+De har foreslået en styrkelse af disse kinesiske mure.
+Jeg venter mig endvidere en hel del af forbedrede vilkår for dyrehold.
+Der er ikke hverken planter eller dyr tilbage.
+Det har efterladt mange af os med flere spørgsmål end svar.
+Det er enten sundhed, der er vigtigst, eller også er det markedet.
+Med direktivet indføres der harmonisering af uddannelseskravene til sygeplejersker.
+De var de primære ofre for de selvudnævnte hellige krigeres kaste.
+Vi opfordrer de belarussiske myndigheder til at løslade disse øjeblikkeligt.
+Jeg har imidlertid forbehold vedrørende de sprog, der skal anvendes.
+Lad mig for det tredje nævne undtagelsesbestemmelserne.
+Vi vil være forsigtige med nye love, for erhvervslivet klager over for meget regulering.
+Begge disse rådgivere oplyste, at det anvendte retsgrundlag var forkert.
+Vi må undersøge denne sag omgående.
+Politikerne bør ikke blande sig i økonomien.
+Vi ønsker alle, at han hurtigt må komme sig.
+For mig drejer det sig om en beslutning mod racisme, fremmedhad, antisemitisme og homofobi.
+Et andet spørgsmål vedrører problemet om harmonisering af stik og stikkontakter.
+Kommissionen forholder sig meget tit passiv og gemmer sig i nogle tilfælde bag reglerne.
+Desuden ved vi også, at fattigdom og underudvikling er en stor usikkerhedsfaktor.
+Det, der foregår, er uacceptabelt.
+Det medfører både menneskelige, økonomiske og sociale omkostninger.
+På denne måde opstilles kunstige barrierer for tjenesteudbydernes virksomhed.
+De har varetaget formandskabet med succes.
+For det fjerde findes der også misbrug af statsmonopoler.
+Bør vi gå mere i retning af et formelt banktilsynssystem?
+Men det endelige ord har vores befolkninger.
+Forbrugerorganisationerne vil blive hørt om indholdet i disse mandater.
+Vi er på opløbsstrækningen, men resten af vejen vil stadig være fyldt med udfordringer.
+Den intellektuelle ophavsret er nu beskyttet på passende vis.
+Sidstnævnte indebærer beskyttelse af naturen mod udnyttelse.
+Hvis ingen andre gør indsigelse, betragter jeg protokollen som godkendt.
+Uafhængige journalister lever i konstant frygt for forhør og anholdelse.
+Det begrænser en af de grundlæggende friheder i traktaten.
+Meddelelse fra formandskabet
+Dermed vender jeg tilbage til den forrige taler.
+Dette punkt medtages sidst på dagsordenen for i dag.
+Vil kommissæren skride til handling på grundlag af disse forslag?
+Vi må imidlertid ikke glemme, at disse spørgsmål er særdeles politisk følsomme.
+Indtil for nylig var malkekvægbrug askepotsektoren i den britiske landbrugsindustri.
+Derfor har klassificeringen ugyldiggjort sig selv.
+Hvis det er tilfældet, så har jeg misforstået spillet.
+Det giver en mere levende adgang til forhandlingerne end blot en tør tekst.
+Tidligere på året opgav jeg mine vigtigste prioriteter.
+Udvekslingen af bedste praksis er meget vigtig.
+Alt sammen eksempler på de talrige spørgsmål, der rejser sig.
+Det ene er et ortodokst pilgrimscentrum, mens det andet er et katolsk pilgrimscentrum.
+Dette omfatter fem portugisiske langlinefartøjer.
+Der hviler de med et utal af andre børn, og alle er de skuffede.
+Vi har derfor brug for et bedre klima.
+Udlændinge fra tredjelande beskæftiges ofte i de tungeste og lavest betalte job.
+Jeg erkender, at man kan argumentere mod centralisering.
+Så sluttelig vil jeg sige, der skal ligge nogle meget klare svar.
+Jeg kan ikke se, at det kan være længere end seks uger.
+De er et stort fremskridt med hensyn til institutionel beskyttelse af mindretallenes rettigheder.
+Industrien betaler allerede sine infrastrukturafgifter, hvoraf nogle går til miljøforbedringer.
+At bekæmpe handel med kvinder er at bekæmpe et mål, der er i bevægelse.
+Dernæst skal vi tilføje målrettede politikker.
+Har de skjulte ambitioner om at blive en stat?
+Med det mener jeg, at vi faktisk har mange forskellige arbejdsopgaver.
+Jeg vil gerne vide hvorfor, da det er meget beklageligt.
+Jeg hører bemærkninger fra mange af mine kolleger i dag om menneskerettigheder og religionsfrihed.
+Vores befolkning kan omkostningsfrit aflevere deres bil hos den endelige sælger.
+Og demokrati er ikke kun frie, demokratiske valg mellem flere kandidater og flere partier.
+Det tredje tema er hvidvaskning af sorte penge.
+Så er de efter min mening kompatible med hinanden, og vi kan vedtage dem.
+Tjenesteydelser af almen interesse er også blevet udelukket.
+De har nu i syv dage levet og overlevet i et absolut helvede.
+Konventet er et instrument.
+Der er derfor behov for klare regler og tillidsskabende foranstaltninger.
+Det, vi alle betaler dyrt for med vore bidrag, skal beviseligt have positive virkninger.
+Vi sender en valgobservatørmission, men vi sender også denne mission.
+Disse foranstaltninger kan inddeles i fem hovedbeskyttelsesniveauer.
+Han har vundet den store gevinst!
+Rusland er jo virkelig det vigtigste problem i vores udenrigspolitik.
+Men erfaringerne skræmmer.
+Det sker både nationalt og internationalt.
+Endvidere, hvor stort vil det maksimale støttebeløb være, målt i procent af skadesomkostningerne?
+Alle nationale mærker bør dog ikke skubbes i baggrunden.
+Rumfarten skal have et nyt skub fremad.
+Nogle slagterforretninger er blevet lukket.
+Jeg finder det dybt bekymrende.
+Først og fremmest er der det sociale aspekt.
+På den anden side er der produkternes forskellige miljømæssige aspekter.
+Den vil også opfordre til åbning af store arbejdspladser.
+Kommissionen har allerede taget det skridt, og det har visse medlemsstater også.
+Vi vil helt afgjort presse på, for at disse ting bliver gennemført.
+Indholdet er dog blevet alt for fokuseret på fossile brændstoffer.
+Det europæiske miljømærke er, må man sige, et barn af det indre marked.
+Det problem, vi drøfter, er både teknisk og politisk.
+Vi ønsker, at de bevæger sig i retning af demokrati og respekt for menneskerettighederne.
+Derfor har vi brug for en ny vilje til samarbejde.
+Jeg tror, at netop de grænseoverskridende møder på uddannelsesområdet kan have forbilledlig karakter.
+Jeg håber, at det også gælder os som politikere.
+Lad os tage eksemplet med det første direktiv på listen, det om vildledende reklame.
+Begrebet ligestilling mellem mænd og kvinder bør helt bestemt være indprentet i vores tankegang.
+Lad os lige huske på, at de nationale stater også har problemer.
+Det er det, vi forsøger at opbygge her.
+Med hensyn til dette emne vil jeg gerne understrege to punkter mere.
+Dette gælder også for stabilitetspagten.
+For det andet transport ad vandveje.
+De tre byggesten er nødvendige for at udvikle demokratiet på europæisk plan.
+Det skulle man tro, når man læser erklæringerne fra indholdsindustrien.
+Kommissionen vil kigge nøje på dette interessante forslag.
+Er det at diversificere økonomien i regionerne?
+Jeg hylder disse modige kvinder.
+Vi må undgå, at der sker sociale lagdelinger.
+Derfor kan man vel ikke ønske at patentere disse ting.
+Det er ikke let for dem at involvere sig.
+Personaleressourcerne skal kunne reallokeres mere fleksibelt, og overflødige stillinger nedlægges.
+Jeg vil især fokusere på større bøder og omkostninger i forbindelse med manglende overholdelse.
+Afskedigelser bliver mere og mere almindeligt.
+I den periode har vi oplevet både højdepunkter og lavpunkter i den europæiske politik.
+Det er vi stadig meget langt fra at nå.
+Jeg vil imidlertid komme med et par korte præciseringer.
+Det kan man kun fuldt ud hilse velkommen og understrege.
+Vi må derfor sikre, at det bliver mere end blot et projekt.
+Det samme gælder udviklingen af nye lægemidler.
+Erfaringen viser, at det er nødvendigt at oprette en permanent europæisk udrykningsstyrke.
+Der er desværre mange fiskeriaftaler, der er værre end denne.
+Den ville således først og fremmest berøre vores medborgere.
+Trichet oplyst, at de langsigtede finansieringsforanstaltninger er blevet forlænget endnu en gang.
+Derfor er det vigtigt, at regeringskonferencen ikke træder et skridt tilbage.
+Trods særdeles gode udgangsbetingelser forløber konjunkturen uregelmæssigt og kommer ikke i fart.
+Vi har afsat hjælp til fiskeriregionerne og hjælp til grænseregionerne.
+Det lyder måske hårdt, for min skyld måske endda simpelt, men sådan er det.
+Med menneskehandlen stiger den økonomiske og seksuelle udnyttelse også.
+Sammensætningen af denne gruppe vil blive offentliggjort i protokollen for dette møde.
+Det er, som det er blevet nævnt, nødvendigt at undgå jargon og uforståelige udtryk.
+Jeg mener, at det er i denne ånd, vi må handle.
+Det er ved overdreven indtagelse af alkohol, at problemet opstår.
+Det er en omfattende betænkning af høj kvalitet.
+Det er ikke noget at kimse ad.
+Det er af disse årsager, at jeg trods alt velvilligt stemte ja.
+Det er en stor ære og en stor hjælp for os.
+At være dum og ondskabsfuld.
+De store bilproducenter har en klar overvægt.
+Vi står ved afgrundens rand, men vi er ikke gået over den.
+Rådet afviste strengt dette og med rette.
+Der er i øjeblikket et påtrængende behov for, at man giver små, passende både.
+Graviditeten må under ingen omstændigheder være grund til diskrimination mod kvinden.
+Tiden tillader bare et par kommentarer fra min side.
+Disse midler bør vi stille til rådighed på kort sigt.
+Han var menneskelig og tog nogle gange fejl.
+Derfor mente han, at programmerne skal strammes op.
+Jeg glæder mig over alle tiltag, som kan forbedre dyrenes velfærd under transport.
+Hvis det samme sker igen, hvordan vil pagten så blive anvendt?
+I skyggen af topmødets succes lurer en uafsluttet debat.
+Kommissionen vil fortsat give sit bidrag til, at vi kan nå denne målsætning.
+Økonomisk opsplitning kommer i stedet for geografisk opsplitning.
+Kolonihaverne spiller således en vigtig rolle i det miljøpolitiske og sociale område af byerne.
+Jeg ville gerne tilføje en overvejelse om borgernes initiativret.
+Jeg siger kommissæren tak for hans svar.
+Forhåbentlig vil den amerikanske regering vælge denne løsning.
+Det har givet håb, hvor der var fortvivlelse.
+Derfor har de gjort en stor indsat i de forløbne år.
+Vi skal selv være så åbne som muligt.
+Den politik, der er gennemført hidtil, har ikke formået at ændre denne situation.
+Vi må nu afbryde forhandlingen og gå over til afstemningerne.
+Men i praksis fungerer den i de fleste tilfælde allerede nu som sådant.
+Der er ikke blevet oprettet nogen database.
+Så hvorfor ignorerer højresiden det?
+Der skal stemmes om en beslutning her på torsdag.
+Der må sættes en stopper for dette hykleri.
+De fleste af os bruger køretøjer på disse veje.
+Disse regioners handicap og problemer afspejler den europæiske integrations begrænsninger.
+Denne proces har vist sig meget nyttig.
+Dette forslag er allerede blevet præsenteret adskillige gange, men det er aldrig blevet fremsat.
+Jeg synes, en del procedurer går meget rask, meget hurtigt, som denne betænkning viser.
+Hvis vi vil noget med dette, så er det på sin plads med beslutninger.
+Det ser ud til, at de vanvittige finansmarkeder ikke har lært noget af krisen.
+Om der skal findes straffe eller bøder, var et af de mest komplicerede spørgsmål.
+Derfor er resultatet, facit, i dag ikke tilfredsstillende.
+Vi er os dog bevidst, at vi ikke kan se til i det uendelige.
+Jeg vil gerne takke ham for det.
+Det er på tide at indlede fredsforhandlinger.
+Vi startede på et meget godt grundlag, og vi samarbejdede godt hele vejen igennem.
+De skal således handle i henhold til deres egen forfatning, som ikke bliver overholdt.
+Hvordan skal dette tolkes?
+For det andet er der en overflod af ordninger.
+Trods de prisværdige hensigter er denne beslutning mangelfuld.
+De talte også om nye elementer.
+Men vi fik først dokumenterne tilsendt i september.
+En sådan overgang kan ikke klares med et seksugerskursus, men kræver et længere uddannelsesforløb.
+Dette er en anden detalje, som vi må tage hensyn til.
+Vi kan sige, at vi er nået det punkt, hvor historiske begivenheder kan ske.
+Det synes imidlertid ikke at ske i biludlejningsindustrien.
+Det er vigtigt at anerkende.
+Man kan nu engang ikke udkæmpe kompetencestridigheder på andres bekostning.
+Dette er dog kun muligt, hvis de biometriske data registreres korrekt.
+Denne aftale er et eksempel på, hvordan der kan skabes tætte forbindelser gennem aftaler.
+Det er sandsynligvis korrekt, men vi må undersøge sagen.
+Måske vil han rydde op i sit affald.
+Hermed er dette punkt på dagsordenen afsluttet.
+For de tre foranstaltninger gjaldt der forskellige betingelser for støtte.
+Vi kan ikke kritisere dem for at gøre det, men vi kan undre os.
+Helcom er indehaver af en handlingssplan for reducering af belastninger fra næringsstoffer.
+Det er den form for dynamik og drivkraft, vi behøver for at komme videre.
+Så har vi ikke noget demokrati at tabe, men alt at vinde med samarbejde.
+Jeg ønsker formandskabet held og lykke i det næste halve år.
+Jeg mener, at det er vigtigt, at vi er lidt dristigere i vores tænkning.
+Vi støtter den humanistiske vinkel, som betænkningen er udarbejdet på baggrund af.
+Jeg vil hævde, at obligatorisk oprindelsesmærkning er et tydeligt eksempel på dette.
+Personligt går jeg ikke ind for nyprotektionistiske tendenser i international handel.
+Uden en enhedsregering for palæstinenserne kan fredsprocessen ikke styres.
+Jeg har stemt for det fælles forslag til beslutning, som jeg finder afbalanceret.
+Jeg vil også nævne det cypriotiske spørgsmål.
+Under den nuværende interimsaftale bliver overholdelsen af disse principper periodisk overvåget.
+Forenkling af processerne er derimod den bedste forudsætning for at bekæmpe disse fænomener.
+Jeg synes, at vi har valgt den forkerte vej.
+Medlemsstaterne er desværre ikke længere herre i eget hus.
+Jeg tror, at vi kan have et fordrejet billede af virkeligheden.
+Hvor bliver den horisontale antidiskriminationslovgivning af?
+Det er bestemt fristende at tænke på gengældelsesaktioner via toldtariffer.
+Støjgener er lokale og bestemt ikke grænseoverskridende.
+Min gruppe stemmer derfor imod alle dele i beslutningen, der indeholder en sådan konklusion.
+Duff vil korrigere mig, hvis jeg har fået lidt forkert fat i tallet.
+Vi lægger vægt på opholdet i andre europæiske lande.
+Liberalisering kan kun gennemføres gradvist og må nødvendigvis ledsages af reguleringsprocedurer.
+Det skyldes naturligvis holdningen fra den amerikanske regering og de multinationale selskaber.
+Man fornemmer ganske rigtigt en del positive signaler.
+Indikatorer er ikke et mål i sig selv.
+Det har genoptaget høringerne og forhandlingerne mellem regeringskonferencens deltagere.
+Hvis det er det, ordføreren har foreslået, kan jeg tilslutte mig denne opdeling.
+Endvidere savner jeg incitamenter til at vælge mere sikre trafikmidler såsom toget og cyklen.
+Vi understreger derfor, at denne indsats kræver retfærdige, upartiske og uafhængige retssager.
+Rådets opfattelse i dette spørgsmål er meget mærkelig og desuden urovækkende.
+Selfplanning og analyse kan sættes i gang med det samme.
+Fru formand, det er første gang, man gør mig opmærksom på dette problem.
+Jeg håber, at de vil reagere på kommissærens opfordring.
+Martyrapporten er skrevet på en endnu mindre ansvarlig måde.
+Kosovos uafhængighedserklæring skaber store bølger i vores region.
+Direktivet er baseret på patienternes behov og ikke på finansielle ressourcer.
+Jeg er altid spændt på, hvordan de oversætter sådan noget.
+Jeg tænker her især på den græske oversættelse.
+Dette forfærdelige sår bløder stadig, og det vil bløde længe endnu.
+Desværre har mange af køreplanens aspekter været og er fortsat under angreb.
+Det er dejligt at se, at du gør, hvad du lover.
+Tyrkiets reformproces er i gang.
+Det er skuffende, at den nye forfatning ikke kunne vedtages før udvidelsen.
+Jeg er ikke enig i undermineringen af udstationeringsdirektivet.
+Men mangelen på finansiering skal afhjælpes for at høste fordelene ved disse projekter.
+Kan vi ikke nok tilskynde andre donorer til at fokusere på disse områder?
+Man bliver syg efter indtagelse af en vildtmiddag.
+Vi bliver nødt til at finde den rette balance her.
+Jeg vil også sige et par ord om standardisering.
+Der er forskel mellem en opdagelse og en opfindelse.
+Resultatet er derfor, at tre ud af fire emissioner stiger kraftigt.
+Dets hidtidige anvendelse har afstedkommet en række tvivlstilfælde eller endog direkte overtrædelser.
+Jeg vil gøre brug af konklusionen fra studiegruppen, der skal forberede regeringskonferencen.
+Et andet område, hvor der er brug for forandring, er pressefrihed og ytringsfrihed.
+Efterhånden som debatten skrider frem på regeringskonferencen, får denne uantagelige konturer.
+Ligger det ud over jeres forestillingsevne?
+Dobbeltregulering af reklame løser ikke problemet.
+Galileo er et nyttigt projekt.
+De strider ikke mod hinanden.
+Samtidig sikrer den borgerne beskyttelse med chartret om grundlæggende rettigheder.
+Israel kan gennemføre langt større operationer i dette område end tidligere.
+Jeg ville rent faktisk tage afstand fra ethvert forbud af denne art i medlemsstaterne.
+Strukturfondene bør kun bruges til at støtte bæredygtige projekter.
+Jeg ved, at sådan noget vækker angst for mere bureaukrati i begyndelsen.
+Så der må være et problem med computeren.
+I forslaget til forordning står der ligeledes, hvordan dette program skal finansieres.
+Faktisk er der proklameret en forlovelse, der højner den sociale dialogs legitimitet.
+Det er hele tiden arbejdstagerne, der betaler, aldrig plutokratiet.
+Der findes europæiske standarder for fødevaresektoren, der sikrer en effektiv produktkontrol.
+Næsten uundgåeligt betyder i vort vestlige samfund styring af omkostningerne færre arbejdspladser.
+Disse master formerer sig hastigt i mit eget land.
+Vi må være parate til udfordringerne ved økonomiske ændringer og reformer.
+Det betyder, at der egentlig er en hel del ting, der er i fare.
+Men vi har fundet et kompromis, og derfor skal forhandlingen afsluttes.
+Jeg kan desværre på grund af tidnød ikke gå i detaljer.
+Efter vor mening er det et frontalangreb på vedvarende energikilder og energieffektivitet.
+Vi håber, at det luxembourgske formandskab vil udtænke en mere rimelig løsning.
+Reel lighed er stadig en drøm, og diskrimination imod kvinder er et faktum.
+Men hvad er det nøjagtigt, samfundet forventer?
+Det ville jeg have haft opklaret i betænkningen.
+Skal de medregne tilgængeligheden af tilstrækkeligt kvalificerede ansøgere?
+Er det designet, materialerne, kvaliteten af konstruktionen eller bygningstilsynet?
+Jeg tænker her især på merværdiafgiften.
+Jeg har allerede sagt, hvad vi vil gøre, når jeg har fået oplyst kendsgerningerne.
+Forhåbentlig er der en række undtagelser og reduktioner for børn, studerende og aktive unge.
+Hvad angår alternativerne, er de fremlagt i rammeprogrammet.
+Zuma, at det ganske enkelt ikke er en mulighed.
+Nigeria er desværre et eksempel, som vækker bekymring.
+I denne forbindelse er det postdirektivet, som er lakmusprøven.
+Valget er ikke legitimt, eftersom den siddende præsident kom til magten ved et statskup.
+Dels det symbol, der ligger i temporal enhed.
+Derfor er vi ikke enige i ordførerens meget kritiske vurdering og begrundelse.
+Det havde været tilstrækkeligt at udskyde denne debat til en senere dato.
+De skal beskyttes ordentligt.
+Demografiske udviklinger kan altså meget hurtigt blive aktuelle.
+Der ses også på de miljømæssige aspekter og på handicappede menneskers situation.
+Men jeg har ikke støttet hende på dette punkt ved førstebehandlingen.
+Det er det, som er sagens kerne.
+Dermed har den i første omgang stået sin prøve.
+Det er en myte, at statskontrol kan begrænse spekulation i selve knudepunktet for spekulation.
+De har ikke nogen som helst officielle oplysninger.
+Det nytter helt sikkert ikke at oplagre kød alene.
+Jeg støtter et stærkt substitutionsprincip.
+Jeg er den tredje ordfører om de baltiske lande.
+Det syvende rammeprogram kan heldigvis virkelig koncentrere sig om topforskningen.
+Vi ser ikke nogen fornuftig grund til udsættelse.
+Alt dette skal afklares, før vi kan påbegynde en lovgivningsproces.
+Man har desuden gjort det umuligt for somalierne at sende penge til trængende familiemedlemmer.
+Denne undervurdering er ikke uskadelig.
+Vi skal åbne døren helt for oplysninger, vi selv søger.
+Disse mål, demokrati og effektivitet, nås kun gennem en føderalistisk model.
+Sundhedstjenester, socialt boligbyggeri, lokalsamfund og børnepasning må ikke behandles som varer.
+Det har bragt os frem i førtiltrædelsesfasen.
+Det betyder, at der inden for seks år vil blive behov for en revision.
+Kosovos regering må forstå, at respekt for mindretals rettigheder er en europæisk værdi.
+Hensigten med dette forslag er, at vi skal kunne sige det samme om skattefar.
+Mit sidste punkt er nulmålsætningen på langt sigt.
+Hans intervention i debatten i går var da beklageligvis også en stor omgang jamren.
+Der aftegner sig tre udfordringer til den europæiske industri.
+Dette emne har været genstand for lange og ophedede diskussioner.
+Vi vil fortsat være årvågne og strenge.
+Politikere og højere embedsmænd diskuterer nu åbent, hvordan man skal tackle disse valgresultater.
+De udarbejder europæiske standarder, som aftales ved konsensus og er baseret på frivillig aftale.
+De materielle ødelæggelser vil præge hverdagen i lang tid fremover.
+De tjener solidaritetens og subsidiaritetens principper.
+Derfor appellerer jeg meget indtrængende til at indføre den europæiske dimension.
+De frister en tilværelse mellem viden og profit.
+Alligevel fortsætter flygtningestrømmen.
+Jeg vil understrege, at kvinder i disse situationer også har ret til at vælge.
+Udvalget ser desværre hele tiden bort fra disse modsætninger.
+Jeg skal begrænse min belysning heraf til et par eksempler.
+Biavl fremmer også den økonomiske udvikling i landdistrikter.
+Hvor der ikke er en sådan velstand, er der heller ikke så massive problemer.
+Det er specielt farligt at forlænge den nuværende situation.
+Et stadig større antal unge kan ikke følge undervisningen i overskoler eller på universiteter.
+Hvad angår sikkerhed, bør vi på intet tidspunkt spring over, hvor gærdet er lavest.
+Indlæg af et minuts varighed om politisk vigtige sager
+Under sådanne omstændigheder ville det være dumt ikke at udvide dagsordenen.
+Hundredtusindvis er spærret inde, og mange har ikke adgang til humanitær bistand.
+Positiv særbehandling skal ikke bruges hovedløst og automatisk.
+Der er en række positive ting i denne dechargebetænkning.
+Jeg rejste dertil og spurgte ad.
+Tøver vi nu, siger vi, at menneskerettigheder ikke har nogen plads i international politik.
+Vi skal derfor snarest fremsætte et ændret forslag.
+Jeg vil som dansker gerne sige, at det er jeg fuldstændig enig i.
+Afgørelse om uopsættelighed
+Det bliver endnu vanskeligere at nå legitime økonomiske mål.
+Det er jo faktisk hele processens troværdighed, der står på spil.
+Det skal i højere grad dreje sig om varig turisme.
+Vi tager punktet ad notam, men jeg ønsker ikke at genåbne forhandlingen nu.
+Det er trods alt blot et system, som har givet reelle liberaliseringer af verdenshandelen.
+Bitumenholdigt sands miljøpåvirkning er klar.
+Denne kriminalitet udvikler sig på tværs af grænser.
+Europa er trækplaster nok til, at journalister ikke behøver at få en godtgørelse.
+Fællesskabets indvandringspolitik er fortsat skizofren.
+De egentlige udfordringer med genetisk manipulation er faktisk af etisk og miljømæssig art.
+Vi skal rent faktisk redde hele landet.
+Vi har løst de problemer, som programmet havde i starten.
+Det syntes jeg, at jeg ville understrege, for det kan være blevet glemt.
+Flystøj er dermed blevet en plage for en stadig større del af befolkningen.
+Vi vil også skabe sikkerhed for, at udvalgsformændene ikke bistås af medarbejdere.
+Derfor håber jeg, at vi enstemmigt vedtager en betænkning, der kritiserer disse forhold.
+Jeg er uenig i dette, da det kan føre til øget korruption og overtrædelser.
+This is the game that we came here for.
+Men nogle tjenestegrene synes at udnytte den aktuelle uklare situation til egen fordel.
+Analyser viser, at elforbruget på verdensplan vil blive fordoblet i de nærmeste årtier.
+Nielson nu har vist initiativ til at ville gøre det.
+Der blev givet en vetoret baseret på befolkningsantal til brug for de store lande.
+Jeg trøster mig med, at jeg ikke er den eneste.
+Disse mennesker prøver at forbedre deres liv, og det er ikke en forbrydelse.
+Affald, der indeholder asbest, er farligt affald.
+Det er et klart budskab, som skal sendes til den amerikanske ledelse.
+Det er derfor meget usædvanligt, at man ikke har behandlet dette spørgsmål.
+Jeg takker rådsformanden for hendes svar.
+Den materielle skade beløb sig til halvanden milliard euro.
+Her vil aftalen næppe spille en rolle.
+Fra industriens side anføres, at modeltekniske tilpasninger kræver en lang periode.
+Jeg håber, at der snart bliver indgået en aftale om dette forslag.
+Kommissionens beretning er meget omfattende.
+Denne finansiering vil således ikke automatisk blive dækket af de finansielle overslag.
+Desværre er det stadig sådan, at mange unge begynder at ryge.
+Det vil reducere transportomkostningerne, godtgørelserne, hotelregningerne osv.
+Denne import er steget betragteligt de sidste fem år.
+Europa skal have menneskeværdige fængsler.
+Derfor bringer jeg dette emne på bane.
+Det bliver interessant at se, om kommissæren har lyttet til disse bekymringer.
+Disse data kan man anvende på en rimelig og lovlig måde.
+Jeg har nu to års erfaring i min nye kapacitet.
+Økonomiske sanktioner har samme mål.
+Det vil også lette presset på vejene og flytte transportstrømme over til jernbanen.
+Desværre kan vi intet gøre for de forsvundne, men blot kondolere deres familier.
+Beslutningsforslaget er fyldt med det kendte julestads som f.eks.
+Nederlænderne har ofte ved plenarmødet klaget over, at det nederlandske fjernsyn ikke kan ses.
+Allergene parfumestoffer forbydes også i overvejende grad.
+Normalt bliver det ikke til meget mere end diskrete hentydninger.
+Et andet problem, som vi får med at gøre, er falskmøntneri af kontanter.
+Forslaget er et eklatant eksempel på manglende respekt for nærhedsprincippet.
+Som bekendt har århundreders borgerkrige præget vores erindring.
+Der ser man kun de flasker, som kan genbruges.
+Vi vil have svigtet set ud fra børnenes perspektiv.
+Så jeg er meget enig i det, det ærede medlem har sagt.
+Med henblik herpå er to modeller mulige.
+Det virker helt utroligt på mig.
+Jeg plæderer for, at man ikke driver en kile ind mellem parlamenterne og regeringerne.
+Fremskridt forbindes med høj kvalitet på højere læreanstalter.
+Der kom et polariseret svar ud af konsultationen.
+Fiori for et bemærkelsesværdigt engagement i denne sag.
+Jeg synes, at det er en meget klog beslutning.
+Vi skal i sidste ende opnå en politisk løsning.
+Jeg mener, at det vil føre til ustabilitet.
+Forfatningen blev sat ud af kraft.
+Jeg vil prøve at illustrere dette med et eksempel.
+Der foreligger ikke nogen troværdig beregning af udgifterne og de sociale konsekvenser.
+Det er ikke uden grund, at stålindustrien er blevet nævnt.
+De forskellige magter i verden bakker ikke op om disse mennesker.
+Tiden er inde til at fremskynde etableringen af en permanent international strafferet.
+Hvorfor pålægge unormalt korte frister for opfyldelsen af disse nye forpligtelser?
+Hvilken anden mulighed har de end dette oprør, end at protestere mod deres skæbne?
+Så lad os få en mere nuanceret tilgang, hvor man også skuer fremad.
+Den måde, de bruges på i dag, er langt fra optimal.
+Efter min mening starter den reelle debat med denne irske folkeafstemning.
+Jeg opfordrer til, at vi gør den mere synlig i de kommende år.
+Gør nogen indsigelse mod, at det mundtlige ændringsforslag sættes under afstemning?
+Samtidig har personer kunnet passere grænserne uden at vise pas.
+Dette direktiv kræver en rimelig kompensation for visse af undtagelserne, herunder privatkopiering.
+Nuvel, i første omgang en positiv vurdering.
+De er værd at kæmpe for, og det er præcis, hvad jeg vil gøre.
+Det største problem, hvad angår de egne indtægter, udgør momskarrusellerne.
+Fiskeriet reducerer mængden af genudsætninger og bidrager til torskeproduktionen.
+Ellers fremgår det ikke, hvad tvisten handler om.
+Det er for nemt at foregive, at jernbanernes tab af konkurrenceevne skyldes manglende liberalisering.
+Jeg synes om kommissærens næstsidste afsnit om, hvordan bilindustrien bør være.
+Der findes ingen væsentlige eller rationelle begrundelser herfor.
+Hvis vi virkelig vil bekæmpe det, er oplægget for enkelt.
+Den aktuelle økonomiske situation kræver ro og forsvarlige indgreb.
+Og det skal være reformer, der er langvarige, vedholdne og målrettede.
+Det gjorde vi ikke dengang, vi ændrede bestemmelserne i stedet.
+Jeg håber, at vi er på rette spor her.
+Men jeg vil påstå, at de er bedre end det europæiske gennemsnit.
+Det er ubegribeligt, at man kan indgå aftale med en retspolitisk bananrepublik.
+Kun at tale om watt siger ikke en stor del at menneskene noget.
+Jeg har altid forsøgt at lade så mange som muligt komme til orde.
+Det var min hensigt, men jeg vendte papiret for hurtigt.
+Transponderne udsender flyets kode og dets position.
+Det ville helt sikkert have resulteret i et nej.
+Den er uegnet til manden på gaden.
+Tiltrædelsesforhandlingerne fortsætter målbevidst under det finske formandskab.
+Bankerne har trukket sig tilbage i deres skjul og tjener ikke deres formål.
+Hvis lægerne ikke får det, vil deres dømmekraft lide under det.
+Det vil skabe meget utilfredshed og ærgrelse.
+Disse punkter er for vage og vanskelige at håndtere som rettesnore.
+Det er det resultat, vi vil opnå ved hjælp af disse kliniske forsøg.
+Det internationale samfund skal drage passende konklusioner heraf.
+Begrebet volontørtjeneste findes ikke i den finske arbejdsmarkedslovgivning.
+Det er derfor logisk, at nogle af mine kolleger her vil modsætte sig betænkningen.
+En krig derimod kan få fuldstændig uoverskuelige følger.
+Dertil skal først og fremmest udbuddet gøres bedre, mere forskelligartet og mere konkurrencedygtigt.
+Det er vigtigt, at disse mål forbliver øverst på verdenssamfundets prioriteringsliste.
+Vi er nået langt, men der er stadig diskussion om et par ømtålelige punkter.
+Fra nu af vil hvert led i fødekæden blive en integreret del af produktionsprocessen.
+Derfor siger mit parti, at vi skal stole på folket og holde en folkeafstemning.
+De ændringsforslag, der er stillet til betænkningen, kaster imidlertid barnet ud med badevandet.
+Det er en måde at bevise den europæiske moms og dens effektivitet.
+Deres ideer spredte sig meget hurtigere og bredere end de selv.
+Det vil betyde bæredygtig vækst.
+Det synes jeg, at rapporterne om denne sag har vist os.
+Parlamentet har ydet et betydeligt bidrag til denne proces.
+Vi skal ikke straffe befolkningen for dens leders misgerninger.
+Nu vil bankcheferne endnu en gang få rekordhøje lønninger.
+Jeg anfægter ikke personspørgsmålet, men procedurerne.
+Jeg har anlagt følgende filosofi ved udarbejdelsen af betænkningen.
+Testene giver nye muligheder for at teste et stort antal dyr på rutinebasis.
+Jeg vil sørge for, at der tages hensyn til det ærede medlems synspunkter.
+Det er, fordi disse befolkninger ikke er neurotiske.
+Efter vores opfattelse er energi en livsfornødenhed, og adgang hertil er en grundlæggende rettighed.
+Det er vores hensigt at indhente alle nødvendige oplysninger om indsamlingen af fingeraftryk.
+Det er derfor imamernes opgave at hjælpe med at udrydde dette fænomen.
+Unionens interesser er hverken en samling eller en udvidelse af medlemsstaternes.
+Men vi bør også nedsætte arbejdstiden som en del af forbedringen af beskæftigelsesmulighederne.
+Han blev indlagt på hospitalet med åbent sår.
+Det er en skam, han ikke havde tid til at høre mit svar.
+Haiti kommer også på dagsordenen for topmødet af indlysende årsager.
+Det skorter ikke på midler til køb af mad og medicin til befolkningen.
+Vi agter at øge denne form for samarbejde og koordination hurtigst muligt.
+Dette er absurd og i sandhed vanskeligt at forsvare rent demokratisk.
+Den forfatning er død og begravet, i det mindste hvis vi kalder os demokrater.
+Den kan ikke gå fremad på kun to ben et monetært og et socialt.
+Herved er der lagt pres på koalitionen.
+Gennemførelsesforordningen fastlægger den administrative arkitektur for, hvordan dette skal fungere.
+Det virker sandsynligt, at disse udsving vil fortsætte, fru kommissær.
+De to forordninger er trådt i kraft, og vi anvender allerede den nye pagt.
+Logisk set burde kravet om klarificering af procedurerne heller ikke gøre det.
+Der er ikke bare trojanske heste, men også mange falske identiteter på nettet.
+Jeg er bange for, at denne tekst vil vække bekymring i målgruppelandene.
+Jeg har derfor uden forbehold stemt for frigivelsen af støtte fra fonden.
+Kære kolleger, det drejer sig ikke her om et fantasifuldt initiativ.
+Ingen europæisk sejr eller civilisation er betydningsfuld på verdensplan uden økonomisk innovation.
+Jeg er også nødt til at nævne samarbejdet med det tjekkiske formandskab.
+Derfor må kollektive søgsmålsmekanismer indeholde dertil egnede forholdsregler.
+Jeg har tre årsager til min anmodning om henvisning til fornyet udvalgsbehandling, fru formand.
+Jeg finder, at vi ved denne lejlighed bør tilbyde vores samarbejde og vores velvilje.
+Ikke desto mindre kan vi ikke acceptere denne betænkning.
+Det er jeg meget lidt begejstret for.
+Jeg vil igen understrege, at der er behov for stor forsigtighed inden for bioteknologien.
+Der er allerede truffet nogle afgørelser.
+Europa må gribe ind for at lukke denne kløft mest muligt.
+Det er rigtigt, at vi befinder os i en vis overgangsfase.
+Kun hvis vi ikke lader os splitte, kan vi være stærke.
+Der er ikke et loft uden et gulv.
+Endnu en gang hjertelig tak!
+Derfor forløb valgkampen ensidigt.
+Det er nødvendigt, at vi beholder landbrugsudgifterne på et ordentligt niveau.
+De oplever, hvordan deres hjem rives ned.
+Er alle hindringer for det transatlantiske marked uønskede?
+Nogle mener, at han er for veg.
+Derfor skal medlemsstaten fremgå af etiketten.
+De har allerede rigeligt med våben.
+Vi bør stræbe efter at opnå resultater og fortsætte arbejdet konsekvent!
+Uanset vores politiske tilhørsforhold har vi arbejdet for kultur, uddannelse, unge og sportsfolk.
+Det har været en udfordrende proces, især på grund af omarbejdningens meget restriktive karakter.
+Jeg støtter det beslutningsforslag, som vi skal stemme om i morgen.
+Der er blevet sagt meget om islam her.
+Det er sådan, tingene i virkeligheden hænger sammen.
+Men der er ikke sket noget.
+Men man er en ganske smule urolig for sammenføjningen af alle frihandelszonerne.
+Hidtil har forslagene været uhyre detaljerede.
+Svineindustrien er vigtig.
+Strukturfondene er blevet nævnt som en potentiel kilde til boligfinansiering.
+Andre prioriteter er afbetalingen af høj statsgæld og omstruktureringen af pensionssystemer.
+Denne arbejdsløshedskrise forsvinder ikke, fordi vi nægter at afholde flere møder.
+Vi har ikke brug for en eskalering af overskrifter i pressen.
+Websteder af samfundsmæssig interesse omfatter for øvrigt også websteder af kommerciel art.
+Derfor bør man naturligvis være påpasselig med enhver form for triumferen og jublen.
+Jeg vil også gerne understrege betydningen af garanti mod handelsforvridning.
+Vores klima trues af både vores udnyttelse og afhængighed af fossile brændstoffer.
+Den nye version er en forbedring i forhold til den første.
+På den måde kan forbrugerne vælge på velinformeret grundlag og opnå bedre lånevilkår.
+Men det er bare sådan, at vi ikke har en fælles visapolitik.
+Er deres stemmeforklaringer så gyldige eller ej?
+Det er desuden billigere end at anvende ineffektivt biobrændsel.
+Pakken er ligeledes et led i vores forsvar af euroen.
+Socialpolitikkens eksterne dimension er en vigtig prioritet for vores gruppe og for mig personligt.
+Vi skal have tillid til forbrugerne og lade dem drikke, hvad de vil.
+I et år, hvor vi oplever masseafskedigelser, er dette aspekt næppe helt irrelevant.
+Først da kan vi atter vinde de europæiske vælgeres støtte.
+Den anden type ændrer forslaget materielt ved at tilføje eller slette visse vigtige bestemmelser.
+Kommissionen skal begynde at behandle middelhavslandbrugerne rimeligt.
+I den forbindelse er den europæiske naboskabspolitik et vigtigt instrument.
+Desværre er tempoet for dem faldet.
+Vi skal især lægge vægt på at beskytte sårbare grupper som børn og gravide.
+Disse områder øger blot bureaukratiet og tynger budgettet uden at bidrage med væsentlige resultater.
+Tre europæiske statsborgere holdes stadig som gidsler.
+Vi skal vælge ægte frihed.
+Virkningerne er katastrofale.
+Det sker på grund af en manglende europæisk integreret havpolitik.
+Derfor er de såkaldte europæiske partier på udkig efter nye næringsveje.
+Alle omkostninger, der lægges til ordrens værdi, afholdes af sælgeren.
+De udgjorde et betydeligt fremskridt.
+Nanopartikler har ikke samme toksiske egenskaber som almindelige partikler.
+Racisme er et indviklet sagsområde, som giver anledning til forvirring.
+Vi kan dog ikke glemme så mange uskyldige ofres lidelser.
+Der er politiske, økonomiske, kulturelle og åndelige rum såvel som sociale rum.
+Kommissionen bedes foretage denne positive bestemmelse i fremtiden.
+Hvis folk tror, ejere ikke påvirker dagbladene, må de tro om igen.
+Den europæiske bilindustri er en central branche.
+Derfor har vi brug for bindende mål for energieffektivitet.
+Spørgsmålet om dominerende nationale selskaber er meget følelsesladet.
+Jeg tror, at det kunne have hjulpet os.
+Det bulgarske parlament har i øvrigt enstemmigt udtalt sig herfor.
+Lad os slå ind på denne kurs.
+Måske skulle vi også overveje at kanalisere penge i denne retning.
+Vi skal have stoppet denne nedgang.
+Det besluttes ikke her, det besluttes faktisk derude i medlemslandene.
+Lad os få de andre på bordet.
+I år vil vi kunne glæde os over et budget, der sparer skatteyderen mere.
+Det vil betyde, at vi frasiger os vores ansvar.
+Det skal omsider slås fast, at denne såkaldte kritiske dialog er mislykkedes.
+Vi afviser denne pakke som en overdrevet abstrakt og misvisende fremgangsmåde.
+Det er desuden godt at notere, at en bedre køremåde også skåner miljøet.
+Og som sådan fungerer den uafhængigt af en hvilken som helst eksklusiv regional kontekst.
+Vi har samtidig problemer med vores skærm og computer.
+Denne ensidige løsrivelse skaber en utilladelig præcedens i internationale relationer.
+Ovenstående retningslinjer sigter også mod at styrke vor konkurrenceevne.
+I takt med at befolkningen forandres, gør deres kultur det også.
+En tredje fælde er måske uklarhed.
+Der skal gives nødlån og ikke andet.
+Men behovet for yderligere, ubegrænsede beføjelser er ikke blevet bevist.
+Uddannelsesmæssig segregering er en af de værste former for forskelsbehandling for romanibørnene.
+Hydroelektricitet er en vedvarende energikilde.
+Som følge heraf går hver dag mange europæiske arbejdspladser tabt, og nye bliver oprettet.
+Hvem giver medlemsstaterne pengebeløbene i første omgang?
+Vi må ikke forveksle humanisme med naiv optimisme.
+En tilpasning af denne begrundelse forekommer mig derfor nærliggende.
+Jeg vil omtale nogle af de vigtigste ændringsforslag nærmere.
+På det punkt vil vi være urokkelige.
+Disse oplysninger findes iøvrigt stadig på hjemmesiden, hvis nogen skulle være interesseret deri.
+Efter de ufødte børn kommer turen til oldingene.
+Rådet er besluttet på at støtte de stærkt forgældede fattige lande.
+Det vil sige, når der er tale om forsæt og grov uagtsomhed.
+Det bør stå klart for forbrugerne, hvad de lægger i kurven.
+Dette har ikke udmøntet sig i højere lønninger eller en væsentlig stigning i beskæftigelsen.
+Mange børn og gamle mennesker dør allerede af sult.
+Samtidig skal de tilpasse deres interne procedurer og om nødvendigt opgradere deres udstyr.
+Massemediernes dækning under valgperioden anses for at være ensidig.
+Det stiller os over for et grundlæggende dilemma.
+Meget store mængder brugt affald fra atomubåde er lagret under meget dårlige forhold.
+Det andet praktiske spørgsmål vedrører den blå boks.
+Hvis det er ulovligt, er vi nødt til at indlede en overtrædelsesprocedure.
+Men jeg gentager, at dette kun kan være et første skridt.
+Men det er også nødvendigt at bygge broer til de andre kontinenter.
+Jeg kan også acceptere, at visse grundlæggende kriterier overføres fra bilagene til artiklerne.
+For det fjerde ønsker vi, at der udarbejdes en pluralistisk og uafhængig evalueringsmetode.
+Hvilke forhold oplever dem, der arbejder på dette fabriksfartøj?
+Men først og fremmest skal vi bekæmpe de mafiaer, der handler med mennesker.
+Måske skulle de have tænkt sig om en ekstra gang, før de accepterede udbetalingen.
+De har rent faktisk forsøgt at regulere reklamen for tobaksvarer.
+Det samme gælder for olien.
+De regionale forskelle mellem bjergområder og lavlandet er helt åbenlyse.
+For det andet er det decentralisering, som skal forhindre en opsplitning af landet.
+Lugten af korruption er alle vegne og bliver værre dag for dag.
+Efter at to forslag til havnedirektiv er kuldsejlet, måtte der nytænkes.
+Det er deres lille frynsegode.
+For det femte er det klart, at antallet af inspektioner skal øges.
+Vi må erkende, at ingen hengiver sig til at transportere dyr af lyst.
+Protokollen fra mødet i går er omdelt.
+Dertil kommer, at de pågældende summer grundlæggende er symbolske.
+Europa gør noget for sikkerheden til søs og forebyggelsen af forurening.
+I den forbindelse skal to interesser afvejes.
+Det skete på en uciviliseret måde.
+De glemte blot, at den lammende regel om enstemmig beslutningstagen stadigvæk finder anvendelse.
+Jeg husker, at jeg gik til udvalget og sammen med kvinderne argumenterede for andragendet.
+Hurtigruterne udgør et betydeligt fremskridt henimod den sande liberalisering af jernbanemarkedet.
+Kommissionen vil omhyggeligt gennemgå konsekvenserne af at vedtage en sådan bredere definition.
+Flere og flere børn og unge lider af forhøjet blodtryk og diabetes.
+Foranstaltninger til beskyttelse af skove er af afgørende betydning.
+Det er derfor, at jeg insisterer på sikkerhed, uanset pas.
+Men harmoniseringen af momssatserne og andre satser spiller også en vigtig rolle.
+Men meget kan stadig gå galt.
+Afstemningen finder sted under mødeperioden i første uge af maj.
+Det skaber problemer i form af miljøforurening, støj, trængsel og ulykker.
+Det vil også være en hjælp i den tyske diskussion om den nye postlov.
+Vi følger med den største opmærksomhed den politiske udvikling og de tiltag, der bebudes.
+Tilsætning af sødestoffer skal reguleres og fremgå klart af etiketten.
+Hvis man virkelig vil, kan man ganske vist stadig afvise disse gamle fly.
+Den tredje er, at der må gennemføres en formelig revolution i forvaltningen af fiskeressourcerne.
+Taler vi ondt om virksomheden?
+Af alle disse grunde støtter jeg ikke afskaffelsen af mælkekvoteordningen.
+Jeg er glad for, at vi er enige om betydningen af åbenhed og gennemsigtighed.
+Alle foranstaltningerne, som i bogstavelig forstand skal sættes på skinner, har længe været påkrævet.
+Er en centraliseret pengepolitik acceptabel for lande, som har så udpræget forskellige rentesatser?
+Direktivet indplacerer entydigt kosttilskud som fødevarer.
+Syrien er en kæmpe katastrofe.
+Derfor kommer den femte samhørighedsrapport på det helt rette tidspunkt.
+Udviklingslandene kan nemmere nå tærskelen.
+Ville det ikke være en lovende metode?
+De bliver fritaget for at betale skat.
+Den bør ikke nedprioriteres eller ophæves.
+Der blev arrangeret et, som resulterede i en regering og i et statskup.
+Derved skaber man nemlig et forkert indtryk hos mennesker.
+Et sådant hus skal så også have en vicevært.
+Afghanistan og dets befolkning har fortjent vores fulde engagement.
+Sidste år sagde vi for første gang, at der skulle indføres nationale erklæringer.
+Man må mildest talt sige, at forbrugerens interesse ikke altid følger producenternes.
+Dette problem kan ikke klares med elektricitet eller gas, da det er politikernes opgave.
+Den slags nyheder er daglig kost.
+Kan der anlægges sag mod dem?
+Vi må hurtigst muligt bringe subsidierne til fossile brændstoffer til ophør.
+Så marcherer vi væk fra funktionsdygtige genbrugssystemer i retning mod uløste affaldsproblemer.
+De kan ikke eksistere side om side.
+Der er mange flere uudnyttede muligheder.
+Det sidste kan godt gå hen at blive meget vanskeligt.
+Malta berøres rent faktisk mindst, idet der ikke er nogen permanent fuglebestand på øen.
+At fotokopiere gener og herefter kalde dette en opfindelse er en videnskabelig parodi.
+Det vil sige de medicinske og videnskabelige usikkerheder, der stadig hersker.
+Det er en helt klar advarsel.
+Vores historie disponerer os til at være forsigtige.
+Men der er stadig meget, der skal gøres, først og fremmest på asylområdet.
+Sikkerhedsfolk, der var klædt som demonstranter, angreb på lumsk vis og med stor brutalitet.
+Vi er ikke ekstremister, så i dette nødstilfælde stemmer vi altså for budgettet.
+Desværre kan jeg kan ikke acceptere den burmesiske regerings og de burmesiske myndigheders opførsel.
+Dernæst fordi bestemmelserne i dette kapitel er nyttige.
+Han skal efter min mening støttes af vores diplomatiske indsats.
+Vi deler rent faktisk et overordnet og fælles syn på indvandring.
+Men det er rigtigt, at jobskabelsen stadig halter bagefter.
+Hvis de ingen finder, er det deres pligt at videregive denne oplysning.
+Efter min mening er det soleklart, fordi via dem kan miljøpolitikkens centrale områder styres.
+Jeg ved, at landbrugerne ikke plejer at holde sig tilbage.
+Alligevel er de udenlandske reserver nødvendige.
+Vi skal sørge for at lette byrden for producenter, distributører og detailhandlere.
+Den modvirker hele intentionen med betænkningen.
+Fiori var inde på, og at for meget realisme virker svækkende.
+På sundhedsområdet må vi overveje, hvordan vi især kan behandle aldersrelaterede sygdomme.
+Renaults ledelse, som ikke har fremsat noget konkret forslag, fastholder sin beslutning.
+Dermed ikke være sagt, at andre forureningsrelaterede sygdomme ikke skal omhandles af dette program.
+Vi er meget foruroligede over disse voldelige angreb.
+Med lidt god vilje og fantasi kan denne cirkels kvadratur løses.
+Det var en meget malende beskrivelse.
+Disse ord var ubesindige og byggede ikke på fakta.
+Ellers får vi en helt mislykket kemikaliepolitik.
+Vi ønsker at fortsætte med samme omhu for vores forhandlingsdokumenter.
+Vi kan ikke have en visumpolitik, hvis ikke vi har grænsekontrol.
+Den skulle træde i kraft om nogle måneder.
+Enhver havn eller ethvert skib er specifikt.
+Dette er imidlertid stadig kun dråber i et hav af behov.
+Dermed krænkes menneskeværdigheden.
+Desuden mener jeg, at vi bør støtte genopbygningen af de grundlæggende serviceydelser.
+Det er helt afgørende i lyset af næste års præsidentvalg.
+At ingen i virkeligheden ville have et frihandelsområde, og det beroligede mig meget.
+Jeg ser, at kulturpolitikken skal blive den tap, som den europæiske politik drejer om.
+Jeg er nysgerrig efter at se, hvordan fondene konkret vil blive administreret.
+Lad os være blandt dem, der forsøger at frelse det.
+Kommissionen bevarer på sin side kontakten til de berørte medlemsstater.
+Jeg vil endvidere gerne henlede opmærksomheden på liberaliseringen af energimarkedet.
+Vores arbejde er ikke færdigt.
+Denne stat, denne regering, denne præsident håner mænds og kvinders rettigheder.
+Vi udleverer også lister til dem og siger, her, her, her, noget skal gøres.
+Deres forventninger skal endvidere imødekommes.
+Tal om at skyde spurve med kanoner!
+Med henblik herpå skal den optages i traktaterne.
+Tibetanerne er berørt af dem, men også ugurerne og mongolerne.
+Vi talte om, at han var i fare for at dø.
+Dette er rigtigt og på sin plads, idet familien og børns trivsel bliver inddraget.
+Ifølge deres rådgivning bør alle lovforslag opridse formålet med den foreslåede lovgivning.
+Jeg tænker her på nødvendigheden af et mere solidarisk og generøst koncept om migration.
+Nye medlemmer vil naturligvis straks skulle have løn i overensstemmelse med det nye system.
+Busk, for deres udmærkede betænkning.
+Men betænkningen indeholder både korrekte videnskabelige data og fejlagtig polemik.
+Vi skal støtte det libanesiske folk, og vi skal støtte de libanesiske demokrater.
+Ingen forlader sit land, sin kultur og sin familie for sjov.
+Men dette er ikke reelle besparelser.
+Direktivet forbyder kloning.
+Sådanne netværk har vi brug for.
+Her er der også store ubalancer.
+Tekstiler og tøj er især berørt, særligt på grund af sektorens høje gradueringstærskel.
+Denne beskrivelse er også dækkende i negativ forstand.
+Udviklingen i det indre marked skal ikke overlades til markedets nåde.
+Coelho med yderligere to succesfulde betænkninger.
+Militære øvelsesflyvninger i lav højde skal forbydes, hvis der er risiko for borgerne.
+Parlamentet skal gøre det ved at turde give ansvarsfrihed, når der er problemer.
+Hun foreslår, at differencen skal betales ud af de nuværende kvoteejeres lommer.
+Også dets industri, dets landbrug og dets tertiære sektor frembyder gode muligheder for udvikling.
+Fred kan kun baseres på ligeværdig respekt for modpartens territoriale integritet og rettigheder.
+Hovedproblemet i nutidens samfund er netop, at alderspyramiden bliver stadig bredere i toppen.
+Terrorister, mordere og kommunister!
+Jeg ønsker ikke at se disse ting degenerere til overcentralisering, kaos og forvirring.
+Denne særdeles lave pris er kun mulig på grund af masseproduktion på minimale arealer.
+Eksportstøtten udfases også.
+Alle flypriser skal uanset salgsvejen fremstilles omfattende og detaljeret.
+Ensartet anvendelse af forordningen er desuden af stor betydning.
+Spredningen over generationer og risici gør, at fondene kan investere så meget i aktier.
+I den nuværende situation er der mere end nogensinde brug for en sådan domstol.
+Vi må erkende, at usikkerhed og blomstrende opiumsvalmueproduktion er to sider af samme sag.
+Vi har også forslag om minimumsnormer vedrørende information, samråd og delagtighed.
+Man gav mig mit gamle kort tilbage.
+Der er en imponerende ambition heri.
+Jeg glæder mig også over den gradvise fremgangsmåde og udelukkelsen af lavrisikoaktiviteter.
+Vi forventer langt mere, ikke bare som den europæiske venstrefløj, men som europæiske borgere.
+Vi bør heller ikke glemme, at fødselstallet er faldet i de seneste år.
+Han standsede for at hjælpe et medmenneske, der var i nød.
+Jeg vil gerne slå fast, at jeg er imod anvendelsen af dødsstraf for mindreårige.
+Disse informationer er ikke et resultat af det årlige budget.
+Østrig har også regelmæssigt bragt dette emne på bane.
+Traktatreform er den korrekte reaktion på borgernes forventninger.
+Denne militante xenofili og antipatriotisme er meget opslidende.
+Det har gjort det muligt at identificere de relevante emner.
+Kommissionen støtter forskning i passende metoder til deinstitutionalisering.
+Så vil vi højst sandsynligt være nødt til at gå i forhandling.
+Klagerne kom altså også fra videnskabelige cirkler, men også fra andre boghandler.
+Vi ved alle sammen godt, at tiden nu er ved at udløbe.
+Hendes liv og helbred er fortsat i fare.
+Jeg var der for at tale om bypolitik.
+Vold kan ikke bidrage til at helbrede disse skel.
+Når man ser på selve programmet, bliver diagnosen ikke bedre.
+Jeg vil gerne bemærke, at dette emne er blandt det spanske formandskabs prioriteter.
+Adfærd af denne art kan blive virkelig farlig i sidste ende.
+Jeg vil gerne se denne knowhow blive brugt.
+Vi skal derfor genoverveje retningen for politikken for bekæmpelse af global opvarmning.
+Jeg ønsker det og dermed vores ungdom held og lykke!
+Vi har efterlyst respekt for retsstaten og umiddelbar løsladelse af disse mennesker.
+Bjergenes økosystems betydning er en kulturarv.
+Vi lader forbryderen gå ustraffet og behandler ofret letsindigt.
+Vi har brug for enkle regler om overførsel af erhvervstilknyttede pensioner.
+Den indonesiske hær greb ikke ind for at beskytte befolkningen.
+Han var beleven, klog, flot, principfast og umådeligt effektiv.
+Ordføreren mener, at fatalismetankegangen fremmer narkotikamisbruget.
+Rådet mindede ligeledes om sin sædvanlige og stærke modstand mod dødsstraffen.
+Det er ufatteligt, at man forelægger formanden et sprog, hun ikke taler.
+Den kan også have ødelæggende virkninger, både fysisk og psykisk.
+Den kemiske industri gør sig umage for at bagatellisere pesticidernes indvirkning.
+Formålet er at hindre omfattende forstyrrelser i produktionsmønsteret og jordens værdi.
+Suveræniteten bør bevares.
+Inflationen ligger nu på et historisk lavt niveau.
+At skabe arbejdspladser må være et nøgleord.
+Han er blevet frataget muligheden for at rejse samt ytringsfriheden.
+At lave politik kræver lidenskab og veltilrettelagt diplomatisk aktivitet.
+Hvornår får vi transeuropæiske net, som vi stadig venter på?
+Hermed er jeg kommet frem til det sidste forslag, nemlig om hasteforanstaltninger for ophugning.
+Vi ville have foretrukket, hvis direktivet fokuserede på forældreorlov i stedet for barselsorlov.
+Klagerens ret til anonymitet må respekteres.
+I virkeligheden er udsigten desværre helt anderledes.
+Formandskabet befinder sig i krydsild.
+Der er endnu ikke draget nogen faste konklusioner, men smuthullet er blevet afsløret.
+På et overordnet plan har forslaget til betænkning affødt en række spørgsmål.
+Hvordan ønsker vi at udforme frekvenspolitikken?
+Garosci, for det fremragende arbejde, de har gjort.
+Men det er beklageligt, at vi ikke nåede helt frem.
+Det er derfor på høje tid, at kreditvurderingsbureauerne holdes i kort snor.
+Hvorledes vil det løse problemet, og hvilke foranstaltninger har det til hensigt at iværksætte?
+Den kan ikke skjule den totale mangel på grundlæggende indrømmelser fra amerikansk side.
+Alkohol er særligt farlig i andet og tredje kvartal.
+Den vigtigste årsag er først og fremmest den øgede befolkningstilvækst i tredjelande.
+Generalen overtog magten ved et kup.
+Vi ved vældig meget, og der er ingen genvej.
+Landbrugsudvalget har rent faktisk den holdning, at vi bør vove springet.
+Det første punkt er corporate governance.
+Jeg så ingen maskiner i går.
+På langt sigt har vi brug for mere kongruens, hvis vi vil undgå konkurrenceforvridninger.
+Der kan også være andre årsager til det stigende antal døde.
+Hvad forhindrer, at denne associeringsaftale bliver gennemført?
+Pleje af børn og ældre slægtninge er under alle omstændigheder fortsat en opgave.
+Forbrugernes tillid er slået om i udbredt mistro.
+Overordnet set er buspassagerer som helhed blevet dårligere stillet.
+Racisme er et hårdnakket og voksende problem i de europæiske samfund.
+Vi udtrykker således vores ambition om at højne globaliseringen i moralsk henseende.
+I andre områder sælger man vin på strøer.
+Banebrydende resultater kan kun opnås på grundlag af velplanlagte langfristede investeringer.
+Donnelly kom ind på dette.
+Det drejer sig om jægere og sportsskytter, som rejser til konkurrencer.
+Klokken er nu et minut over tolv.
+Dette er baggrunden for, at de ikke bryder sig om konventionen.
+Bistanden blev ydet i form af interventionsmandskab, højt specialiseret udstyr og finansiel støtte.
+For mig udgør den en slags idyllisk politisk konsensus.
+Ruslands tale om privilegerede interesser i sit naboområde vidner om dette.
+Bekymrer vi os ikke den mindste smule for vores omdømme?
+For det første forbedring af de legale indvandringskanaler
+Jeg mener derfor, at der stadig er enorme mangler i denne henseende.
+Hvad tobakken angår, baserer vores forslag sig også på en vidtrækkende konsekvensanalyse.
+Det er en uretslov og en skamplet.
+De forsøger at erstatte reformerne, som endelig sker, med flere oplysningskampagner og salgsfremstød.
+Poettering har jo gjort klart, at valgkampen allerede er i gang.
+Ordføreren har tilegnet sig en gradvis fremgangsmåde, der er den helt rigtige.
+Kommissionen vedtog først direktivforslaget sidste onsdag.
+Det er naturligvis vanskeligt at besvare direkte.
+Hovedproblemet inden for landbruget er landbrugernes lave indkomster.
+Derfor er det latterligt, at man nu skændes om, hvordan dette instrument skal finansieres.
+Undertrykkelse integrerer ingen, det fører til disintegration.
+Er de glade for det på de nærliggende loppemarkeder?
+Morillon udeladt dette aspekt, som jeg synes er vigtigt.
+Der skal afholdes et trepartsmøde i aften.
+Åbning af den årlige session
+Jeg havde krævet, at dette agentur skulle være en uafhængig og gennemskuelig instans.
+Alle undersøgelser, som søger at kaste lys over fakta, er velkomne i denne sag.
+Allerede i dag findes der alternativer uden fluororganiske forbindelser på markedet.
+Men vi har svært ved at tage nogle af de nævnte problemer alvorligt.
+Jeg mener, at der er nogle huller i deres forslag.
+Jeg kan kun bekræfte, at der skal afholdes et kabinetsmøde i overmorgen.
+Balikonferencen resulterede i en moderat succes.
+Vi kan ikke have en discountudgave af fair trade.
+Fremover skal det være gravemaskiner, der rasler med kæderne hos jer, ikke panservogne!
+Men vi må have fragten igennem.
+Nogle af de foranstaltninger under tredje søjle, som er under forberedelse, som f.eks.
+Det er ikke legitimt udelukkende at betragte bøger som et økonomisk gode.
+De gamle medlemsstater modtager mest, og de nye modtager langt mindre.
+Grænsen mellem skjult reklame og produktionshjælp er meget vag, hvilket skaber tvivl og diskussion.
+De ender med at smitte andre og ikke søge behandling selv.
+Jeg ønsker at gentage, at vi vil yde en langsigtet indsats.
+Det viser debatten om det blå brev også.
+Europa er en smule bagud, men skal nu viderebringe dette budskab!
+Glædelig jul, mine damer og herrer!
+Så det kvindelige islæt i ungdomsprogrammerne er bydende nødvendigt for at opnå resultater.
+Så lad os følge franskmændene.
+Hvilke situationer er menneskelig set vanskeligere end det illegale ophold?
+Jeg har stemt for votummet.
+Sådanne overgreb kan ikke tolereres uden en stærk reaktion fra de europæiske institutioner.
+Fischlers og min holdning.
+Der er mange tilfælde af svig, navnlig i de østlige og sydlige medlemsstater.
+Det skaber større ulighed end den, der hidrører fra forskelle i købekraft.
+Vi må forstå, hvorfor flere statschefer ikke mødte op.
+Vi har også brug for en forøgelse af de nuværende grænser ved vores kyster.
+Det har den i øvrigt gjort opmærksom på skriftligt med delikat diplomatisk bitterhed.
+Herved frakender vi vore medmenneskers værd med deres egen plads i skabelsen.
+Gabet mellem verdens rige og fattige er vokset.
+Der kan mennesker ikke bo, men vi bruger havet stadigt mere intensivt.
+Vi støtter de italienske myndigheder.
+Overgangsperioden på to år for barometre mener jeg er fuldkommen tilstrækkelig.
+Jeg glæder mig over denne pragmatiske tilgang.
+Hvilke forholdsregler må vi træffe?
+Det forbliver ved de smukke ord, og den konkrete handling udebliver.
+Hvilket lingvistisk system skal der anvendes?
+Desuden er det uhyre vigtigt for havmiljøet, at støtten til de flydende fiskefabrikker ophører.
+Det er på ingen måde uproblematisk.
+Clerides, som indtil videre ikke har givet mærkbare resultater.
+Men vi eksporterer al denne uld i uforarbejdet stand.
+Indenlandsk produceret kul er langt mere miljøvenligt end importeret kul.
+Afrika er det kontinent, hvor man finder flest kapitalindskydere.
+Flere redningsholds erfaringer var ikke engang tilstrækkelige.
+Derfor kan ækvidistance være et instrument, selv om målet for mig afgjort er upartiskhed.
+Corbetts forslag bliver forkastet på onsdag.
+Der er dog noget, jeg gerne vil dementere.
+Det er vores amerikanske venner nødt til at acceptere.
+Det kan man udmærket gøre også med særskilt afstemning.
+Det er, hvad jeg vil kalde mobning på arbejdspladsen.
+De har endvidere mulighed for at få initiativer ført ud i livet.
+Desværre forbliver disse ord sommetider kun smukke ord.
+Vi har ventet her i aften i mange timer for at tale.
+Hvad er den egentlige leje?
+Jeg refererer hovedsageligt til de kommende forhandlinger om den fælles landsbrugspolitiks fremtid.
+Kommissionen har forsømt dette område i sin grønbog.
+En ny strategi til et gammelt mål!
+De er overregulerende, overbureaukratiske og unødvendige.
+Et yderligere væsentligt punkt som led i udvidelsen mod øst er beskyttelsen af arbejdstagerne.
+Rehabiliteringen af både kommunistiske og nazistiske symboler skal fordømmes i lige høj grad.
+De olympiske lege var det første organiserede fredssystem.
+For det andet forestiller nogle sig ofte, at er synonym med selvregulering.
+Afslutningsvis blot en enkelt sætning.
+Dette var oprindelig en foranstaltning vedrørende sædskifte, fordi sædskifte også krævede vegetation.
+Det vil imidlertid være vores udgangspunkt, da vi går grundigt til værks.
+I øjeblikket er det omvendte tilfældet.
+Selv tilhørerlogen er ved at være tom.
+Formelt siger man, at subsidiaritetsprincippet skal overholdes, men det er et tomt løfte.
+Disse mænds og kvinders mod er beundringsværdigt.
+Jeg og mange aktører mener ikke, at det er en ønskelig udvikling.
+Jeg synes imidlertid heller ikke, at fredsforhandlingerne var en komplet fiasko.
+Vrede over fødevareprisernes himmelflugt har ført til stor uro i mange lande.
+Jeg hørte et interview med en tyrkiskcypriotisk ung kvinde i radioen.
+Poettering om, at det østrigske formandskab skal kigge i kalenderen igen.
+Denne opgave bør overlades til uafhængig akademisk forskning og offentlig debat.
+Er det mon det, man ønsker?
+Uden salt og uden sukker går det ikke.
+Vi må imidlertid også høre de stumme skrig, der lyder i verden.
+Det er et kapløb med tiden.
+Strengere akkreditering af disse laboratorier vil øge offentlighedens tillid.
+Som fortaler for retten til liv kan jeg ikke med god samvittighed stemme for.
+At fremme udøvelsen af private søgsmål vil gøre konkurrencereglerne mere effektive.
+Denne forblindelse får dem til at benægte de forudsigelige konsekvenser af et sådant medlemskab.
+Livet i landdistrikterne, herunder landbruget, står over for mange trusler i dag.
+Vi må sammen finde den rette balance mellem økonomi og økologi.
+De er nært knyttet til medlemsstaternes statsopfattelser og de kulturelle ting, der er opnået.
+Det sjette punkt er inddragelse af virksomhederne i debatten.
+Derimod vender jeg mig mod mange af de unuancerede udtalelser om udbud om kontrakter.
+Tekstilindustrien er ikke et levn fra fortiden.
+Det opnår man ikke med tvang.
+Er det helt umuligt at skabe balance i den ligning?
+Kommissionens forslag vedrører ikke indholdet af mærkningen med ingredienser.
+Som medmennesker er hendes kamp immervæk også vores kamp.
+Databeskyttelsesmyndighedernes uafhængighed er nøglen til et vellykket stykke arbejde.
+For at kunne gennemføre en begrænset fiskeriindsats har vi brug for dybhavslicenser.
+Det er derfor, at mange vandområder tæt på kysten trænger til rensning.
+Den berygtede, nye økonomi kommer ikke til at tjene lønmodtagernes interesser.
+Støttemodtagerne skal udvælges på en demokratisk og gennemskuelig måde.
+Ukrainerne må selvfølgelig selv gøre en omfattende indsats, og valgløfterne skal indfris.
+Ligeledes er konkurrencen heller ikke fuldt ud garanteret i hvert hjørne af energisektoren.
+Information bør ryste politikken.
+Det er der, oplysningerne stammer fra.
+Undskyld, at jeg ikke ytrer mig om det britiske oksekød.
+Disse ændringer i deres aparte form, alt er klassisk i dette budget.
+En anden ansøgningsomgang er også i gang ude i samfundet.
+Her tror jeg, at det gælder om at gøre disse gæstearbejdere til borgere.
+Det handler om virksomhedens beliggenhed og om sikring af arbejdspladser.
+De mest sårbare grupper er ældre, som bor alene, enlige mødre og arbejdsløse.
+I de to år, tunnelarbejdet har stået på, er jernbanegodstransporten ikke steget.
+Bekvemmelighedsflag inden for fiskerisektoren
+Den moderate delegation mener, at anklagemyndigheder skal befinde sig på nationalt niveau.
+For det første vil vi fjerne brugen af giftige tungmetaller fra nye biler.
+Vi stod næsten i den situation med finsk ved den seneste udvidelse.
+Desuden kan offentligheden opfatte disse retsakter som europæisk superbureaukrati.
+Nogle røster hævder, at jeg har for tætte kontakter til regeringerne.
+Jeg vil gerne kort gøre rede for hensigten med forslaget.
+Desværre består denne tradition næsten udelukkende af smertefulde begivenheder og uretfærdigheder.
+Det hele er alt for fladt.
+Vi har også stiftet bekendtskab med russisk isolation.
+Hvor der skulle være ekstra midler, udfylder de i realiteten et tomrum.
+Men kun i de færreste tilfælde er det til forbrugernes fordel, endsige retfærdigt.
+Jeg er moralsk imod abort og kan ikke acceptere en sådan formulering.
+Jeg ved det heller ikke, men jeg har besøgt hospitaler.
+Dermed er fiskeredskabets selektivitet ikke påvirket.
+Men hummerproducenterne kan oprette producentorganisationer for at styrke deres stilling på markedet.
+Vi sakker derfor agterud, også når det gælder innovation.
+Nu er der nemlig blevet læst mange navne op.
+Det er også vigtigt, at vi indfører en række foranstaltninger, der gavner fremskridtet.
+Man kan tit se affald smidt på gaderne og i baggårde i disse områder.
+Vi taler i øjeblikket om total deklaration af foderstofferne.
+Ud af betænkningens mange anbefalinger vil jeg gerne fremhæve to aspekter.
+Desuden blev forhandlingerne vanskeliggjort af de strukturelle særegenheder i flere medlemsstater.
+Roosevelts fjerde element var økonomiske investeringer.
+Den årlige tildeling må ikke overstige denne øvre grænse.
+Spørgsmålet om egne indtægter vil dukke op igen i de kommende måneder.
+Jeg rådgav virksomheder om mobile satellittjenester.
+Jeg har allerede sagt, det er en farverig sag.
+Der er ikke tale om at bedømme en dom, langt fra.
+Det er ikke hensigten at øremærke nye midler til strategien.
+Derfor stilles der også krav om konsultation, inden det kommer til en suspendering.
+Vi må vise en uophørlig interesse for udviklingerne i landet.
+Jeg har en bemærkning vedrørende åben software.
+Verdenssamfundet har samstemmigt anerkendt ham.
+Det vil bestemt også gælde det skotske højland.
+Endnu en gang er det en vanesag.
+Jeg mener, tidspunktet er perfekt til at gennemgå betingelserne for denne grundlæggende forhandling.
+Påstanden om, at bly er forbudt i legetøj, er ikke sand.
+Dermed brydes den onde cirkel, og der skabes en sund udvikling!
+Så kære kolleger, vi må være på vagt!
+Vi venter på den såkaldte ketchupeffekt.
+Det ville være ligeså skadeligt for det indre marked som social dumping.
+Savary mindede om for lidt siden.
+Men disse problemer løses ikke bare med snak.
+Denne vision er fortsat relevant i dag.
+Hvad dyrehold i økonomisk øjemed angår, vil der også i fremtiden skulle være begrænsninger.
+Renlighed er et meget vigtigt aspekt i den henseende.
+Deres overforenklede udelukkelse af databehandling udelukker signalbehandling og digital teknologi.
+Vi vidste, hvor truslen kom fra, for den havde en placering og et ansigt.
+Teoretisk set er der naturligvis forskellige muligheder.
+De to forslag er en del af en igangværende proces.
+Deres borgere er mere trygge ved processen, og det endelige resultat har større legitimitet.
+Jeg håber, at der er opbakning til disse ændringsforslag.
+Alle patienter med blærekræft ønsker at nyde gavn af den østrigske viden og sagkundskab.
+Den europæiske referenceramme for kvalifikationer er en metaramme, som har tre opgaver.
+Det er så uspecifikt og populistisk!
+Det er de caribiske producenter til gengæld.
+Jeg tænker på lørdagens demonstration.
+Til gengæld er vold i hjemmet stadig meget dårligt indkredset, for den forbliver tabu.
+Før krisen accepterede koreanerne ingen kapacitetsreduktioner.
+Samtidig giver det beboere i grænseområder visse fordele, hvilket allerede er blevet påpeget.
+Målet er således at etablere virtuelle centres of excellence på prioriterede områder.
+Fitzsimons har desværre lagt sig syg med en lungebetændelse.
+I de fleste tilfælde er aggressoren kvindens mand eller partner eller et bekendtskab.
+Jeg har lært meget og haft det rart.
+Problemet er, at der ikke fandt nogen endelig afstemning sted.
+Vi kan for vores vedkommende kompensere for mange års uansvarlig adfærd.
+Det er derfor, det er så vigtigt at forbedre mulighederne for at skifte leverandør.
+Derfor er det også nødvendigt med vejledning på disse områder.
+Jeg vil også gerne citere nogle tal.
+Vi er alle enige i og taknemmelige for forslaget om en tidsbegrænset aftale.
+Det første møde vil finde sted i foråret.
+Det, der holder i det lange løb, er samarbejde.
+Dette initiativ skal vare en årrække og nyder allerede temmelig stor succes.
+Vi må ikke hertil føje det, jeg ville kalde den digitale kløft.
+Det er for os et brudpunkt i denne tekst.
+Derfor kan man ikke henholde sig til proportionalitetsprincippet i dette tilfælde.
+Den første, den relativt mest harmløse, ramte også mit eget hus.
+Det er klart, at en sådan attitude er beklagelig.
+Det er imidlertid bevidst forsøgt at finde en stok til at slå hunden med.
+De forhandlere, hvis aftale opsiges, kan nu blive på markedet som autoriserede reparatører.
+Desværre kan svampefiskeri imidlertid ikke på nuværende tidspunkt medtages i aftalen.
+En bøf skal være en bøf, og en skinke skal være en skinke.
+Til sidst vil jeg påpege, at stivelseskartofler ikke kan sammenlignes med spisekartofler.
+Hvorfor siger jeg det, og hvorfor denne sælsomme sammenligning?
+Til september kan det være for sent.
+I år blev der her opdaget en gigantisk bedrageriring.
+Dette kræver en mere proaktiv og radikal fremgangsmåde.
+Budgetforslaget indeholder margener, altså spillerum, på alle områder undtagen strukturfondene.
+Det er til en vis grad en latent besparelse, man lader os stemme om.
+Giv os navnene på alle eksperter.
+Mange iranere er pæne og ordentlige mennesker.
+Det er på tide, at vi virkelig får en meget mere kohærent politik.
+Der kan ske meget på otte år.
+Jeg vil også rose hende for betænkningens kvalitet.
+De årlige fangstmængder er allerede stigende og vil derfor fortsat stige.
+Informationer om muligheder for at studere og forske i udlandet.
+Betænkningen er bygget op omkring seks væsentlige spørgsmål.
+Der skal prioriteres, og udgifterne til uddannelse skal opvejes mod andre udgifter.
+Der skal afsættes tilstrækkelig tid til at udbygge denne dialog.
+Politikken skal ligge fast og eventuelt føres videre fremad.
+Den mest grundlæggende definition af frivilligt arbejde er goodwill i aktion.
+Handlingsplanen om biodiversitet er hæderlig, om end den indskrænker sig til fromme ønsker.
+Hvad nytter det, hvis forbrugerne ikke ved, hvilke rettigheder der virkelig tilkommer dem?
+Der blev postkassen afmonteret om natten, idet bygningsfacaden blev beskadiget.
+Parlamentet agter at kontrollere og overvåge disse missioner mere snævert.
+Vi kan ikke afsætte præsidenter, der er drevet af kriminalitet.
+Dette er en politisk uholdbar situation.
+Disse udkast vil blive behandlet i løbet af de kommende formandskaber.
+Vi har fanget millioner i afhængighedens elendighed.
+Den skal ajourføres og moderniseres.
+Forskningen i regionen må kunne samordnes bedre og rettes mod fælles spørgsmål.
+Der mangler en særdeles vigtig bid, og det er overholdelse.
+I en demokratisk stat har også politiske og etniske mindretal rettigheder.
+Når man taler med albanske kosovoer, er det det første, de spørger om.
+Dette nuværende tidspunkt er meget gunstigt, men det indebærer også mange udfordringer.
+Hvem overlader nutidens videnskabsmænd og forskere projekter, som nødvendigvis er djævelske?
+De døde således ofte som følge af sult og en grusom, umenneskelig behandling.
+Det handlede om at integrere det syvende forskningsrammeprogram bedre og orientere det mod trafik.
+De mistede milliarder, som kunne have været brugt til at sænke lønskatten.
+Vi skal have nogle kvantitative mål for ligestillingen.
+Hvordan fremmer vi bedst anstændighed, mådeholdenhed og pluralisme?
+Det giver det bedste afkast.
+Identitet og enhed skabes af folket, ikke af en elite.
+Og pludselig rammer denne blindhed os som en boomerang.
+Det er noget, der snarere skal bifaldes end kritiseres.
+Mange sygeplejersker blev evakueret, om ikke så mange læger.
+Produkternes betegnelser skal være klart defineret og enkle og forståelige.
+Hvis ikke, vil jeg sende en betjent af sted med en kopi af det.
+Uddybning og udvidelse går hånd i hånd.
+Sundhedsspørgsmål vil fortsat være centrale med en større præventiv indsats imod pandemier.
+I det aktuelle tilfælde var det naturens kræfter, der satte lufttrafikken fuldstændig i stå.
+Som vi har hørt, har vi her et umotiveret mord på en uskyldig mand.
+Jeg valgte denne karriere, men jeg har nogen, der har valgt at blive hjemme.
+Samtidig giver en amnestilov militærpersonerne straffrihed for deres voldshandlinger og ugerninger.
+Vi ved, at spørgsmålet om beskatning af aviser ikke er løst.
+Det er bestemt et argument, det er værd at reflektere lidt over.
+Etnisk udrensning foregår stadig.
+I dag har vi styrket kvindernes rettigheder, men også mændenes med fædreorloven.
+De overvejede ikke sagen efter et år eller to eller tilmed fem år.
+Bruttonationalproduktet er den bedst kendte foranstaltning til makroøkonomisk aktivitet.
+Fru formand, det er allerede gået meget vidt med doping i sporten.
+Megen statsstøtte kanaliseres imidlertid til firmaer i forklædning.
+Bier er af afgørende økonomisk og miljømæssig betydning.
+Jeg konstaterede, at de amerikanske borgere er hjertevarme, entusiastiske, opfindsomme og dygtige.
+I modsat fald ville det naturligvis være fuldstændig absurd at gennemføre den i småbidder.
+Det handler både om ordentlige toldkontroller ved de ydre grænser og kontroller i medlemsstaterne.
+Herefter aflagde udenrigsministre og kommissærer besøg på øen.
+Udbredelse af europæiske film
+Vi taler alle om skandaleplagede borgere, der har mistet tilliden til fødevaresikkerheden.
+Lange har, nemlig at det i allerhøjeste grad ville være nyttigt at inkludere dem.
+Vi må imødegå den vedtagne lov med meget skarpe tiltag.
+Det lød som arrogance i mine øren.
+Der har de en fremragende platform for deres politiske budskab om had.
+I henhold til denne kræves der ordrer på amerikanske værfter til intern navigation.
+Kidnapningerne fortsætter.
+Uetisk forskning er fuldkomment unødvendig...
+Han vil formentlig være fristet til bare at tage pæren ud.
+Nødhjælpen skal fordeles så hurtigt som muligt og direkte til den nødlidende befolkning.
+Berlusconi snart kan forlade hospitalet, og ønsker ham hurtig bedring.
+Jeg takker alle de kolleger, som har medvirket til at udarbejde denne tekst.
+Men vi må ikke hvile på laurbærrene.
+Noget af det, man lærte af dioxinkrisen, var, at disse oplysninger ofte savnedes.
+Derfor går vi nu glip af en chance.
+Disse tilsagn danner igen i morgen grundlag for vores afstemning.
+At give visse sagsøgere fortrinsbehandling er ikke en passende adfærd for en neutral dommer.
+Vi finder endog til vores overraskelse fornuftige forslag til en voluntaristisk familiepolitik.
+Der er ingen tvivl om hushjælpens betydning.
+Der pågår desuden overvejelser om en eventuel ny koordinators mandat og opgaver.
+Jeg vil gerne give en kort definition på både varemærkeforfalskede og piratkopierede varer.
+Det er ikke det rette tidspunkt at yppe kiv på.
+For nylig dukkede spørgsmålet om homoseksuelle pars ret til at adoptere børn igen op.
+Kommissionen accepterede den, validerede den og indarbejdede den i vidt omfang i sit forslag.
+Klimaforandringerne og nye sejlruter indebærer ikke kun risici, men åbner også nye muligheder.
+De ønsker ingen erstatningschokolade, men ægte chokolade med kakaosmør.
+Europa kæmper for at udsprede dets ideal for demokratisk pluralisme.
+Der er tydeligvis spørgsmål, som skal behandles, og nogle er mere følsomme and andre.
+Ønsker den tyrkiske regering virkelig at give republikken et nyt demokratisk fundament?
+Vores indsats skal være mere utvetydig og resolut.
+De nuværende vacciner er mere avancerede.
+Jeg tror, at vi her i denne sal er på rette vej.
+Selvfølgelig bliver der ballade.
+Jeg synes, det er fascinerende at se, hvad bilindustrien allerede kan i dag.
+Jeg lykønsker hæren med dens professionalisme i beskyttelsen af republikkens institutioner.
+Dermed har de udelukket millioner af atypisk beskæftigede med deres specifikke forskelsbehandlinger.
+Det nye program vil udvide mulighederne samt utvivlsomt give endnu flere fordele.
+Det institutionelle nirvana er ikke noget sikkert sted, og det er der indicier på.
+Det allervigtigste mål for den er at nå ned på nul ofre.
+Jeg vil også gerne takke alle skyggeordførere for det glimrende samarbejde.
+Jeg ser frem til en stimulerende og tankevækkende debat i eftermiddag.
+Det er de desperate, der rejser ud.
+Der var også mange, som åbenlyst viste deres sympati for oppositionspartierne.
+Hvordan kan vi hjælpe nordkoreanerne i denne situation?
+Fakta og fiktion er blandet sammen her.
+Jeg håber, at dette bliver en fordelagtig stimulans, navnlig for udbredelsen af onlinesalg.
+Det er ikke mit ønske at være smålig, når jeg siger dette.
+Titley så udmærket har forklaret det, er det nødvendigt at hjælpe bilisterne og passagererne.
+Budapests indbyggere mister imidlertid hele tre år af deres liv.
+I de nye rammer for denne lovgivning skal barnet anbringes i centrum af adoptionsprincippet.
+Europa skal have modet til at kalde en spade en spade.
+Den ville have fået en varm modtagelse.
+Ellers vil vi næsten kun have tabt og intet vundet ved den uofficielle forhandling.
+Bør de ikke nyde den samme internationale beskyttelse som alle deres kolleger fra musikområdet?
+Møllen maler langsomt, men jeg tror den maler.
+Den blev foretaget i november sidste år.
+Jeg mener seriøst, at vi har behov for en ambitiøs reform.
+Det er sandt, at de er i hi, mens vi har denne drøftelse.
+Dette gælder navnlig veterinærmedicinske produkter.
+Nu sidder han bag tremmer.
+Det eneste sted, hvor staten stadig har et magtmonopol med væbnede styrker, er politiet.
+Det bliver vanskeligt, når der ikke findes nogen definition af, hvad strafbar pornografi er.
+Det er et drama, som alle disse lande slås med.
+Det kan være direkte misvisende at angive et oprindelsesland.
+Vil der komme et svar fra vores nuværende premierminister eller finansminister?
+Jeg forstår mishaget hos kollegerne fra andre lande.
+Her havde kroaterne våben, og så fejede de straks serberne af banen.
+Alle forråd af basisfødevarer er opbrugt.
+Vi vil gerne vide, hvor længe disse to typer data bliver opbevaret.
+Vi må ikke handle uværdigt ved at forsøge at udnytte deres død.
+Hvilke trin består initiativet så af?
+Det er vanskeligt at fange lovovertræderne på internettet, men det er ikke umuligt.
+Gå ind på facebook for at standse tabet af biodiversitet, og støt kampagnen.
+Vores motto skal til enhver tid være gennemsigtighed, ansvarsfølelse og effektivitet.
+Spørgsmålet om ramperne er særdeles væsentligt.
+Køb af sex er vold og bibeholdelse af vold.
+Vågn for himlens skyld op.
+Indtil det sker, må der ydes midlertidig overgangskompensation til de ramte fiskerivirksomheder.
+De har arbejdet flittigt, og vi bør stemme flittigt.
+Vi har dog også oplevet fodboldspillere, der blev stillet til personligt ansvar for nederlag.
+I kampen mod udplyndringen af biodiversiteten er spørgsmålet om skovødelæggelse helt afgørende.
+Jeg ved ikke, om det skyldes nærsynethed eller politisk fejhed.
+Teknisk kan afstemningen udsættes til april.
+Det er om muligt endnu mere rædselsvækkende end heroin.
+For det andet hindringer for forståelse på grund af den uigennemskuelige hjemmeside.
+Man skal melde sig, inden stemmeforklaringerne begynder, men jeg er dog fleksibel.
+Vil det afstedkomme en udligning nedefter?
+Det samme system for alle, erga omnis , ingen undtagelser.
+Parlamentet vil drøfte dette spørgsmål senere på ugen.
+Fri handel, som denne aftale åbner op for, vil bringe alt dette i fare.
+Vi bør derfor gå imod de japanske og norske forslag om at genoptage erhvervet.
+Jeg vil gerne understrege, at der findes sager, hvor der er begået forbrydelser.
+Der bør ikke være noget institutionelt kævleri.
+Hvad en stat bygget på løgne kunne miste, bevarede ungarerne som nation.
+Vi er ivrige efter at få dem løst.
+Vi ved, at afbrændingen af bøger betød meget mere end blot afbrænding af bøger.
+Derfor bør denne kategori defineres klart og være omfattet af statistikkerne.
+I modsat fald er der fornyet risiko for, at borgerkrigen vil blusse op igen.
+Foranstaltninger, der iværksættes på europæisk plan, skal supplere nationale og regionale strategier.
+Verheugens udtalelser om udvidelsen
+Leinen sig over den reviderede rammeaftale og tilslutter sig den.
+De kan ikke udnyttes termisk og heller ikke genanvendes.
+Jeg vil gerne fremsætte nogle politiske og faglige bemærkninger.
+Det er en milepæl på vores vej til fremtiden.
+Der kræves finansiering til den europæiske økonomiske genopretningsplan og støtte til mejerisektoren.
+De lukkede øjnene for den.
+Hvis dette ikke sker, bliver demokratiet en deformeret størrelse.
+Bjergområder og ugunstigt stillede områder opretholdes, som de er nu.
+Hvad gør medlemsstaterne ved deres egen strategi for livslang læring?
+De har afgivet en meget lang redegørelse.
+Folk er i defensiven med hensyn til en eventuel nedbrydning af deres sprog.
+Egentlig er man for en økonomisk boykot.
+Sådanne forsinkelser skal ubetinget forhindres fremover!
+Vi har stærkt indtryk af, at der endnu ikke er truffet ordentlige bestemmelser derom.
+Der bør skelnes skarpt mellem terapeutisk kloning og reproduktiv kloning.
+Det sker også i de lande, der praler af stor åbenhed.
+Michelin er desværre langt fra en undtagelse på området.
+Vi må benytte princippet om at hjælpe folk til at hjælpe sig selv.
+Denne tilsyneladende konkurrence har sat landet i en politisk apati og devalueret dumaen.
+Parlamentet vil forblive en central figur i udviklingen af denne politik.
+Producenternes økonomiske resultater er for nedadgående.
+Rusland spiller en førende rolle på den internationale scene.
+Derefter var målsætningen socialisme og blonde kammerater.
+Europa skal vise flaget her!
+Det har været noget af en føljeton.
+Det siger jo noget om atmosfæren i landet.
+Der fandt mere intensiveret chikane af systemkritikere sted, og mange aktivister blev arresteret.
+Men lad mig se på den globale søfart.
+Det kræver efter vores mening en separat budgetpost og en passende reserve.
+I kældrene er kloakeringen brudt samen, og de er oversvømmede med menneskers ekskrementer.
+Vi skal overveje artsspecifikke kontroller i forbindelse med toskallede bløddyr.
+Montenegros skæbne ligger derimod helt i landets egne hænder.
+Sydafrika har især en betydningsfuld rolle i sin egen sydafrikanske region.
+For det første opt in eller opt out.
+Skoleeksempler på beskyttelse af biodiversiteten er fugledirektivet og habitatdirektivet.
+Selv i sparetider skal man betale sin elregning.
+Økonomiske vækstperioder varer ikke evigt.
+Et tredje eksempel er nuklear sikkerhed.
+Når alt kommer til alt, udvindes alle diamanter under frygtelige forhold.
+Erklæringer alene uden konkrete handlinger er kun hule ord.
+Hjælpen til en stabil, vellykket udvikling i landene er jo tvingende nødvendig.
+Vandkraft, vindkraft og kernekraft rummer disse muligheder.
+Dette misforhold viser, hvor vigtigt det er at indføre et fælles observationssystem.
+De inviteres til at sidde med ved bordet, men de deltager ikke.
+Uanset hvor erfarne chauffører er, skal de altid spænde sikkerhedsselen.
+Især blev ændringsforslagene vedrørende omfordeling af fiskerimulighederne nedstemt.
+Intermodalitet og intermodal godstransport
+Jeg vil imidlertid gerne tilføje, at valutakurskriteriet er vigtigt.
+Vinteren nærmer sig, og en ubønhørlig beskæftigelseskrise vil fjerne enhver udsigt til udvikling.
+Det lykkes højt udviklede lande at fastholde en næsten uændret miljøsituation.
+Det passer måske ikke, men alligevel er der et tonefald, som ikke lyver.
+Varslingen kom næsten tre uger efter, at olierne var blevet leveret.
+Det drejer sig om fire år plus to fra det nye direktivs ikrafttræden.
+Det er den læresætning, der bør stå på styringspakkens titelblad.
+Mange lande har valgt denne dato til at fejre deres skytshelgen.
+Enhver reform af den fælles fiskeripolitik skal sætte en stopper for det katastrofale udsmid.
+Jeg glæder mig over interessen for potentialet i de kulturelle og kreative industrier.
+Der må reageres over for denne uheldige situation.
+I januar lovede vi et parlamentsvenligt formandskab.
+Stenalderen sluttede ikke, fordi vi ikke havde flere sten.
+Ved uregelmæssigheder forstår man en overtrædelse af en europæisk lovbestemmelse.
+Men her har man sprunget kendsgerningerne over.
+Ciampi og hans embede, at det samme følgelig gælder hans indlæg.
+Oplysninger om etnisk eller racemæssig oprindelse indgår ikke normalt heri.
+Svig, dårlig forvaltning og nepotisme opstår ikke tilfældigt.
+Der er intet belæg for, at homoseksuelle par er dårligere forældre end andre.
+De kristelige demokrater holdning vil ramme genindustrien som en perfekt boomerang.
+Vi skal værne om de borgerlige rettigheder.
+Heri ligger der en stor rigdom.
+Jeg støttede ændringsforslagene vedrørende folkemordet på armenierne.
+Mange af vores lande har tropper og et betydeligt antal civile medarbejdere i landet.
+Nu får vi et ansigt, vi får en adresse.
+Den roamingforordning, vi har undertegnet her i dag, er et eksempel på det.
+De har lanceret et websted.
+Schengenområdet er dog også et område for tillid.
+Det er først i dette århundrede, at vi har fået lighed i skilsmisselovgivningen.
+Se i øjnene, at målsætningen om en tættere, utroværdig politisk union simpelthen er uopnåelig!
+Nødforanstaltningerne skal fremmes ved at udpege beskyttelseszoner, fortøjringszoner og nødhavne.
+Jeg er sikker på, at denne ubekymrede holdning skyldes ordførerens sindsligevægt.
+Det tredje punkt er rådighedstiden eller det tidsrum, hvor lastbilchaufførerne skal stå til rådighed.
+Jeg ville gerne vide, hvilke ulemper og for hvem.
+Videnskab er ikke et totem.
+Vi står kort sagt tilbage med en bunke problemer.
+Cook, forvandledes hurtigt til en omfattende krig mod en europæisk nation.
+Reach vil kun blive en succes, hvis svaret er ja.
+Nu er uddannelsessystemet fuldstændig decimeret.
+Vi skal have øget denne sum i de næste år.
+Heldigvis startede vi ikke på bar bund.
+Kun på den måde vil vi til sidst finde sagligt korrekte løsninger.
+Det skal alle huske på i dag, også de politikere, der har sæde her.
+Jeg synes, det er lidt upassende.
+Der kan ikke ydes nogen driftsstøtte i forbindelse med bilproduktion.
+Hvad vi har til fælles, og hvad der unikt er vores.
+Er det med rette, at vi nærer så store forhåbninger til dette finansielle instrument?
+Hvad er begrundelsen for, at vi skal behandles mod underlivsbetændelse gennem ostemadder?
+Det revolutionære aspekt er, at flyvninger og flyselskaber fra tredjelande også er omfattet.
+Jeg stemte imod den, fordi den tydeligt bekender sig til den neoliberale økonomiske politik.
+Men der er ikke kommet nogen projektforslag fra den venezuelanske regering.
+Alt for ofte er systemet blevet udnyttet, og parrets interesser er kommet før barnets.
+Tortur, fængsling og tvangsarbejde hører til dagens orden.
+Ellers er globaliseringen en ren jungle.
+Jeg tror, at der er mindst tre nuller for meget.
+Dette omsving burde få det afgående formandskab til at tænke efter.
+Det er ganske enkelt et påtvunget opsyn med vores befolkninger og nationer.
+Men jeg fik mit lån, og min mand skrev ikke under.
+Hvad angår mærkning af oprindelsesland, er der en række uafklarede spørgsmål.
+Der er stadig mange smuthuller i loven, som muliggør uberettigede ernæringsanprisninger.
+Det har sjældent syntes mere vedkommende.
+Andre europæiske lande hjalp os med at kæmpe.
+Hvorfor er mælkeindustrien bange for, at bestemte områder ødelægges ved afkobling af mælkepræmien?
+Hver enkelt ø, hver enkelt territorium har sin egen særlige karakter, identitet og problemer.
+Derudover er den dobbeltmoralske holdning et irritationsmoment.
+I politik møder vi af og til snydeemballager.
+Men det nederlandske polderlandskab kan tillige være et topografisk motiv for et kørselsforbud.
+Hvis de søger kvalifikationer til medarbejderne, er de oppe mod en særdeles sektoropdelt politik.
+Kurderspørgsmålet må ikke længere fortrænges.
+Vi bør også have en demokratisk procedure for udnævnelse af dommere.
+Hvad nogle lande angår, vil vores ja være mere dæmpet, mere tøvende.
+Vi vil i hvert fald gerne have det afprøvet.
+Jeg taler om retten til refusion af sundhedsudgifter i udlandet.
+Adgang til information er baseret på princippet om aktiv søgning.
+Det er dette arbejde, der har vejet tungt på sekretariatet.
+Vi er også modstandere af, at privatpersoner selv skal kunne transportere store mængder fyringsolie.
+På intet tidspunkt følte jeg mig truet.
+Hvis staten accepterer kredit, som den ikke kan tilbagebetale, bebyrder det den næste generation.
+De praktiske ubehageligheder væltes nemlig over på de litauiske grænsemyndigheder og de rejsende.
+Irland er sjældent det første sted, hvor folk søger asyl.
+Vi er nødt til at gå ud og promovere vores kvalitetsprodukter.
+Lad mig på grund af den knappe tid kun nævne to spørgsmål.
+Nogle ressourcer såsom kulmuler, torsk, sardiner og tunfisk er i fare.
+Fru formand, kolleger, tag det nu roligt!
+Jeg beklager, at det på denne måde faktisk er gået lidt skævt.
+Ellers er der ikke nogen ændringer af bestemmelserne for cadmium eller kviksølv.
+Vores langvarige kamp mod rygning har ikke været forgæves.
+Det er, fordi banditter og kriminelle ikke frygter loven.
+Blandt disse befolkningsgrupper er mapuchefolket den procentuelt største.
+For at opsummere har arbejdet været fokuseret på udpegelsen af områder.
+Vi skal også overveje, hvordan vi sammenfører new economy med den såkaldte old economy.
+Hvis vi ikke handler nu, vil det næste århundrede blive behersket af dramatiske problemer.
+Det er ikke nogen gave til fattige naboer.
+Det tredje indsatsområde er meget bredt og omfatter alt det, vi kalder rumapplikationer.
+Vi skal jage piraterne og fange dem, ellers vil det ikke nytte noget.
+Det er udmærket, men hvornår lykkes det os at blive af med tågen?
+Til denne plenarforsamling er der genfremsat syv ændringsforslag.
+Uventede massearrestationer af styrets kritikere efterfølges af hurtige skinprocesser.
+Næste gang der byder sig en formel lejlighed, må vi have champagnen frem.
+Desuden slap vi for det oprindelige vanskelige udvalgsarbejde.
+Gigtsygdomme er den næsthyppigste årsag til lægebesøg.
+Efter min mening er den lære, der i dag kan uddrages, soleklar.
+Fælles operationer og pilotprojekter iværksættes efter aftale med de berørte medlemsstater.
+For bisværmene er reduceret drastisk igennem flere år til et niveau, der truer bestøvningen.
+Det tredje er beriget materiale, som overtræder bestemmelserne, og som fortsat fremstilles.
+Lytter man virkelig til de ansatte?
+Lehne og åbner døren på vid gab for misbrug.
+Det er en virkelig sensationel succes på højde med den europæiske enhedsagurk!
+For det andet fokuseres der på målsætningen om bekæmpelse af svig og smugling.
+Thailand gennemgår en meget alvorlig periode i sin historie.
+De har imidlertid tidligere anslået ganske andre toner.
+Deres pseudoøkonomiske styring går langt ud over budgettilsyn.
+Forurening og miljøforandringer resulterer i en stadig mere skrøbelig og ustabil produktionsform.
+Det er på høje tid, at vi påtager os vores ansvar.
+Mindre er i den her forbindelse lig med mere!
+Uden tvivl vil denne strategi bære frugt, hvis den anvendes konsekvent.
+Spørgsmålet om profilering blev også taget op af det belgiske formandskab.
+Telekommunikationssektoren betragtes allerede som liberaliseret, og den er derfor ikke medtaget.
+Vi er ikke en tigger, der søger almisser ved den europæiske dør.
+Vi har allerede kedelige eksempler på dette i andre sammenhænge.
+Det er vel egentlig helt evident.
+Hvis vi skal dekoncentrere, betyder det forvaltning af programmer på stedet.
+Katastrofen står prentet i mange ukrainske indbyggeres hukommelse.
+Jeg prøvede tidligere i dag meget ihærdigt at opnå enighed om et fælles beslutningsforslag.
+Der er behov for strukturelle ændringer for at gøre dem mere hørbare.
+Der er brug for mere end blot renere motorer og svovlfattigt brændstof.
+Og det giver ikke nødvendigvis bedre ydelse for alle.
+Det, vi drøfter og beslutter i dag, bliver en ny etape.
+Kommissionens forslag om en fælles måldato har netop dette mål.
+Jeg græd over, at den israelske soldat havde mistet sin medmenneskelighed.
+Det vil også omfatte offentliggørelse af besiddelserne af statsgæld og kapitalstruktur.
+Samtidig skal der komme ens spilleregler for alle involverede.
+Tanken er fin, men gennemførelsen er tvivlsom.
+Der blev refereret til et topmøde og til andre rygter.
+Hermed viser han ikke just stor respekt for sit nye job.
+Det er en vittighed, der ligesom alle vittigheder indeholder en kerne af sandhed.
+Det er også vigtigt, at vi har fundet ensartede kriterier for målinger.
+Naturligvis henvises der til, at lønudgifterne er meget høje.
+Rådet har imidlertid blokeret sagen i flere uger, og proceduren er endelig strandet.
+Det kan hævne sig, og hvis det gør, har vi mistet befolkningens tillid.
+De ambitiøse mål, som vi ønsker inden for denne temastrategi, er ikke urealistiske.
+Og det perfekte er altid det godes fjende.
+Fortæl mig venligst, hvorfor min regering har indtaget denne holdning?
+Det er os, der formodes at omsætte deres vilje til handling og ikke omvendt.
+Dette følsomme biologiske område fortjener beskyttelse.
+Denne politik skal omvæltes.
+Disse værdier er også baseret på den hellenistiske arv og romersk lov.
+For at opnå dette minimumssikkerhedsniveau skal alt rullende materiel opfylde visse minimumskrav.
+At øge topledernes ansvar på denne måde er en af nøglerne til reformens succes.
+Vi må ikke glemme, at vi drøfter budgettet og ikke et sekundært spørgsmål.
+Brugen af smart cards og elektroniske punge vil snart falde os alle naturligt.
+Midtvejsevalueringen må ikke være endnu en forspildt lejlighed.
+Han havde derfor solgt den til den kroatiske husejer.
+Dublinbugten blev nævnt som et særligt beskyttet og vigtig område for fugle.
+Militær har grebet magten og enhver spæd fremgang er tilintetgjort.
+Mange forfalskede lægemidler kommer ind i forsyningskæden under omemballering.
+Også det europæiske gartneribrug berøres, om end indirekte, af denne aftale.
+Der kommer desværre provokationer fra de folk, der burde udvise lederskab.
+Kære kolleger, stol på kvæstorerne.
+Cancer er blevet den nye sorte død.
+Vi lever i en verden, som forandrer sig lynhurtigt.
+Alt det medfører førtidspensionering af en række tjenestemænd og ansættelse af nye personer.
+Jeg gør honnør for de modige ansøgerlande, som har støttet koalitionen med specialstyrker.
+Kombineret kraftvarmeproduktion
+Fanatismen klæder sig blot i et religiøst gevandt.
+Det var en forfærdelig skæbne at skulle bære fjendens uniform.
+Det vil sandsynligvis ikke blive nogen nem vej at gå.
+Serbien er et grelt tilfælde.
+Jeg anmodede selv den israelske ambassadør om at komme til mit kontor.
+Måske er det en generation, som ikke tilfældigvis er født i rigdom og velstand.
+Nogle gange er retsgrundlaget ikke blevet godkendt på grund af spørgsmål om komitologi m.v.
+Bowis med en klar betænkning og klar stillingtagen til et aktuelt problem.
+Han er stadig under husarrest og skal melde sig dagligt hos politiet.
+Det fører i en række tilfælde til utydelighed og til langvarige procedurer.
+Begge disse områder har relation til det europæiske perspektiv, men de kræver forskellige redskaber.
+Det er en stor misforståelse, at en regering foreslår at erstatte lossepladser med forbrændingsanlæg.
+Menneskers værdighed krænkes på de mest nedrige måder verden over.
+Kommissionen er vogter af traktater, som i forvejen er uacceptable.
+Samtidig er jeg enig i synspunktet om, at der ikke findes nogen mirakelløsning.
+Vi har brug for fleksibilitet og bedre muligheder for omprioriteringer inden for rammen.
+Det ville være unfair over for os, og det skal vi gøre klart.
+Jeg havde svært ved at finde noget i den, der var forståeligt på engelsk!
+Men egentlig er der ingen uorden.
+Det atypiske arbejde af i dag er måske det typiske arbejde af i morgen.
+Det er efter vores mening helt skørt.
+Vi har alle set, at han helhjertet går ind for søtransport.
+Rådet mener, at regionale rådgivende råd er vejen frem.
+Jeg går også ind for rettigheder til unge, ældre, handicappede og mange andre minoriteter.
+Kan vi virkelig være sikre på, at produkterne på vores køkkenbord er sikre?
+De har annulleret netop den mening.
+Den senegalesiske regering og alle de andre regeringer kan også bebrejdes.
+Lissabonstrategien var mellemstatslig og slog fejl.
+Europas landbrugsjord skulle derfor udtages, og produktionen drosles ned.
+Jeg synes stadig ikke, det er korrekt at koble den til rejseudgifterne.
+Denne sammenfatning vil blive vedlagt det fuldstændige forhandlingsreferat
+Vi har hørt nok dirrende stemmer.
+Jeg bifalder og støtter fuldt og helt det foreliggende kodificeringsforslag.
+Man kunne formulere det uhøjtideligt.
+Men nu kære kolleger, lad os ikke lade verdensdagen for fattigdommen gå upåagtet hen!
+I denne årsberetning har vi fire hovedbudskaber.
+Alle vores assistenter og alle de medarbejdere, der er til stede, kunne deltage.
+Implementeringen er vigtig.
+Hjerteligt tak til ordføreren, som har sørget for, at vi har en god lovtekst.
+Albinoerne er ofte genstand for diskrimination og chikane.
+Lad mig skildre følgende case for kommissæren.
+Dog ser man sjældent tegn på fremskridt i mandens deltagelse i de huslige pligter.
+Den anden bremseklods er af meget mere politisk karakter.
+Intet land bør være et andet lands skraldespand.
+Det er lige præcis denne perverse virkning, som er blelvet opnået.
+Den europæiske historie fortælles næsten altid kun nationalt på nationale museer.
+Så driver de forretning på forsøgsbasis, før de etablerer et kontor eller en filial.
+De resterende beløb skal udredes af de nationale kasser.
+I den sammenhæng er samhørigheden essentiel i implementeringsprocessen.
+Alligevel har termen globalisering en negativ klang.
+Vi kan stemme elektronisk uden asterisken.
+Vær så god, gå bare i gang!
+Derfor skal auktion af mobilkommunikationsfrekvenserne bekæmpes kraftigt.
+Rådet har faktisk opført sig som en bulldozer, og det på tre områder.
+Parlamentet iagttog stående et minuts stilhed
+Endelig har vi brug for tillid fra os alle, når det gælder domfældelse.
+De nationale regeringer står altid imellem.
+Stigningen i forbruget af biocidholdige produkter er alarmerende.
+Irland kræver ikke et klap på hovedet eller en præcisering af den nuværende traktat.
+De svenske skove, rygraden i svensk økonomi, forvaltes økologisk og under hensyntagen til miljøet.
+Thrombin bruges alligevel i nogle medlemsstater, uden at forbrugerne er informeret herom.
+Af analysen fremgår det, at der er behov for en ny udviklingsstrategi for byen.
+Hidtil er vi imidlertid ikke stødt på problemer vedrørende oplysningspligt.
+Men den barbariske behandling af kvinderne knytter sig ikke kun til præstestyret.
+Så vil denne aktion tjene til vores nationers æres.
+Måske den offentlige europæiske debat venter på at blive rusket op.
+En gammel trawler er lige så farlig som en gammel olietanker.
+Ifølge mine oplysninger stilles de op få kilometer herfra, hvorfor, ved jeg ikke.
+Vi skal dog afholde en afstemning for at få fastlagt næstformændenes rangfølge.
+Det er billigere end at lægge korn på lager.
+Økonomi, æstetik og teknologi indgår i en symbiose med hinanden.
+Situationen vil blive værre, hvis de unge ikke anspores til en forskningskarriere.
+Desuden virker førstegenerationsbrændstofferne som bro til anden generation.
+De skyldige udpeges klart, og det havde vi også bedt om.
+Lad os håbe, at det sætter en trend for fremtiden.
+Diverse radiostationer i ansøgerlandene går alt for vidt med hadetirader mod romaer og jøder.
+Flere og flere medlemsstater ser nu det akutte behov for visumlempelser og tilbagetagelse.
+I forslaget klarlægges bestemmelserne om udøvelse af vejtransporterhvervet.
+Det er en besnærende skelnen, som selv retsudvalget ikke kunne støtte.
+Hatzidakis, er blevet alt for forsinkede.
+Parlamentet vedtog sin betænkning om strategien i oktober.
+Hvis det skal det, skal disse lægemidler så doseres forskelligt?
+Mange af formuleringerne fortjener absolut ros.
+Den koncentrerer sig nemlig kun om dette udsnit.
+Det islamiske regime har degraderet kvinder til andenklasses mennesker.
+Ved at tie pådrager vi os et medansvar.
+Problemet er, at politikere ofte er meget mindre ydmyge end forskere.
+Snigende reformer uden klare målsætninger skal afvises.
+I længden gælder samme acquis communautaire for alle medlemsstater.
+De vil aflægge rapport om, hvordan det bliver ført ud i livet.
+I de lande, der ikke har deltaget i aktionen, bliver kvæget i staldene.
+Jeg mener, vi bør drage politiske konsekvenser deraf.
+Jeg sagde dengang, at hver anden flyafgang aflyses.
+Vi vil kun ty til beskyttelsesforanstaltninger som en sidste udvej.
+Det, der mangler, er kvalificeret omskoling og uddannelsesmuligheder for unge arbejdsløse.
+Tampere by, arbejdsformidlingen og det regionale arbejdsmarkedsråd har undertegnet aftalen.
+Det giver os tilstrækkelig vished for, at processen virkelig omfatter alle interesserede parter.
+Dette glas skal bruges til at drikke af.
+Selim gik imidlertid endnu videre.
+Den er dybere end det, og den går meget længere end det.
+Det betyder, at vi i samme uge, som alle ved, stemmer her i salen.
+Det er naturligvis først og fremmest bosættelsespolitikken, som har startet denne nye voldsspiral.
+Hvis det dog blot gjaldt alle luftfartsselskaber, alle afgange og alle problemer.
+Fagforeningerne kan i så fald se frem til nogle kønne lønforhandlinger.
+Alt dette og mere til dæmmer op for affolkningen af landdistrikterne.
+Hidtil er de nye medlemsstater blevet beskrevet som klynkehoveder.
+Arbejdsvilkårene om bord på mange af fartøjerne svarer til intet mindre end slavearbejde.
+Det lyder meget nemt og pænt.
+Sokrates er en mønstergyldig fornuftig og kontrollerbar investering i fremtiden.
+En institutionel opprioritering af turismen forudsætter, at den bliver budgetmæssigt synlig.
+Nu er bolden igen blevet spillet tilbage.
+For børneofrene skal det primære fokus være barnets tarv og strengere straffe til menneskesmuglerne.
+Pompidou, hvis store kompetence på det videnskabelige område, vi alle kender.
+Der er faktisk reelle problemer med at få dømt menneskehandlere.
+Den folkelige kamp må forenes mod det samlede imperialistiske system.
+I denne uge mødtes jeg med iatrogene patienter.
+En vital europæisk kultur skal betragtes som en vigtig drivkraft bag økonomisk vitalitet.
+Epidemiologisk overvågning
+Dossieret over denne evaluering er derfor afgørende.
+Forklaringen på de overdrevne udgifter er først og fremmest leflen for kunderne.
+Der er ingen tvivl om, at retorikken vil fortsætte.
+Enhver handelstvist bør løses ved at søge at nå gennemskuelige, velovervejede løsninger.
+Et spørgsmål, som stadig står åbent hos os, er kurertjenesterne.
+Skabelse af arbejdspladser er vor hellige gral.
+Jeg er ikke den eneste, der opfatter de to som uadskillelige.
+Den blev helt klart brugt som en politisk rambuk.
+I denne periode vil den kinesiske ledelse være særligt følsom over for budskaber udefra.
+Dette er altafgørende for at fremme iværksætteri og vækst og skabe job.
+Ytringsfriheden er urørlig.
+Overtagelsen af frivilligt og ulønnet arbejde alene er heller ikke løsningen.
+Der er ikke nogen økonomisk grund til at begunstige denne eller hin sort.
+Det er morsomt med den store interesse for dette område.
+Lad os forsøge at bevare roen med hensyn til dette punkt.
+Det vil sige, der skal være frirum og et finansielt sikkerhedsnet.
+Energiforsyningen skal blive mere alsidig.
+Det cambodjanske parlament har erklæret sig indforstået hermed.
+I den forbindelse er jeg særlig bekymret over børns, især pigers, skolegang.
+Aserbajdsjan er et potentielt rigt land.
+Soldaterbander er jævnligt indblandet i angreb, røverier og voldtægt.
+Det, som skatteyderen skal bøde for, må ikke gøre krav på hemmeligholdelse.
+I udviklingslandene tørrer jorden ud, og sygdommene breder sig.
+Fru formand, jeg vil gerne støtte afstemningen om pædofili.
+I stedet blev den ændret til henrettelse ved hængning for påstået mord.
+Der er endvidere mange arter, som venter på at blive opdaget og beskrevet.
+Afskaffelsen af saksefælder løser jo ikke ubetinget problemet alene.
+Vi har hørt nok af fine tomme ord.
+Når vi forsøger at hjælpe kvinder, risikerer vi at straffe dem på jobmarkedet.
+Vi ved også, at antallet af leukæmitilfælde hos soldaterne er unormalt højt.
+Han afviser beskikkede advokater, hvis erfaring afspejler en eftergivenhed over for anklageskriftet.
+Jeg synes også, at vi skal være særlig opmærksomme på køn og handicap.
+Ikke en eneste familie i mit land har været upåvirket af den sovjetiske besættelse.
+Forordningens ikrafttræden vil gøre det nemmere for handicappede at rejse med bus.
+Dette handler om fælles forvaltning, ikke enegang.
+Forslaget til beslutning er velafbalanceret og rimeligt.
+Newman, der har gjort et godt stykke arbejde for at demonstrere dette udvalgs betydning.
+Den skaber også holdninger til aids i den bredere befolkning.
+Derfor skal dette spørgsmål tages op med stor finfølelse.
+Hvem vil tale for de udslidte og de ulyksalige?
+Der er sydlige stater med vanskelige søgrænser og lande med lange landgrænser.
+Beskyttelse af dyr på aflivningstidspunktet.
+Det er det grundlæggende aspekt i sagen og det strategiske, geopolitiske og geokulturelle nøglepunkt.
+Jeg tror, at stærke ord forstås bedre af vores russiske kolleger end undvigende adfærd.
+Og endelig når navigationen udvikles, er det fordi havene har geostrategisk betydning.
+Jeg glæder mig over, at der nu bliver en røgfri zone.
+Her er det egentlige spørgsmål, på hvilke betingelser conditional access skal indføres.
+Kommissionens udtalelse i dag vil jeg kalde for et gult kort.
+Sekretariatet begyndte at se frem til deres frokost.
+De siger, at det ikke er så let at kapre et fly.
+Stalddøren blev tydeligvis ikke låst.
+Vi vil altid stå på demokratiets side, ikke på tyranniets.
+Princippet om gradvis adgang til tohjulede køretøjer vil helt klart forbedre sikkerheden.
+I fremtiden vil der være adgang til en bredere vifte af miljørelaterede internettjenester.
+Vi var særdeles bekymrede for, at japanerne og amerikanerne ville tage føringen uden os.
+Derfor er dette særtilfælde fuldt begrundet.
+Udover dette ubevægelige grundlag findes der mindre justeringer, som det er værd at erindre.
+Det håb er nu desværre bristet.
+Jeg er enig i betænkningens ordlyd og vil stemme for dens vedtagelse.
+Samfundet kan være retfærdigt, men det kan aldrig elske.
+Dette omfatter forslaget om finansiering af forskning i fosterstamceller.
+De mener ikke, at væksten eller nøden er ligeligt fordelt.
+I hvilken udstrækning vil bankerne lade kunderne betale omkostningerne ved omregningen?
+Jeg har hvert år bemærket en ufuldstændig udnyttelse af disse bevillinger.
+Bøderne skal sættes kraftigt i vejret i disse sager, navnlig i gentagelsestilfælde.
+Almindelige mennesker jagter i bogstavelig forstand penge, eftersom priserne stiger.
+Jernbanevirksomhederne bliver således begrænset til en rolle som serviceydere, der sikrer togdriften.
+Navnlig speditører hævder, at den eksisterende forordning fungerer tilfredsstillende.
+Rumforskningen har spillet en pionerrolle.
+Tværtimod er dette engagement i en tostrenget strategi det rigtige.
+Først vil jeg gerne vide, hvad man mener med en hårdere linje.
+Bjerget skælvede og fødte et bureaukratisk fantasifoster.
+For øjeblikket er dataene i omløb uden nogen form for garanti.
+Jeg mener, at vi har forbedret det nugældende direktiv på en række vigtige punkter.
+Lannoye i hans udtalelser om, at vores politikker skal ændres.
+Netop disse virksomheder har problemer med at skaffe risikokapital.
+Vores institutionelle system må ikke favorisere det ene eller andet system.
+Europas maritime interesser påvirker hverdagen og beskæftigelsen for millioner af vores borgere.
+En størrelse passer ikke alle, hvad enten det drejer sig om handelspolitik eller sko.
+Tuberkulose er et åbenlyst eksempel på den ulighed, der gennemsyrer vores verden.
+Jeg fryser, og jeg fryser faktisk meget!
+Derfor oplever vi denne bagvaskelseskampagne.
+Der er intet alternativ til tålmodig dialog.
+Europa har behov for et nyt pust, der er baseret på gennemsigtighed og demokrati.
+Fattigdom er den største enkelte determinant for sundhed.
+Parlamentarisk immunitet omfatter ikke almindelige straffesager.
+At giftige kemikalier har indvirkning på hormonbalancen, er indlysende.
+Frankenstein skabte med sin teknologi et monster, som overgik ham selv.
+Retningslinjer for vertikale begrænsninger
+Med andre ord, aftalen er ikke strålende, men den er rimeligt tilfredsstillende.
+Det tjekkiske formandskab har fulgt situation nøje længe inden årsskiftet.
+Det er hajer, som slipper gennem nettet.
+Området trues imidlertid af byplanlæggere, der ønsker at bygge huse.
+Vi ønskede at forhindre, at oplysningspligten kunne gemme sig bag immaterialrettighederne.
+Vi delte moldovernes begejstring over en ny fremtid.
+Dette blev slået fast i midten af juni, da betænkningen blev færdiggjort.
+Kommissæren ville betegne det som opsøgende arbejde.
+Jeg mener, at vi bør gå videre og ligeledes forbyde brug af bundsatte hildingsgarn.
+Nu er udsigterne dystre, idet planen er lagt på hylden af udelukkende politiske årsager.
+Der er ingen lovmæssig hindring.
+Det er adgangsstyring til digitalt tv.
+Debatten om bioteknologi kræver en integral, etisk tilnærmelse.
+Endvidere skal klageren have mulighed for at anke en negativ afgørelse.
+Nairobi giver os mulighed for at gå løs på denne udfordring.
+De skulle jo fodres, så vi havde et alvorligt problem.
+Systemets pålidelighed er vigtig, da det skal fungere hele tiden.
+Kan man handle via kirker og på andre måder?
+Vi ønsker ikke nogen varig subvention.
+Menneskehandlen berører især kvinder, som er ofre for organiserede mafiaer og for prostitution.
+Brok, ville vi faktisk allerede været kommet langt videre.
+Krisens økonomiske omkostninger er endnu ikke endeligt opgjort.
+Det forsøger at købslå sig frem, men er dømt til at mislykkes.
+Derfor kan vi ikke acceptere, at vi bliver miskrediteret på denne måde.
+Beder de om at samarbejde og føre dialog med bødlerne og spotte ofrene?
+Denne talsætning af ændringerne viser også, at der er sket forbedringer.
+Man gør stadig brug af gruopvækkende straffe.
+Jeg vil ikke lægge skjul på, at jeg også overvældes af et vist vemod.
+Demokratiet forudsætter en folkelig beslutning, ikke en manipulation fra apparaternes side.
+Vi betragter denne aftale som en milepæl i vores kommende forbindelse med latinamerikanske lande.
+Vi er medlovgivere på lige fod.
+Fremskridt er et udtryk for politisk vilje, hårdt arbejde og dedikation, hvilket skal belønnes.
+Hvis nogen rydder en hektar frugthave, er det, fordi der er en økonomisk tilskyndelse.
+Medierne var også medvirkende til panikken.
+Ingen af disse bange anelser stemmer overens med virkeligheden.
+Vi mener, at hyppigheden og omfanget af den tekniske inspektion af flyene bør øges.
+Sult og død hærger fortsat landet.
+Jeg kan se, han nikker bekræftende, så jeg har citeret ham korrekt.
+Lige som førhen står mange spørgsmål åbne.
+Jeg har også min rugbyklubs flag til at hænge derhjemme!
+Denne flove smag er efter min mening på ingen måde fjernet.
+Og for det tredje skal vi forfølge en holistisk politik, ikke en fragmenteret.
+Det tager meget lang tid at nedbryde batterier og akkumulatorer, der smides ud.
+På den baggrund bør anvendelsen heraf ske efter nøgtern overvejelse.
+For os er spørgsmålet om guld også vigtigt.
+Fællesskabets aktion kan og skal være et godt eksempel, også i vore store byområder.
+Derfor må vi ubetinget sige nej til import af klorkyllinger.
+Vi er ikke tvunget til at holde fast i denne forkerte afgørelse.
+Marques, og jeg vil gerne rose dem begge.
+På hvad kan man se, at denne genopbygningsbistand rent faktisk ankommer?
+Dette blev konstateret på den første donorkonference i juli.
+Kina har ændret sig, og det har vores forbindelser også.
+Anerkendelsen af det civile samfund som en samarbejdspartner er en meget stor nyskabelse.
+Jeg kan give et eksempel af nyere dato herpå.
+Sidste søndag var den internationale dag for udryddelse af fattigdom.
+Det vil således være uhensigtsmæssigt, hvis jeg på nuværende tidspunkt uddyber det nærmere.
+Dette skal ske ubureaukratisk og hurtigt.
+Værdipapirhandlere og omvekslingssteder får i år anmeldelsespligt.
+Til sidst vil jeg sige, at det finske formandskab var koldt, roligt og fattet.
+Jeg håber, at håbet vil vinde over skepsissen.
+Hvis cementovne samforbrænder affald, skaffer det mange penge.
+Her begår vi en fejl, og vi opfører os tåbeligt.
+Hverken skik og brug eller alkohol bør betragtes som formildende omstændigheder.
+Vi har fastholdt vores prærogativer.
+Der er stadig to områder, jeg gerne vil gå i dybden med.
+Vi finder det også vigtigt, at togføreren kan få adgang til sine egne data.
+Båden begyndte at vippe faretruende, og folk gik i panik.
+Vi kan selvfølgelig rykke lidt rundt.
+Europas integration er bygget på et sæt grundlæggende værdier, som konstant udbygges.
+Mozambique er nu kommet ind i en vanskelig fase.
+Disse krævende genvindingsmål vil uden tvivl afæske industrien visse anstrengelser.
+Jeg synes, at kønsulighed skal udfases.
+Det er derfor positivt at sænke tærskelen og udvide den kulturelle arena.
+Personligt er jeg stor tilhænger af behandling i brystcentre.
+Salmaan betalte for denne støtte med sit liv.
+Det er et fornuftigt og afpasset svar.
+Men man skal ikke tro, at vi kan skabe arbejdspladser ex nihilo.
+Loyalitet bygger ikke kun på statsborgerskab, men også på fælles holdninger.
+For det andet vokser andelen af plastik i affaldet.
+Vores handlinger har rakt langt videre.
+Det har aldrig benyttet sig af denne bemyndigelse.
+Når det gælder konkretiseringen af frister osv., er det dog stadig meget trægt.
+Det er en betænkning, der hædrer det parlamentariske arbejde.
+I denne forbindelse har vi vedtaget en række foranstaltninger vedrørende vinfremstillingsredskaber.
+Ved hjælp af denne kriminalisering forhindrer han fair play, også ved de forestående lokalvalg.
+Og det behøver vi både til benzinmotorer og til dieselmotorer.
+Det er sandt, at euroens dyder ikke taler for sig selv!
+En fastfrysning af deres lønninger på flere millioner dollars er ikke en straf.
+Alle går ind for europæisk samarbejde på dette felt.
+Vor dronning, der er oranier, er dronning for både katolikker og protestanter.
+Blandt de opstramninger jeg gerne vil pege på, er der dels anvendelsesområdet.
+For øvrigt skulle tusindvis af tjetjenere have kæmpet sammen med talebanerne.
+Vi må tage os i agt for sådanne tendenser.
+Der sejler i øjeblikket fire søsterskibe rundt.
+Rehder har givet et bidrag dertil.
+Vi ønsker ikke denne dødbringende dogmatisme overført til fællesskabsplan.
+Den ensidighed, som ofte præger diskussionen, er imidlertid påfaldende.
+Men nejsigernes triumf bliver kort.
+Derfor er spørgsmålet, hvorvidt vi tillader bodyscannere eller ej.
+Der bor et stort russisk mindretal i landet samt mange ungarere, tatarer og rumænere.
+Hvorfor har slagtedyr større ret til velfærd end fededyr?
+Der er en dyb kløft mellem den politiske retorik og de finansielle perspektiver.
+Der skal hellere ydes støtte til de landmænd, som dyrker afgrøder efter traditionelle metoder.
+Demokratisk, parlamentarisk og judiciel kontrol findes ikke i virkelighedens verden.
+Det er på tide at indse, at papegøjen virkelig er død.
+Det er roden til hele misforståelsen.
+Europa som hjemsted for erhvervslivet kommer under pres og bliver mindre og mindre attraktivt.
+Europæiske normer har globalt ry for at være meget strenge.
+Det er rigtigt nu at foreslå en særordning endnu en gang.
+Vi må ikke være for magelige, men nu gøre det, der skal gøres.
+Man kan trygt sige, at flyselskaberne tidligere ynkeligt har negligeret passagerernes sundhed.
+En indforståethed, der bringer volden med sig, som en tordensky bringer torden.
+Det er særligt uærligt over for det tyrkiske folk.
+Borgernes opvågnen er i alvorlig fare.
+Sammenfattende og til sidst slår jeg til lyd for en pax avianautica.
+Det lagde ud med fanfarer og slutter med dødsklokker ved den fattiges grav.
+Schulz, nemlig at det er vigtigt at fremhæve den multilaterale tilgang hertil.
+Finlands eget nationale parlament, , fejrer et særligt jubilæum.
+Europæiske intellektuelle ejendomsrettigheder vil opnå øget beskyttelse.
+Blair, der understregede, at der ikke vil blive afholdt en folkeafstemning.
+Det beskytter skibsfartens storkapital mod idømmelse af sanktioner.
+På grund af disse udfordringer må vi ikke være gerrige over for vores borgere.
+Alle glødede af optimisme, men det fusede ud.
+Det er ikke ukrainere, der i flokkevis ansøger om asyl hos os.
+Det er imidlertid bekosteligt at etablere biogasanlæg.
+Ligesom champignon efterlades briterne i mørket og fodres med møg.
+Og hvad med de medlemsstater, som finansierer dyrkning af agrobrændstof i sydlige lande?
+Rådet fornyede sanktionerne over for regimet, men slækkede samtidig på kravene.
+God gratis undervisning er væsentlig for udviklingen.
+Der lægges særlig vægt på forebyggelse af hiv i forhold til mødre og børn.
+Det er kun delvis korrekt.
+De må studere, men lektioner, der afholdes af mænd, ser kvindelige studerende på video.
+For når en stat er meget uvigtig, bliver den hurtigt dømt.
+Man skal trods alt være katolik for at kunne blive pave!
+Tværtimod lod de nærmest til at være fjendtligt indstillet over for dem.
+Vi vil følge sagen til dørs.
+Euroen administreres på oligarkisk vis.
+Det første vedrører den økonomiske effektivitet af flykontrollen.
+Det er godt, at midlerne til højkommissæren for menneskerettigheder fordobles.
+To punkter har vi særligt bidt mærke i.
+De små virksomheder og mikrovirksomhederne er de arbejdsløses bedste håb.
+Det virker som noget meget mystisk og specialiseret.
+De nye lovregler om fjernsyn uden grænser har ikke haft ubetinget succes.
+Ministerrådet må imidlertid ikke lade sig bagbindes af et eventuelt veto.
+O.k., men selv det ville kræve et møde i det korresponderende udvalg.
+På den anden side har vi gassen.
+Jeg er helt overbevist om, at vi vil ride stormen af denne gang.
+Efter vores mening er en aftale med bilfabrikanterne den rette fremgangsmåde.
+Angolas befolkning fortjener en anden skæbne.
+De mange minutters unødvendig tavshed her koster yderligere millioner, og sådan fortsætter det.
+Østersøstrategien bliver en af prioriteterne under det svenske formandskab.
+Jeg forstår, at der er brug for en reform af vinmarkedet.
+Jeg er ked af, at ændringsforslagene til disse betænkninger ikke blev vedtaget.
+Jeg har ikke benægtet gaskamrenes eksistens eller bagatalliseret emnet.
+Gang på gang bliver håbet knust.
+Havde vi ikke det indre marked, måtte den britiske regering betale hele gildet selv.
+Men det er allerede ti år siden.
+Der er ikke nogen lovhjemmel for sådan en handling.
+Så har vi klaret inkonsistensen mellem elektriciteten og naturgassen og inden for naturgassen.
+Nice kan ikke bruges, det siger sig selv.
+I betænkningen står der også, at stigende vækstrater kan afværge en katastrofe.
+Det vil formentlig tage et halvt århundrede at tæmme kernefusion.
+Der er opstået et dramatisk underskud, der kræver en nyorientering.
+De er desuden meget bioakkumulerende.
+På min fars tid blev de afgjort med nogle stokkeslag eller nogle lussinger.
+Det var umuligt at komme af motorvejen, og der var snart en lang kø.
+Der er sagt tilstrækkeligt om lodserne.
+Vi skal koncentrere os om at mindske risiciene ved zoonotiske agenser til et minimum.
+Uddannelse, långivning og netværksopbygning skal være de vigtigste støtteforanstaltninger.
+Jeg endte med ikke at stemme imod beslutningen.
+Det ligner lidt tæppehandlermetoder.
+Positive impulser er helt afgørende.
+Det er mange, der taler om benchmarking i alle mulige sammenhæng.
+Der vil være fare for alvorlig krise og stagnation.
+Den skal så være gældende, indtil reevalueringsproceduren er afsluttet.
+Jeg taler ikke om andre meget grusomme metoder at slå folk ihjel på.
+Forslaget gør det kompliceret for biblioteker, arkiver, kunstskoler og uafhængige filmproducenter.
+Men disse gode år er ovre.
+En abort er en falliterklæring for faderen, som ofte lusker bort i nedtrykt tilstand.
+For det andet kræver en effektiv brug af kryptering et sikkert system til nøgleadministration.
+Det er ret pinligt, i betragtning af at alle andre har udtalt sig.
+Bruxelles er et tiltrækkende sted for erhvervslivets lobby.
+Her har vi været frygtsomme og har gået som katten om den varme grød.
+Gid solidariteten vil sejre over det tøjlesløse ønske om profit.
+Lokal beskæftigelse, lokale tjenester, ok.
+Men de, der klamrer sig til fortidens job, begrænser fremtidens job.
+I modsat fald kan vi befordre absentisme.
+Der bør opmuntres til udenlandske studier.
+Som dreng kunne jeg ikke handle i en tyskejet butik.
+Sverige vil føre os ind i en ny æra i europæisk fællesskab.
+Alene fra årets start er tre fredelige demonstrationer blevet brutalt nedkæmpet.
+Gawronskis vegne, men vi vil vende tilbage til dette emne.
+Bioetiske anliggender vil helt sikkert beskæftige os mere fremover.
+En budbringer fortalte os, at vi var blevet udsat for en kollektiv afskedigelse.
+Som om vi alle gemmer kvitteringer for alle vores indkøb!
+Nu er det vigtigt at styrke ombudsmandsinstitutionen.
+Det er et modbydeligt signal at sende, ikke mindst i disse urolige tider.
+Fremtiden for mobilitet i byer hænger derfor tæt sammen med fremtiden for flodtransport.
+Det var de radikale, der i første omgang bad om udsættelse.
+Jeg har imidlertid en bøn til de kommende formandskaber.
+Makhmour er en kurdisk flygtningelejr for tyrkiske kurdere med ca.
+Vi ser ingen grund til at revurdere holdningen heri.
+Gaza er en israelsk fangelejr!
+Den tilpasning kræver, at lederne træffer vanskelige beslutninger, som ofte er upopulære.
+Det ville nærmest minde om en advarselstekst af den type, der findes på cigaretpakker.
+Men en unilateral holdning uden begrundelse er utilgivelig.
+Derfor vinder særinteresserne ofte, og der bekymrer min gruppe.
+Sammen er vi fast besluttet på at undgå nye færgekatastrofer.
+Vi må usvigeligt stå vagt om vores værdier.
+Den vil give næring til nationalismen i stedet for at tørlægge dens kilder.
+Ingen lønarbejdere kan eller bør nære nogle illusioner.
+I min folkeskole skulle vi lære adskillige nye sange.
+Der er også blevet indført en ny certificeringsmetode, som har skabt visse problemer.
+Det er ikke kun tilfældet fra medlemsstat til medlemsstat, men sågar inden for medlemsstaterne.
+Denne uges topmøde vil afgjort skulle inddrage dette vigtige mål.
+Eller vil vi stadig sende vores udtjente skibe til uansvarlig ophugning på indiske strande?
+Desuden stiger antallet af langtidsledige og antallet af ledige unge stadig.
+Menneskerettighedsorganisationen sammenfattede det med, at det er rævene, som vogter gæssene.
+De voldsomme angreb fra den europæiske industri mod forslagene er ulidelige.
+Det er en kendsgerning, der kategorisk afkræfter de negative varsler, som mange har fremført.
+En sådan opvisning af enhed er generelt altid meget bevægende.
+Spørgsmålet om donation fra levende donorer har været den største udfordring.
+Det er dog det værd, og jeg synes, det er fint, at det findes.
+Jeg vil også gerne komplimentere vores nye kommissær for hans debut her til aften.
+Denne betænkning er en påmindelse om, hvad det europæiske agentur for lægemiddelvurdering burde være.
+Afstemningen af retningslinjerne og af den økonomiske politik er upræcis og uforpligtende.
+Der er de besynderligste forhold i alle disse stater.
+Selvfølgelig husker jeg tiden med mælkesøer og smørbjerge, og den ønsker jeg ikke tilbage.
+Det er meget ærværdige mål.
+I dagens episode ligger der politisk stof.
+Canada handler langt fra i god tro, og dermed opretholdes en fjendtlig holdning.
+Jeg synes, at det er et meget veludført arbejde.
+Enhver forsinkelse vil bane vejen for simpelt tyveri af intellektuel ejendom.
+Farlige stoffer som phthalater skal sættes ud af spillet og erstattes af ufarlige.
+Der skal ikke herske tvivl om, at jeg ikke ønsker at ty til demagogi.
+Landet befandt sig dengang i den mest alvorlige krise i nyere tid.
+Retten til at indgive andragender er en af de ældste rettigheder for enkeltpersoner.
+Sidste sommer overtog blågrønne alger hele havet med hjælp fra det varme vejr.
+Mønterne skal være påført særlige sikkerhedstræk for at begrænse mulighederne for bedrageri.
+En sådan måde at agere på er naturligvis politisk uacceptabel.
+Om det er bedrag, ond tro, inkompetence, sløsethed, uvidenhed?
+Vi kan ikke forhandle i ugevis og så se kompromiset undermineret i sidste øjeblik.
+Det afstedkommer naturligvis mange frustrationer.
+Vi må ikke fralægge os vores ansvar.
+Først da kan dette meget triste kapitel i regionens historie endeligt afsluttes.
+De kunne kombineres i et enkelt forslag på samme retsgrundlag i den første pille.
+Jeg vil gerne rette blikket mod nogle aspekter af den fælles landbrugspolitik.
+Kunstig inseminering og embryonoverførsel gør dette muligt.
+Det er ikke det blæk værd, som det er skrevet med.
+Dette punkt på dagordenen er afsluttet.
+Indtil da var det som bekendt kun forbudt for drøvtyggere.
+Derfor kunne vi spare penge på at bringe denne absurde månedlige udflytning til ophør.
+Grækenland har et særligt problem.
+Vi må frem for alt ikke skabe forbindelser, så længe alle cubaneres rettigheder krænkes.
+Det fører til, at vi udhuler respekten for vores egne høje principper.
+Det er ikke en beslutning om overgangsbestemmelsen i sig selv, men kun noget redaktionelt!
+Andor, mine damer og herrer!
+Europol får til opgave at kontrollere og godkende amerikanske begæringer.
+Indehaverne af disse licenser omfatter store globale energikoncerner.
+I øjeblikket står den ubrugt hen og bevogtes af tyrkiske tropper.
+Det udelukker ikke, at private udbydere kan og skal tumle sig her.
+Dupuis, der kræver fuldt medlemskab.
+Jarzembowski, hjertelig tillykke med det storartede arbejde, som de har udført.
+Der sættes handelsrekorder for køb af soja, majs og hvede.
+I optællingen var mit navn stadig med.
+Er den vikaransatte en arbejder som alle andre?
+Det er et interessant spørgsmål, for her kunne vi jo umiddelbart tage affære.
+Udviklingslandene er blandt dem, der lider mest under denne økonomiske recession.
+Den svenske opinion har også udviklet sig i positiv retning.
+For tydelighedens skyld tager jeg hvert ændringsforslag efter tur.
+Denne situation må anskues med alvor og ansvarlighed.
+Lad os ikke henfalde til amerikanske tilstande.
+Kommissionen har kun initiativret, og slet ikke enekompetence, inden for helt bestemte områder.
+Lad os droppe denne unøjagtige, ulogiske og misvisende resolution.
+Vi kan ikke vente på nye havretsregler eller lukke øjnene for situationens alvor.
+Det kræver både uddannelse af høj kvalitet samt hensigtsmæssige jobudsigter og karrieremuligheder.
+Det er kort sagt et spørgsmål om både pisk og gulerod.
+Men hvem afgør, om de filer, vi har, er af kommerciel art eller ej?
+Jeg tænker navnlig på de mindste og nyeste medlemsstater.
+Men udviklingslandenes økonomi er hovedsageligt baseret på salg af disse råstoffer.
+Og hvis et tog kører forbi et rødt stopsignal, aktiveres bremserne også automatisk.
+Det er afgørende at sikre nøjagtig kontrol og registrering af omladninger og landinger.
+Flexicurity i sig selv er hverken en god eller en dårlig politik.
+Hvori består nu egentlig den skade, der udgår fra disse skibe og fra bekvemmelighedsflaget?
+Alle her husker, hvad der skete med en forfejlet landbrugsøkonomisk politik, med kogalskabsproblemet.
+Ud fra egen erfaring lovpriser han irakiske studerendes niveau.
+Mulder ville have været enig med mig, hvis han havde været til stede.
+Det er i alles interesse, at denne indsats gennemføres så glidningsløst som muligt.
+Spørgsmålet om sikkerhedspolitik var reduceret til en garanti om grænsernes ukrænkelighed.
+Alle bevillinger og al administration foretages i dag på edb.
+Uddannelse skal uddanne, ikke skabe billige, lydige arbejdere.
+Bygningens udvendige glasparti er snavset.
+Målet er udelukkende at fremme liberaliseringen og opbygge a level playing field.
+Her må såvel importører som ferierejsende og forbrugere være sig deres ansvar bevidst.
+Syn ved vejsiden af erhvervskøretøjer
+Men denne model vil redde liv i mange tilfælde, før ambulancen når frem.
+Euratoms sikkerhedskontrol viste derfor ikke, at angivelserne var forkerte.
+Jeg tror, at budgettet kan klare, at alle medlemmer får en papkasse til papirgenbrug.
+Derfor er det vigtigt, at vi ikke vedtager bestemmelser, som er tvetydige.
+Det andet punkt, hvor vi er i dissens, er natarbejde.
+For det femte er den påtænkte retlige brug af de nævnte oplysninger ukontrolleret.
+Hvis arterne uddør, forstyrres naturens balance, hvilket udløser en farlig dominovirkning.
+Her vil jeg gerne fremhæve to meget positive initiativer fra det amerikanske senat.
+Tørke er ligesom ørkendannelse en kilde til alvorlig bekymring.
+Det belgiske formandskab har fortsat det svenske formandskabs kraftige og regelmæssige rytme.
+Der findes mennesker, som foretrækker esperanto til grænseoverskridende kommunikation.
+Arbejdstagernes tålmodighed er nu sluppet op.
+Kommissionen skal være mere hård i flinten.
+I min korte tale vil jeg gerne fokusere på reintegrationen af brystkræftpatienter i arbejdslivet.
+Altså vokser produktionen i kødkvægsektoren mere og mere.
+Derfor vil vi stemme imod lempelsen af standarderne.
+Altid envejskommunikation, aldrig åben debat og altså så meget desto mindre folkeafstemning.
+Skadelige følger af rygning er også sorte rygerlunger og rådne tænder.
+Avisredaktioner ransages for at skræmme kritiske røster i pressen.
+Vi kan forvente, at aftalen vil fungere gnidningsløst.
+Upåvirket heraf udbreder fagforeningerne fortsat usandheder og skaber panik.
+For halvandet år siden truede markederne med at knække hele den globale økonomi.
+Irans dommere afsiger rutinemæssigt dødsdomme over homoseksuelle og teenagere.
+De mener fortsat, at de er højt hævet over lovgivningen.
+Det er at spænde vognen for hesten, fru kommissær.
+De nationale mindretals rettigheder er en ufravigelig del af de grundlæggende rettigheder.
+Vi har talt om valutauro, børskrak og finanskriser.
+Vi taler om linoleumsgulve med disse virkninger.
+Medlemsstaterne skal skabe alle mulige strukturer og procedurer for at fordele byttet.
+Lige fra begyndelsen har disse kriterier været genstand for heftige debatter.
+Occhetto på den anden side.
+Problemernes iboende natur gør, at der kræves multilaterale løsninger.
+Balkenende, det ved jeg, er en god kender af tysk historie.
+Koudiadis, fordi han gjorde det rigtige og opgav sin betænkning.
+Vi har konstateret, at når orkanen hersker på havet, bryder alt sammen.
+Den tåler kun dårligt markedskræfternes lammende greb.
+Her hjælper højglansbrochurer ikke noget.
+På den måde kan vi også sikre en godt udrustet og kompetent arbejdsstyrke.
+I alle samfund, også det litauiske samfund, er der lesbiske, bøsser og biseksuelle.
+Sådanne handlinger kan ikke regne med støtte fra enevældige myndigheder.
+Der må sættes kurs mod en omlægning fra produktionsstøtte til landbrugspolitik.
+De handler imidlertid som brandfolk med pyromani.
+Hvis vi kan reducere det antal glasål, der fanges, vil vi kunne opbygge ålebestanden.
+Det kan være et spørgsmål om deres bopæls territoriale beliggenhed.
+Fordelen er, at vi reducerer udgifterne til veksling af penge samt andre transaktionsudgifter.
+Vi bør ikke forbyde den jagt, der traditionelt udføres af inuitterne.
+Der skal også tages hensyn til statens subjektive opførsel.
+Et spørgsmål, som feminismen løbende har drøftet, er spørgsmålet om den hjemmegående husmoder.
+Dette beviser bl.a., at jagt kan drives uden de barbariske rævesakse.
+Min mor døde for en måned siden.
+Vi ønsker at vide, om denne aftale fremmer udviklingen af denne øgruppe.
+Der var et spørgsmål om enzymer og lovgivningen om genmodificerede fødevarer og foder.
+Disse resultater eller dette task force blev ikke nævnt.
+Vi har også indført fleksibilitet i forbindelse med pauserne.
+Dette forslag angår den srilankanske observatørmissions arbejde.
+Husk at tage sikkerhedsbælte på, også på bagsædet!
+Det var et udmærket spørgsmål, men det kom ubelejligt.
+Disse artikler er særlig vigtige for individets og hele samfundets velbefindende.
+En anden god nyhed er, at sagsbehandlingstiden er faldet til ni måneder.
+Vi kan kun acceptere brugen af anordninger, der opfylder alle disse krav.
+Intimideringsmønsteret er klart.
+Før jeg kom her, svor jeg, at jeg ikke ville fortælle vittigheder.
+De bortførte estere er imidlertid stadig overladt til deres bortføreres nåde.
+I går var der trompeter og basuner lige uden for vores mødelokale.
+Brandfarlige møbler er et eksempel, som jeg har i tankerne.
+I den nederlandske tekst er der en fejltagelse eller en trykfejl.
+Selvfølgelig var der fejl ved deres plan, og deres fantasifulde monetære system brød sammen.
+Hvor bliver sodfiltrene på biler af?
+Irerne har sagt nej til at få den demokratiske kontrol væk fra borgerne.
+Disse manøvrer er latterlige.
+Særlig kosmetikindustrien er berørt af disse metoder.
+Ved hårdhændede udvisninger er der også tidligere faldet døde og sårede i andre medlemsstater.
+Hvad vil der ske, såfremt den drastiske rentenedsættelse medfører en overophedning af økonomien?
+Jernbanespeditørerne er et sammenbrud nær.
+Det handler også om guld, diamanter, cobalt og værdifuldt tømmer.
+Roche har fremsat under denne meget interessante forhandling.
+Vi er muligvis på nippet til at finde de politiske løsninger på vores problemer.
+Og så tager de ansvarlige benene på nakken.
+Det er uhøfligt over for medlemmerne, og det forstyrrer debatten.
+I henhold til vores oplysninger har man endnu ikke truffet beslutning om en bygmester.
+Doha er det bedste handelspolitiske værktøj til vores rådighed på begge disse fronter.
+Men tilbage til manuskriptet.
+Det arabiske fredsinitiativ blev enstemmigt bekræftet sidste forår.
+Præamblen er ekskluderende og afspejler en forvrænget fortolkning af historien.
+Forslaget betoner alligevel i stor udstrækning både proportionalitet og subsidiaritet.
+Det første er den audiovisuelle sektors betydning for sportens fremme.
+De fortjener alle et godt nytår!
+Det er en positiv beslutning efter et langt og til tider møjsommeligt arbejde.
+Der er tale om en nødvendig og kærkommen udvalgsinitiativbetænkning.
+Det burde skabe større likviditet.
+Det er urealistisk at fortsætte med braklægningsrettighederne.
+Opdræt af hjorte, af ræve og af mink er helt forskellige spørgsmål.
+Stevenson for hans fantastiske arbejde.
+Lad ikke fattigdomsbekæmpelsen bliver offer for dette dødvande i forhandlingerne.
+Kapitalisme er et kasino, hvor der trækkes lod om energiprisen på fondsbørserne.
+Det er derfor, vi har mødt problemet med fjernelse af hajfinner de senere år.
+Det var ualmindelig vanskeligt at tage hensyn til alle ønsker.
+Død og hungersnød udgør en dårlig grobund for fred.
+Den syvende samling finder sted i næste måned, og der bliver megen travlhed.
+Man bliver rent ud sagt næsten svimmel af dette samfunds dynamik.
+Dog er det nødvendigt at beskytte de europæiske landmænds særpræg.
+Jeg tænker på de asiatiske tigre i forhold til de sydasiatiske lande.
+Dyr skal slagtes så tæt som muligt på avlsstedet.
+Libanons hær bør have monopol på militær aktivitet og kontrollere landets territorium.
+Det er i alles, herunder tamilernes, interesse, at denne fredsproces sættes i gang.
+Det er noget komplet sludder.
+Om ikke andet kunne vi stoppe frøspredningen over store områder i den frie natur!
+Og ligeledes det første medlem fra den iberiske halvø, som har denne funktion.
+Kvinder skal ikke umyndiggøres med kvoter, men hindringerne for deres karrierefremgang skal fjernes.
+Der er en nagende usikkerhed over landets fremtid.
+Disse procedurer er blevet kritiseret fra alle kanter.
+Blot en enkelt afsluttende bemærkning til emnet, som måske også burde mane til eftertanke.
+Men handel er ikke nogen magisk kugle.
+Der er adskillige eksempler på illoyal konkurrence fra visse af vores handelspartnere.
+Tidligere var sagerne imidlertid stort set ukendte, og civilsamfundet var ikke så aktivt.
+De nye medlemsstater er vant til årlige opgørelser.
+Vi må derfor undgå at skabe præcedens ved at acceptere asociale foranstaltninger.
+Hvad blev trampet ned af politiseringen?
+Derfor skal vi være varsomme, før vi prædiker over for resten af verden.
+Havmiljøet er helt klart grundlaget for vores havøkonomi.
+Køreplanen er således rigtigt tilrettelagt, og den skal overholdes.
+Cyperns befolkning har lidt kolossalt under øens deling.
+Jeg vil dog ikke remse alle fortidens historier op endnu en gang her.
+Ettl vil jeg tale om begge betænkninger samtidig, da de rejser de samme spørgsmål.
+Det er et nobelt forsøg, men stadig ikke tilstrækkeligt.
+De skal bevisligt opsamles, lagres, behandles og markedsføres separat.
+Det er et af de instrumenter, der er nødvendige for at kunne bekæmpe virussen.
+Og vi bør indrette vores lovgivninger, således at der sættes en stopper for sexturisme.
+De kan ikke puttes ned i den samme form, i den samme forhandling.
+Der skulle ganske rigtigt mange englebørn og ærkeengler til at skabe dette lille mirakel.
+Rygeforbuddet har allerede ført til hundredvis af publukninger med tab af arbejdspladser til følge.
+Vi hører fra eksperterne, at vandstanden kan stige med op til en meter.
+Vi har brug for fyrtårne i den europæiske forskning.
+Jeg taler om catalansk, mit og ni millioner andre europæeres modersmål.
+Haarder er jeg i høj grad utilfreds.
+Jeg vil især nævne fremskridt med hensyn til renere vand, hygiejne og sygdomsforebyggelse.
+Fru kommissær, bak op om mejerifonden!
+Jeg er omgivet af nogle meget opmærksomme mennesker her.
+Biler med polske nummerplader underkastes kontroller, der varer flere timer.
+Vi er nødt til at have en tydeligere sondring mellem dem.
+Hvordan står det til med udviklingen af disse filtersystemer til luftfartsselskaberne?
+Holodomor var produktet af et totalitært politisk regime.
+Kun paven er ufejlbarlig, vi er ikke.
+Hun har valgt en kort, generel og for hvert enkelt medlem enslydende evaluering.
+Men der er fortsat udfordringer, som skal takles.
+Det er ikke tilstrækkeligt med øjentjenester i form af høring.
+De må ikke overtages af de korporative interesser.
+Der findes ikke sådan noget som nulrisiko.
+Ja, naturligvis fortsætter diskussionen, men hvad dette punkt angår, vil løbet være kørt.
+Vi opretter ikke monopolvirksomheder, som så må sejle deres egen sø.
+Sidste spørgsmål handlede om fuldstændig scanning af indgående containerfragt.
+I stedet er der søskenderivalisering og derefter mord, brodermord.
+Denne beslutning tager bestemt ikke blidt på stofferne.
+Også det bør afdækkes ved langtidsstudier, og resultaterne bør offentliggøres.
+Jeg vil nødig score politiske point på det.
+Den virksomhed, der eksploderede, producerede gødning.
+De annoncerede mål og ambitioner vil ikke blive opfyldt.
+Hvordan genkender borgerne sig heri?
+Det er jo ikke de store armbevægelser, der bringer os fremad.
+Artiklen stod i et tidsskrift, der kun læses af folk, der arbejder med bogføring.
+Lige nu er der lagt låg på trykkogeren.
+Jeg støttede denne tekst, der indebærer en kærkommen justering af loven om metrologi.
+Det vænnede jeg mig til under det britiske formandskab.
+Ergo er der en reel risiko.
+Den georgiske regering står over for en vanskelig opgave.
+Rivaliseringen mellem de to førnævnte politikere og deres tilhængere har fatale konsekvenser.
+Kort og godt ønsker de at kunne udråbe en ægte og lovlig uafhængig stat.
+De har nu lejlighed til at sige noget desangående.
+Producenterne vil opleve et økonomisk flop med disse produkter.
+For det andet eksisterede der ingen basale samfundsstrukturer.
+Med dybdeborede huller eller rør til transport, er vores evne som donor ret fantastisk.
+Skubber man østudvidelsen ud i fremtiden, kan disse gevinster gå tabt.
+At brænde lejre ned og jage mennesker gennem gaderne er helt uacceptabelt!
+At plante træer er med til at bekæmpe ørkendannelse.
+Endelig foreslår vi adskillige ændringer vedrørende tungmetaller og pvc.
+Ved at ville være udtømmende løber betænkningen den sikre risiko at være ufuldstændig.
+Det skal ske i samarbejde med moderate elementer i de muslimske samfund.
+For flere af mine kolleger er inkompetence en religiøs synd
+Vi har beskyttet sælerne, og det er godt.
+Det vil give et tiltrængt opsving for den vaklende landbrugsøkonomi.
+De begynder så småt at tro, at de ikke er ønskede.
+De pårørende håber stadig, at deres kære måske stadig er i live.
+Jeg går selv altid ind for nultolerance, hvad angår mærkning.
+Hidtil har det efter vores skøn ikke været nødvendigt.
+Hovedparten består af kulbrinteteknologi.
+Det betyder helt konkret, at indgreb kun er tilladt i tilfælde af groft misbrug.
+Eftersom jeg er i ekstraordinært godt humør, vil jeg rejse et tredje punkt.
+Jeg har ikke givet carte blanche til kernepolitikken.
+Derfor fordømmer vi naturligvis blasfemi.
+Vi går ind for, at vi udfylder dette behov for beskyttelse, dette vakuum.
+De nytilkomne har optaget helt nye eller ledige job.
+Den stakkels kommissær ønskede et slankt program, men er endt op med en tyksak!
+Jeg slår til lyd for en helt anden løsning end kold sanering eller støtte.
+Hans kone og familie har aldrig fået flere oplysninger.
+Dette rammedirektiv er også kronen på værket af nogle kollegers utrættelige flid.
+Dette forslag er helt ude af trit med realiteterne inden for landbruget.
+Er det tilladt at indføre en statslig hashrus?
+Men jeg kan trods alt måske vove et smil.
+Den anden mulighed er at forbedre flymotorernes brændstofeffektivitet.
+Waltari er en finsk forfatter, der har skrevet en fremragende roman om en ægypter.
+Indbyggere kan stadig ikke vende tilbage og sygner hen i flygtningelejre.
+Det er ikke hensigtsmæssigt at fastsætte specifikke begrænsninger for raffinaderibrændstof.
+Shariaen udgør i dens ekstreme form en uovervindelig hindring for en normalisering af relationerne.
+Forarmet uran anvendes stadig på krigsscenen, på land og i by.
+Og vi kan nå stjernerne nu!
+Den skaber identiteter, og bogen skaber identitet.
+Garrigas efterlysning af realistiske budgetter.
+Men vi skal også lade fornuften og visdommen og visionerne herske i denne forbindelse.
+Ærede parlamentsmedlemmer, fru formand, hvordan skal vi bedømme vores femårige indsats?
+Efter notifikationen vil vi selvsagt forsøge at skabe klarhed i sagen i en fart.
+For det andet berøres selve økopointsystemet ikke af kommissionsforslaget.
+Dette kan nødvendiggøre international mægling.
+Hightech skader ikke landdistrikterne.
+På denne måde ville vi hjælpe landmændene med at kunne blive boende i landdistrikterne.
+I mange år har man betragtet deponering som den letteste og billigste løsning.
+Jeg mener ikke, vi kan acceptere, at militæret beholder magten efter kuppet.
+Når beslutningstagende politikere går fra snøvsen, er konsekvenserne uforudsigelige og vidtrækkende.
+Først og fremmest giver de afkald på maksimale udbytter, og vi radrenser vores majs.
+Jeg ville bestemt ikke give dem topkarakter for deres arbejde.
+Og familie betyder ikke at have en vielsesattest.
+Det forbigår fuldstændig problemet med efterladte bilvrag, der skæmmer landskaberne.
+Ganske vist har initiativtagerne skudt lidt over målet.
+Derfor kan vi i og for sig kun have lovord tilovers for denne beretning.
+Målene var at begrænse nitrogenemission, støj og forringelse af trafiksikkerheden.
+Nogle borgere i medlemsstaterne slagter traditionelt grise til jul og får til påske.
+Jasiden og nejsiden skulle have lige store offentlige tilskud.
+Der er tale om lovlige, halvlovlige og ulovlige immigranter.
+Men direktivet er aldrig blevet omsat til national lov.
+Som formand for det udvalg synes jeg, at hendes betænkning er et rosværdigt initiativ.
+Og dog af fortvivlelse kommer fatning, beslutsomhed og håb.
+Efter et par minutter kom stewardessen tilbage.
+Lad os udføre en costbenefitanalyse for alt, vi forordner.
+Jeg håber, at han i aften er lidt medgørlig med hensyn til ændringsforslagene.
+Vi har også en uensartet gennemførelse af de fælles regler i medlemsstaterne.
+Polen sætter sin lid til fælles europæisk politik, hvad angår dette anliggende.
+Vi skal finde balancen mellem at beskytte forbrugeren mod udlåneren og udlåneren mod forbrugeren.
+Det virker som en rød klud på en tyr.
+I energisektoren er de lave gaspriser kun et minde.
+Med den grænse åbnes der for et sjuskeri, en ligegyldighed hos leverandører og producenter.
+Tiden er ikke til defaitistisk tale, men til konstruktive og praktiske svar.
+Denne erfaring bør være den væsentligste præmis bag en helt ny reform af traktatsystemet.
+Jeg synes egentlig, det er ærgerligt, at vi taler så lidt om det nu.
+Tyrkiets kulturelle rødder er mere forskelligartede, end de fleste af os er klar over.
+Den engelske udgave skal betragtes som den originale tekst.
+Jeg var selv fraværende, men det har jeg fået bekræftet.
+Lad os tage et eksempel fra bilsektoren.
+Det andet arbejdsområde, der foreslås i hvidbogen, er rustning af borgerne.
+Det handler også om folkesundhed, tænk blot på aviær influenza.
+De buddistiske munke er intet lille elitært mindretal.
+Systemet indeholder data om savnede personer, stjålne varer og retssager.
+I øjeblikket er det stigende antal ukoordinerede nye kørselsforbud et mareridt for sektoren.
+Vækst ser ud til at være hæmmet af samfundets stigende usikkerhed.
+Men jeg ønskede ikke at lade dette ønske være uudtalt.
+Præferencer alene er ikke nok.
+Hvad er den rigtige anvendelse af ioniserende stråling?
+Det har i tres år været indprentet i vores kollektive hukommelse.
+Medierne, disse ualmindelig pædagogiske redskaber, skal bruges bevidst i denne sammenhæng.
+Trods de høje omkostninger, bør man efter min mening fremme leveringen af lysledernet.
+Derfor er opfindelsen altid noget uhåndgribeligt.
+Jeg er også enig med hensyn til cybertrusler.
+I min gruppe udlægger vi nejet helt anderledes.
+Vi stiller ikke urealistiske krav og søger ikke med vores krav politisk komfortable løsninger.
+Vi ønsker det slovenske formandskab al mulig succes.
+Sæljægerne forsøgte med vold at hindre mig i at se, hvad der foregik.
+Det er min vurdering af gårsdagens begivenheder.
+Ansvaret påhviler nu medlemsstaternes regeringer.
+Arbejdet bestod i sortering af dåser og flasker til genbrug.
+Rådets fælles holdning imødekommer ikke på alle punkter den europæiske fagbevægelses målsætninger.
+Hrusovsky og hans delegation får et behageligt og vellykket ophold.
+Positivt er også forslaget om mere elastiske forudsætninger for at få supplerende støtte.
+Den burmesiske regering gør sit ansvar for at beskytte til en farce.
+Dermed forsvandt tarifaftalerne mellem de forskellige belgiske forsikringsselskaber.
+En sådan form for uanstændigt management er uacceptabel.
+Ellers forsvarer vi altid aggressoren og frikender ham, mens vi prøver at berolige ofret.
+Endnu en gang bliver de generelle europæiske interesser ofre for kapitalismens grådighed.
+Egypten og andre arabiske lande har nu mulighed for at skabe en demokratisk udvikling.
+Dette svarer til at skyde pianisten, hvis man ikke kan lide melodien.
+Først anså vi det slet ikke for muligt.
+Den uformelle plejer eller medlemsstaten bør ikke bære eneansvaret for ydelsen af pleje.
+Men dette kan ikke påbydes.
+Medlemsstaterne må gradvist reducere deres kulstofemissioner.
+Konsensus skal erstattes af konsensus, ikke af påbud.
+Ingen af disse præparater kan siges at fremme miljøet eller sundheden på langt sigt.
+Men så er det godnat for retsstaten!
+Den er også behæftet med temmelig mange fejl.
+For en liter mælk måtte han dengang arbejde ni minutter, i dag kun tre.
+Forskning i multipel sklerose bør også medtages i det syvende rammedirektiv.
+Lyt ikke til de polske politikere.
+Det er det, jeg ville kalde en kartesiansk klarhed.
+De tyer begge til vold, hvilket fastholder håndknuden.
+I dette memorandum of understanding skal de netop nævnte udgangspunkter også fastsættes.
+Her lader man hånt om alt, hvad man kan lade hånt om.
+Hun bor i det område, som min søn repræsenterer i byrådet.
+Jeg har især arbejdet for en forenklet procedure for professionelle brugere af fyrværkeri.
+Og de er blevet pålagt mere end en hætte.
+Det er noget, som vi skal holde et vågent øje med.
+Nu gælder det om at holde dampen oppe.
+Nedslagtningerne har hensat talrige familier i sorg.
+Tja, hvis afholdenhed kan fungere i seksuelle forhold, vil den naturligvis fungere.
+Det er helt sandt, hvad kollegerne har sagt om hudkræft.
+For trekvart år siden var jeg rådgivende ordfører.
+Jeg takker kommissæren for hendes svar, som uden tvivl er velment.
+Jeg vil komme med en spådom.
+Lemlæstede, brændte børn, hele familier var udryddet, en familie mistede fem medlemmer.
+Men selv ikke højere mål for genanvendelse af miljøfarligt emballage er tilstrækkeligt.
+Denne keramikemballage består af ren, brændt lerjord og indeholder derfor ingen skadelige stoffer.
+Hvad angår vraget, er der nogen forvirring.
+Det ville være uheldigt at låse os fast i en forhandlingsposition nu.
+Vi skal dog også være udhvilede, vi skal handle besindigt.
+Han skjuler sig bag, at problemet udelukkende er et spørgsmål om eritreansk lovgivning.
+Det er alfa og omega i denne sag.
+Herved sikres det, at disse medspillere på markedet i fremtiden engageres ved nye udviklinger.
+Det havde været unaturligt.
+Gargani for klarheden og engagementet i hans betænkning.
+Hesten er allerede løbet løbsk.
+Internationalt er der jo i særdeleshed tale om en knivskarp priskonkurrence.
+Det har jeg erfaret på egen krop.
+Gklavakis for hans kommentarer.
+Svær fuel er det farligste produkt.
+Det er rigtigt, at antallet af marsvin er meget lavt.
+Jeg var ikke klar over, at han havde så ærefuld en fortid.
+Staes og andre medlemmer med rette har henvist til.
+I så fald ville vi ikke være mennesker, men guddommelige væsener.
+Det er aldrig godt at unddrage sig regler, man har tilsluttet sig frivilligt.
+Efter min mening er vin et af de mest elegante produkter, landbruget kan fremstille.
+Kvinder er fortsat underkastet diskriminerende love og dybt rodfæstet kulturel ulighed.
+Og alligevel løser det ikke ozonproblemet.
+Jeg kan derfor fuldt og helt gå ind for dette kommissionsforslag om scrapie.
+Halvdelen af de unge tjenestemænd, som rekrutteres fra de nye medlemsstater, er kvinder.
+Der tales i øjeblikket meget om bonuskulturen og aflønning af ledere.
+Det er en luksussituation.
+Den nuværende juridiske ramme er usammenhængende og ufuldstændig.
+Men her og nu må der sikres kaffebønderne en mindsteindtægt.
+Stadigvæk står eller sidder der femårige ved vævestolen, og deres forældre har intet arbejde.
+Wijsenbeek også, formoder jeg.
+Denne ordveksling må høre op.
+Disse vegatabilske produkter spiller i dag en vigtig rolle.
+Disse kys var naturligvis ikke helt uden et vist grundlag.
+For det andet skal vi tilpasse flådekapaciteten til fiskerimulighederne.
+Migrationspolitikken er usund.
+Jeg beklager mig over lydkvaliteten fra forstærkerne.
+Det er nu, vi skal udvise stor agtpågivenhed.
+I stadig højere grad ligner det peruvianske system et militærdiktatur.
+Det ville svare til kætteri.
+Rådet fandt det nødvendigt at introducere yderligere to ændringsforslag.
+Der er ingen, der foreslår, at kobber skal udskiftes i husholdningerne.
+Dette omfatter navnlig fodnoterne til den tekst, der blev vedtaget i dag.
+Det baskiske samfund tager afstand fra organisationens forbrydelser.
+The next item is the vote.
+En sådan situation er både utålelig og ydmygende.
+Heller ikke i denne type spørgsmål kan der ydes nogen form for politisk rabat.
+Vist er korruption en ødelæggende svøbe.
+Jeg noterede mig, at budgetblodet stadig løber i kommissærens årer.
+Ingen skal fare vild i en jungle af uigennemskuelige afgifter og gebyrer.
+Det er vigtigt, at vi får den skruet rigtigt sammen.
+Strafferetten henhører under medlemsstaternes kompetenceområde, og det bør den vedblive med.
+Estlands eksportstruktur beviser, at man imidlertid realiserer denne hightechmerværdi med succes.
+Bibiliotekets betydning for den vestlige civilisation og velfærdsvækst er kolossal.
+Derfor så han ingen mulighed for indrømmelser, så længe våbnene ikke var indleveret.
+Vi lader os ikke styre af fordomme, og tabloidaviserne skal ikke skrive vores manuskript.
+Ifølge dagsordenen afsluttes spørgetiden kl.
+Hvor akavet og ubekvemt demokrati er.
+Analyser og feedback fra medlemsstaterne viser, at retningslinjerne fungerer.
+Dette er et direktiv, der mere specifikt beskæftiger sig med råmaterialer end med tilsætningsstoffer.
+Det nytter ikke, at vi vil gøre lastvognene til en gås, der lægger guldæg.
+Tallene fra gråzonen er nok noget højere.
+For tiden giver svingningerne på råoliemarkedet problemer.
+Det udgør også den ultimative udfordring set ud fra en kommunikationssynsvinkel.
+I rammeafgørelsen er der ikke fastsat en seksuel lavalder.
+Den repræsenterer betydelige fremskridt sammenlignet med status quo.
+Medlemsstaterne kan lette netadgangen for små kraftvarmeenheder og mikrokraftvarmeoperatører.
+Flandern, med det formål at borgernes identitet anerkendes ved disse sportskampe.
+Beherskelse af it kræves nu til dags inden for de fleste professioner.
+Det glæder mig, at den laotiske kongefamilie er til stede her i dag.
+Virksomheder, som tilbyder deres tjenester via access for all , bliver snydt.
+Forarbejdningsstøtten til hør med lange fibre forårsager nu engang større omkostninger.
+Borgerne må ikke blive efterladt ude i den elektroniske motervejs nødspor.
+Den europæiske industri står over for et mægtigt konkurrencemæssigt pres fra udviklingslande.
+Vi er gået fra et substitutionsprincip til et uddelegeringsprincip.
+Newens, fordi de først og fremmest har taget bosættelsespolitikken i denne region op.
+Jeg gætter på, at nogle af vores kolleger vil tale om det her.
+Et meget vigtigt produkt under dette overbegreb er nifursol.
+Liberia har gennemlevet de mest forfærdelige og traumatiske tider.
+De ting, man antyder i dette beslutningsforslag, er meget, meget alvorlige.
+En sådan opførsel gør den sudanesiske regering til medskyldig i disse påståede forbrydelser.
+Denne dekalog fokuserer grundlæggende på tre områder.
+Jeg har endda gjort noget, der måske var juridisk ukorrekt.
+Vi har også bragt et omtåleligt emne på banen.
+Intolerance og ekstremisme skyldes først og fremmest, at historien er blevet glemt.
+Og vi kan snart stå over for en overgang i det besatte, palæstinensiske område.
+I dette tilfælde er der tale om en hekseproces.
+Uighurerne er en moderat sunnitisk minoritet.
+Vi har brug for nye ligaer, vi skal ud af denne snævre nationalstatslige tankegang.
+Derfor skal der slås til lyd for en tosporet politik.
+Kroatien er et ungt demokrati, som stadig lider under krigens følger.
+Der er jo tale om inspektører, der også har deres virke i frøfirmaerrne.
+For øvrigt tales der igen om nettobidragydere, negative og positive saldi, engelske checks osv.
+Nåh nej, det står uafgjort.
+Men det er et langt og sejt træk.
+Asturien er støtteberettiget i henhold til traktaten.
+Det er akkurat nok til to telte og en varmedunk.
+Det er de store ords tid, ord, som er nødvendige.
+Jeg tænker på overvågningen af vores flyrejser, økonomiske affærer og privatliv.
+Jeg tror, at mange her indser, at den type censur ikke er ønskværdig.
+Denne artikel opregner de væsentlige akter, der endnu ikke er ratificeret.
+Nu er det låntagerne, som står tilbage med kursrisikoen.
+I den nuværende situation ville landet ikke engang turde fyre et kanonslag af.
+Vi socialister anråber bønligt om en europæisk pagt for vækst og beskæftigelse.
+Det afhang imidlertid af en udtalelse fra kommissæren i går aftes.
+Af disse grunde lan vi ikke stemme for denne betænkning.
+Entreprenøren har afgivet forskellige erklæringer.
+Det er en konkurrenceforvridning, som vi skal have elimineret.
+Meget ofte bliver de europæiske værdier en hul frase.
+For det tredje er der angivet et for højt kødindhold.
+Vi har gjort dem til kannibaler.
+Princippet om nulvækst på budgettet forekommer både hensigtsmæssigt og klogt.
+Vi er sikre på, at den vil være et frisk pust i istitutionssystemet.
+Tilstandene i landet er kaotiske, og regeringen handler ud fra egne interesser.
+Det andet emne er modregning i eller handel med emissioner.
+Hele lovgivningen bliver desuden omgærdet af hemmelighedskræmmeri.
+Der er ingen lukkede grænser, og vi bliver ikke invaderet af indvandrere!
+Jeg har genlæst denne tale.
+Vores gruppe stillede forslaget om the call back procedure.
+I mit eget land er situationen for asylansøgere for nærværende fuldstændig utålelig.
+Spørgsmålet om biosikkerhed er meget vigtigt, og landbrugerne skal bidrage til at forebygge sygdomme.
+Alle næringsstoffer ville fås ved indtagelsen af den normale kost.
+Hvad i alverden betyder det?
+Det er også, hvad millioner af europæere af tyrkisk herkomst ønsker.
+Men nej, vi vil ikke være dørmåtter!
+Jeg vil gerne fortælle en kort anekdote i denne forbindelse.
+Vigtige er også vores ønologiske traditioner, fru kommissær.
+De gør de grove karikaturer af eurokrater fuldstændig til skamme.
+De medfører oversvømmelser, jordskred, klimaforandringer og ødelæggelse af flor og fauna.
+Jeg er også bekymret over politikken om outsourcing af alle eksterne finansieringsprogrammer.
+Vi må vogte over den proces som høge.
+Bromat findes navnlig i ozonbehandlet vand.
+Så reagerede den kun halvhjertet, vidste ikke, at importvarerne hobede sig op i havnene.
+Jeg tror, at vi er enige om, at de filippinske søfolk også skal løslades.
+Sikken et forbryderisk spild af tapre unge menneskers liv!
+Flertallet af prostituerede lever et usselt liv med risiko for overfald, voldtægt, kønssygdomme osv.
+De vil være parier, forarmede og udstødte.
+Vi udtrykker vores solidaritet med det nepalesiske folk.
+Lad os ikke narre os selv.
+Vi er nødt til at nulstille.
+Reguleringen af lønindekset vil ikke udrydde denne interessekonflikt.
+Årsagerne til flugten kan imidlertid også være etnisk eller religiøs forfølgelse.
+Tegnsprog er ingen krykke, ingen kørestol.
+Passivitet, udsættelse og udmattende konferencer vil kun medføre uoprettelig skade på miljøet.
+Undertrykkelse er i højere grad skyld i dårligt helbred end malaria og trafikulykker tilsammen.
+Dette er en opgave for både paven og patriarken.
+Kriser kan dog blive trappet op til omfattende fjendtligheder.
+Det er ikke noget godt kompromis, det er en vakkelvorn basis.
+I dag er hun fængslet og vi, europaparlamentsmedlemmer, er afmægtige.
+På dette punkt er fiaskoen larmende, må man sige.
+Det er talakrobatik og udgør ingen garanti for borgerne.
+Alt imens ser resten af verden roligt til.
+De koster mindre, er opført som moduler og er derfor lettere at sikkerhedsteste.
+Restkoncentrationer af veterinærlægemidler i animalske levnedsmidler
+Det andet punkt, jeg vil påpege, er orlov.
+Naturligvis må man så også have rigtige parkeringspladser med sanitære faciliteter.
+Vaccination og antibiotika har fået bugt med mange af de livstruende sygdomme i fortiden.
+Det, der tidligere hed direktivet om integreret energiudnyttelse.
+Europa må ikke pantsætte pluraliteten i sine kulturer.
+Det er et hedt emne, der har fremkaldt næsten irrationelle reaktioner.
+Jeg kan ikke alene beslutte, om vi skal frafalde denne anmodning.
+Medicinalindustrien vil aldrig få filantropi som målsætning.
+Marokkos grunde har ikke noget med bevarelse af ressourcerne at gøre.
+Det er absolut forbløffende og bekymrende og en kovending i den britiske regerings politik.
+Det er klart, at vi efterhånden har nået mætningspunktet.
+Det vil borgerne ikke accpetere i længden.
+Hvis vi giver dem kærlighed, bliver tilværelsen her på jorden lidt lysere.
+Det samme gælder for ftalater.
+Ansvarsfordelingen mellem landene for søredningsaktioner skal også afklares.
+Reglerne om bemanding gælder for skibets mandskab som helhed.
+De forskellige holdningsskift hos myndighederne viser klart deres rådvildhed.
+Oppositionen og uafhængige medier undertrykkes, og demokrati er en saga blot.
+Mugabe har ikke gennemført de reformer.
+Ja, vi oplever sågar en renæssance for den såkaldte gamle økonomi.
+Aftalen blev indgået lang tid forinden.
+De bør overvinde deres stædighed og indrømme nederlaget.
+Mange folkevalgte applauderede, da han kritiserede den nuværende politik.
+Det bliver rigtig hyggeligt.
+Brasilien er nu selvforsynende med fødevarer.
+De sætter europæisk vin og vinavlerne uden for markedet.
+Nogle penge skal returneres til medlemsstaterne.
+Forbrugerne, navnlig de yngste forbrugere, skal beskyttes mod skjult reklame.
+Spanske agurker var ikke kontaminerede.
+Fordelen ved snus er, at brugen ikke rammer omgivelserne.
+Man kan sløre mange ting med modernisering.
+For det første tømning af tankene i rum sø.
+Det er ikke kilden til inflation, det er de finansielle aktørers umoralske aktioner derimod.
+Kunne han have haft det i baghovedet, da han forsøgte at mægle mellem handelsblokkene?
+De modtager ingen økonomisk støtte fra regeringen, og kapital til nyinvesteringer rejses på markedet.
+Et bevis herpå er, at de fungerer skidt.
+Vi ved, at den har været omtvistet i årevis.
+Disse informationer kan rekvireres i de rådgivende organers database.
+Kære kolleger, et barn er anderledes vigtigt end euro eller ecu.
+Spørgsmålet om, hvordan de bliver behandlet, har vakt international bekymring.
+Vi må reagere på den økonomiske afmatning.
+Rusland har en magtfuld præsident, der leder en spøgelsesstat.
+Det glæder mig at sige, at disse mål alle er intakte.
+Kun en sejr over erobrerne vil medføre ro og orden.
+Det gør vi med resignation.
+Vi ved f.eks, at de fleste dyreforsøg udføres på dyr af hankøn.
+Dette panel vil snarest påbegynde sit arbejde.
+For det andet kan man hidføre knaphed på det arbejdsvolumen, der står til rådighed.
+Men også her er der et aber dabei, nemlig lovgivningen om punktafgifter.
+Jeg vil fortsat støtte en opfordring til, at vi skal have et stærkt copyrightdirektiv.
+Selvfølgelig er der asymmetrier!
+Deprez, har blot nævnt dette for borgerrettighedernes vedkommende.
+Så længe lønforhandlinger er en sag for mænd, kan løndiskrimineringen ikke fjernes.
+Goebbels også bekendt med.
+En sådan database er det modsatte af hans udmeldinger i begyndelsen af hans embedsperiode.
+Den skal være åben, gennemsigtig og meritbaseret.
+Jeg købte de samme ting i mit eget land tre gange dyrere.
+Retsudvalget tæller jo mange, der arbejder inden for retsvæsenet.
+Der er tale om en harmonisering opefter.
+Jeg tager det til mig, som det ærede medlem sagde om udvælgelsesudvalgets enkønnede karakter.
+Måske er det simultantolkningen, der er årsag til problemet her.
+I mit tidligere indlæg kunne jeg ikke afse tid til dette.
+Europæiske succeser i den globale konkurrence bygger på kyndige og engagerede mennesker.
+Congos myndigheder og hær kan ikke løse områdets problemer alene.
+Sol og vind skal ikke byttes ud med atomkraft.
+Argo kan heller ikke kun være et samarbejde mellem nationale bureaukratier.
+I samme passage findes der også en ræsonnering over, hvordan man bekæmper fattigdom.
+Sådanne beløb kan da også under bestemte betingelser opkræves af medlemsstaterne.
+Det handler ikke om at skabe en masse red tape.
+Den globale opvarmning er for vigtig til, at vi kan nøjes med denne trippen.
+De to lejre består af henholdsvis optimister og pessimister.
+Miljøet er uerstatteligt, og vores skove må ikke blive ved med at forsvinde.
+Den pakistanske regering ved, at det skal gøres.
+Store ord fra sådan nogle krystere!
+Alternativet er kaos og anarki, og det er ikke i nogens interesse.
+Det er de nøgne kendsgerninger.
+De er blevet overtrådt af militæret, men også af guerrillaen.
+Eneforhandleren kan dog sælge til enhver potentiel køber, der besøger hans forretning.
+Det første spørgsmål vedrører den fakultative arealbinding.
+Massedemonstrationer slås ubarmhjertigt ned.
+Dette er det mest vedholdende af årtusindudviklingsmålene.
+Hovedproblemet er eutrofiering, som ordføreren også fint beskrev konsekvenserne af.
+Nabucco kan vise sig at være et godt skridt hen imod energisikkerhed.
+Matsakis i, at blodsudgydelser ikke fører nogen steder hen.
+De frøtyper, der skal certificeres, skal kunne bruges i dyrkningsøjemed.
+Jeg kan acceptere det foreslåede resultat på området securitisation.
+Det kræver de rette geologiske forhold.
+Vi kan således sige, at han skyndte sig at komme før vores parlamentskollegas beslutning.
+Den har især støttet forskning i udarbejdelsen af harmoniserede metoder til at beskrive amfetamin.
+En præsidentagtig guru, der fører sig frem i verden og skaber ballade?
+Screening er afgjort påkrævet, men det er og bliver en sekundær forebyggende foranstaltning.
+Evans, denne rettelse vil blive foretaget.
+Også i weekenderne og på helligdage.
+De takster, som direktivet fastsætter, er dog knap så stor en succes.
+De taiwanske myndigheder har ikke haft adgang til meteorologiske oplysninger om tyfonens styrke.
+Øområderne møder mange vanskeligheder på grund af naturgivne og økonomiske handicap.
+Dette har skrækkelige konsekvenser, fordi der her allerede er etablerede ruter i hele verden.
+I direktivet fastsættes det endvidere i detaljer, hvornår man må sprøjte fra luften.
+I stedet for at føre an udgør vi nu bagtroppen.
+Han sagde, at kineserne skal bygge en stor mur mod separatisme.
+Festligholdelserne har både haft positive og negative følger.
+Vær opmærksom på, at midlerne til kultur hovedsageligt er rettet mod de store bycentre.
+Direktivet er under udfærdigelse, men der anvendes for megen tid til redegørelsesfasen.
+Arbejdstagerne er ikke kun brikker i et spil skak.
+For tiden skjules advarslerne fikst af en smart opstilling eller en farvestrålende pakke.
+Vi kan udbygge kontrollen og verifikationen af de forpligtelser, der er blevet påtaget frivilligt.
+Så hvad det angår, befinder vi os i en særdeles pudsig situation.
+Markedsføring af dichlormethan til erhvervsmæssig brug vil blive underlagt et generelt forbud.
+Men de vil finde sted inden for udemokratiske rammer.
+De foreslår at forvandle stabilitetspagten til en social regressionspagt.
+Det kalder vi samfundsorienteret erhvervsudøvelse som topsport.
+Kort sagt, udviklingen går i retning af en opblødning af de skarpe skel.
+Denne ængstelse skal vi resolut og konsekvent imødegå.
+På længere sigt bør det politiske pres føre til øget politisk frihed og nyvalg.
+Indvandrere bringer anderledes kulturer og skikke, sprog og religioner med til deres værtssamfund.
+Den uberettigede opkrævning af vejafgift er den økonomiske erstatning.
+Derpå blev jeg bedt om at skrive på, hvad jeg havde.
+Husdyrhold spiller en central rolle i den europæiske økonomi.
+Det er en debat for feinschmeckere som os.
+Nu er disse dæk ikke særlig usikre.
+Forbrugere er ikke tossede.
+Lægemiddelindustriens fortjeneste er til gengæld røget i vejret.
+Det truer på ny det højt besungne samhørighedsprincip.
+Hautala hævder, at det er teknisk muligt.
+Korakas, så kan jeg ikke være det mere.
+Vi skal have adgang til skove, enge samt strande ved have og søer.
+Colombia bliver heller ikke nævnt.
+Det er utænkeligt, at det blot på nogen måde ville blive tolereret.
+Argumentet er kolonien af murmeldyr.
+Vi er ikke alle ustuderede røvere eller analfabeter.
+Man kan slet ikke anvende en aritmetisk opdeling a la halvt om halvt.
+Som erhvervsdrivende i en mellemstor virksomhed har jeg adspurgt mange af mine kolleger.
+Det er gyselig bagvaskelse, som har til formål at forvirre og vildlede.
+Swobodas gruppe har hovedansvaret for.
+Endelig understreger vi, at sedlerne skal bringe borgerne tættere på deres valuta.
+Resultatet heraf kan meget vel være meromkostninger og besvær og ikke frihed.
+De var ikke velhavende, men flygtede fra fattigdom.
+Vi taler ikke om fibre, men om andre materialer såsom pels.
+Men selv denne betænkning forfalder af og til at drøfte det grandiose og teoretiske.
+Den menneskeskabte globale opvarmning er en uafprøvet teori baseret på manipulatoriske statistikker.
+Flyoperatørerne skal have korrekte data, så de kan gennemføre de bedste løsninger.
+Lad os endelig også tænke på ofrene, være lydhøre over for ofrene.
+Kommissionens problemer med underbemandingen skal heller ikke betvivles.
+Fru kommissær, der er to spørgsmål, de polske bærfrugtavlere ikke kan forstå.
+Antibiotika må ikke dæmoniseres, men anvendes med forsigtighed hos både mennesker og dyr.
+Jeg er endvidere enig i, at de webbaserede sundhedsressourcer skal fremmes.
+Sigøjnerne er en meget bred, europæisk minoritet.
+Vi skal på dette grundlag i højere grad måle resultater i stedet for input.
+Traktaten om ikkespredning af atomvåben støtter denne nedfrysningsordning for kernevåben.
+Hans mission måtte opgives, da de usbekiske myndigheder nægtede at give ham visum.
+Forhandlingerne skrider planmæssigt frem, og vi overholder tidsplanen til punkt og prikke.
+Vi skal have gode uddannelser og bevidstgørelse for at fjerne vold og stereotyper.
+Hidtil har forskning i stamceller, der stammer voksnes væv givet positive resultater.
+Men dette budskab om håb rummer i sig spiren til det andet fundamentale budskab.
+Hvorom alting er, er stabilitetspagten, navnlig under en lavkonjunktur, en katastrofe.
+Min sidste bemærkning gælder afrustningen.
+Eller er det ikke lukrativt nok?
+Bombardementer, som desværre bifaldes af regeringerne i vores lande.
+Kun den nederlandske minister gik dengang ind for fredning af elefanten.
+Så er der spørgsmålet om kautionsordninger og mange andre.
+Tusindvis af mennesker flytter stadig fra nord til syd.
+Sagen henvises til forvaltningsrådet, som efter en undersøgelse vil svare høfligt på anmodningen.
+Hidtil har der været en tilgang af nationale markeder normalt med offentligt ejede stålvirksomheder.
+Det er faktisk ikke blot sort og rundt, som en lægmand tænker.
+Jobklassificeringssystemerne er fejlbehæftede, hvis de overhovedet findes.
+Af de nordlige totalarealer anvendes under en promille til indvinding af tørv.
+Dette er imidlertid en lappeløsning.
+Vi gør fødevarerne sundere, vi gør kødet, dyreprodukterne, sundere.
+Under alle omstændigheder har det ikke en positiv betydning for jobtallene.
+En enkelt stemme er ikke så stærk som mange stemmer, der synger i kor.
+I stedet er det mennesker, der udsulter andre mennesker.
+En politisk falliterklæring og camouflage!
+Det er en strategi bestående af et hierarki af prioriteter.
+Det er faktisk problemet for de ultrakonservative.
+Man må overvære denne i tavshed og påhøre samtlige indlæg, hvis man ønsker det.
+Arktis er en del af verdensarven og skal også betragtes som sådan.
+Han mener, at finansministre er heksedoktorer, som ofrer job på deres altre.
+Dette er de spændende byfornyelsesinitiativer, som vi bør støtte.
+Universel adgang til højhastighed er i vid udstrækning afhængig af denne fordeling af frekvenser.
+Det ene handler om producentens uindskrænkede ansvar for tilbagetagelse af udrangerede køretøjer.
+Den, der siger r for reformer, må også sige a for afvikling af landbrugsstøtten.
+Jeg var optaget af et interview om denne betænkning, og mit ur gik forkert.
+På dette område ligger der for mig et uvurderligt potentiale.
+Jeg deltog selv i arbejdet med den spanske lovgivning om kameraovervågning af offentlige steder.
+Det er vigtigt at være helt på det rene med hensyn til ugifte partnere.
+Det er for en stor del kopilovgivning og imitationslovgivning.
+Det er rigtigt, at en af mulighederne er at forbyde natflyvninger.
+Chile er et land, hvor man investerer, og landets finansielle reserver øges.
+Øregionerne er økologisk sårbare områder.
+Der er ikke tale om velgørenhed, for velgørenhed er frivillig.
+Virrankoski, som har udført et grundigt stykke arbejde.
+Rissektoren har haft meget vanskelige tider i de seneste år.
+Der er en række tanker og pejlemærker i denne betænkning.
+I andre dele af verden hedder problemet overlevelse.
+Skal vi være et forum, hvor man gør nationale politiske udeståender op?
+Det var en enorm moske, større end denne sal, men ikke så smuk.
+Alt dette forekommer os useriøst!
+Dyrs velfærd er fortsat i for høj grad et konkurrenceforvridningselement mellem medlemsstaterne.
+Samdrægtigheden i det argentinske samfund opbygges gradvis under store vanskeligheder og spændinger.
+Det er i hvert fald mere behagelig læsning, hvad mine områder angår.
+Spørgsmålene om adgangsleverandørers og tjenesteyderes ansvar er subtile.
+Det løfte fik jeg imidlertid i februar af kommissæren også i kulturudvalget.
+Vi har ødslet med ressourcerne i det uendelige.
+Den toldfri import af rødspættefileter skal bringes til ophør.
+Og der er mange lande, hvor man ikke engang har formuleret et lovudkast.
+Efter min mening bør vi gøre dette klart for den yemenitiske regering i dag.
+Men det er den eneste måde, vi kan øve indflydelse på.
+Vi håber, at han får et stilfærdigt otium, men hans direktiv er fuldstændig dødt.
+Bronzesoldaten var blot en undskyldning.
+Additionaliteten af bevillingerne bør fortsat have høj prioritet.
+Vi skal også huske på, at indvandringsstrømme ikke behøver at være fuldstændig uafvendelige.
+Den bedste kur er forebyggelse.
+Apotekere har også behov for pålidelige forsyninger med produkter af høj kvalitet.
+Der er ikke et eneste medlem af min gruppe, der ikke deler denne gru.
+Ambition, ambition, javel, men denne ambition skal være til at få øje på!
+Hvem ejer den symfoni, som vor europahymne stammer fra?
+Kun på denne måde forsvarer man forbrugernes valgfrihed og sikrer også vinproducentens valgfrihed.
+Det skyldes måske til dels, at landbrugspolitikken har ændret sig i løbet af årene.
+Derfor kan disse fradragsretter være fri og udelukkende medlemslandets eget anliggende.
+Vi har brug for en fælles kodning blandt institutionerne, så adgangen til informationerne forenkles.
+Bosnien kan betragtes som værende på randen af den værst tænkelige situation.
+Vi har sandsynligvis brug for passive, men muligvis også aktive sendere til tunge ladninger.
+Det er åbenlyst, at vores skove er mangfoldighedens vugge.
+Store bogkæder overtager ved hjælp af priskrige kontrollen med sektorerne.
+For det andet er der det meget omdiskuterede budget.
+Han skal stadig i retten forsvare sig mod en gammel såkaldt spionagesag.
+Rettigheder uden ansvar svarer i etikkens verden til subprimelån i økonomiens verden.
+Ny økonomisk vækst er bestemt ikke synonym med sløjfning af den europæiske sociale model.
+Så lad os ikke slynge statistik omkring os som fornærmelser ved en fodboldkamp.
+Det kan være, at han ikke har opmålt sin jord korrekt.
+Det tjener intet formål at tale kønt om de handicappedes rettigheder.
+For det andet drejede det sig om at afgrænse mellem infrastruktur og suprastruktur.
+Washingtontopmødet resulterede i et imponerende katalog af prisværdige intentioner.
+Jeg finder dette ubegribeligt, fordi ingen pæn virksomhed behøver at frygte dette direktiv.
+Det andet emne er reduktionen af volatiliteten på fødevaremarkederne, især gennem større lagre.
+Parlamentet sidder for sit vedkommende ikke på tribunen, det er ikke tilskuer.
+Vi kan skimte dem, ikke blot som en vision, men faktisk som en realitet.
+Europa befinder sig ved en korsvej.
+Collins, der foreligger en fejl.
+Vi må bryde ud af den trætte debat om institutioner og forfatninger.
+Jeg vil dog ikke vædde min sidste euro på det.
+Der sker stadigvæk uacceptable ulykker på gårde og i fabrikkerne.
+Eurostat har indgået kontrakter med firmaer, som har fuppet og svindlet.
+Ligesom vi har olielagre, bør vi opbygge gaslagre.
+Den demokratiske debat højnes ikke af at øge antallet af løsgængere.
+Der er absolut ikke plads til cowboys på vejene.
+Vi har her naturligvis at gøre med et typisk tilfælde af mainstream.
+Der er tale om en yderst frimodig ombytning af rollerne.
+Værsgo, men pas på ikke at få det galt i halsen.
+Mingasson og hans medarbejdere for deres meget positive holdning i denne sag.
+Vi har de facto valgt at betragte agenturerne individuelt.
+Popkulturen formidler kulturelle og sociale budskaber.
+Energi er dog en råvare, som skal være underlagt de markedsøkonomiske principper.
+Det skal omdannes til et fissilt materiale ved hjælp af formeringsteknologi.
+Hodie mihi, cras tibi, i dag mig, i morgen dig!
+Jeg er stadig forvirret med hensyn til hakkekødssituationen.
+Efter min mening ville det være farligt at afskaffe disse særregler.
+I mit eget land bliver fluorose et stadig større tandproblem, navnlig hos teenagere.
+Næ, fremskridt og perspektivering har ganske anderledes reduceret betydning.
+Jeg deltog forleden i et seminar om grænseoverskridende kriminalitet.
+Denne situation er nedværdigende og bør stoppes.
+Det er et meget lille land, og de opruster helt ekstremt.
+Meijers fremragende arbejde, hvor vi for øvrigt støtter størstedelen af ændringsforslagene.
+Det skal sikres, at indrejsetilladelser for lærlinge ikke bliver et dække for ulovlig beskæftigelse.
+Nej, de skal skrottes forskriftsmæssigt af dertil godkendte virksomheder på stedet.
+Mugabes misregimente og korruption lammer hele landet.
+Hvorfor er den blevet skåret ned?
+Vi må arbejde på et innovativt aspekt, nemlig fodgængerne i byerne.
+Jeg sov meget dårligt i nat, for jeg havde et rigtigt mareridt.
+Bulkladninger, som kan indeholde gensplejsede organismer, skal mærkes.
+Den nye metodes markedsrettede karakter står også i kontrast til forskrifternes ubøjelighed.
+Det er vigtigt, mener jeg, at sætte fingeren på dette ømme punkt.
+Det, at flyrejser er blevet tilgængelige for alle, har åbnet for hidtil usete migrationsstrømme.
+Som et apropos hertil har der allerede været positive udviklinger inden for klimaændringer.
+Det er i vores interesse, at de brande slukkes så hurtigt som muligt.
+Udskiftning af kanyler fungerer.
+I de tre betænkninger skitseres flere mulige retninger for arbejdet i denne henseende.
+Denne optegnelse skal også regelmæssigt genvurderes og opdateres.
+Der er imidlertid nogle skavanker, som vi henviste til.
+Et fald i midlerne fra samhørighedspolitikken vil blive ved med at smadre vores økonomi.
+Især de unge er meget ilde stedt.
+I går tekstilmarkedet, i dag skomarkedet, hvad bliver det næste?
+Vi skal støtte ham og fortsat gå i brechen for det latinamerikanske folk.
+Så hvor er fødevarerne henne, og hvorfor har vi kun en begrænset forsyning?
+Argumenter baseret på fair konkurrence og miljøbeskyttelse vinder altid gehør hos befolkningen.
+Desuden er der begyndt at fremkomme nye skibsbygningslande på vedensmarkedet.
+Fukushimaulykken har vist os, at visse eksisterende atomkraftværker ikke er sikre.
+Det synes ike helt at være tilfældet for øjeblikket.
+Der skal opstilles passende mål for at sikre passende resultater frem for talmanipulation.
+Hebron er et eklatant eksempel på apartheid.
+Argumentet med, at familien og hjemmets arne er kvindens sande kald, bruges som påskud.
+Kommissionen foreslår nu at åbne markedet for kyllinger, som er desinficeret i en kloropløsning.
+Der er simpelthen ikke troværdigt at sammenligne med bybusser.
+Kommissionen behandler endnu en gang andre folks penge ryggesløst og uansvarligt.
+Lavere rangerende officerer og fascistiske bøllebander støtter denne forfølgelse.
+Endelig mener mange fiskere, at det bringer ulykke at lære at svømme.
+Adam, som har præsteret et usædvanligt godt stykke arbejde, for dette.
+Der bliver ikke nogen amerikansk modaftale på dette punkt.
+Det er naturligvis ikke ensbetydende med, at det pynter på handelsstriden, snarere tværtimod.
+I mellemtiden tikker den globale opvarmning roligt videre.
+I årevis er de blevet grinagtiggjort på grund af mælkesøer og smørbjerge.
+Måske har disse små øer gjort det, fordi de oplever faren meget tættere på.
+Planlægger den moldoviske regering virkelig at åbne ild mod demonstranter i nødsituationer fremover?
+At vi ikke udfaser dem, mener jeg, er uambitiøst, og mener jeg, er trist.
+Det glæder mig, at isolerede, smalsporede og fredede jernbaner vil være undtaget.
+Mange tak, fru kommissær, for at have skabt en quadrilog for os.
+Når man finansierer forebyggelse, begrænser man ligeledes de betydelige udgifter til genrejsning.
+Rehn har forklaret situationen.
+En urentabel produktion bør ikke holdes kunstigt i live i al evighed.
+Mexico er ikke et diktatur, men et demokrati.
+Det er absolut nødvendigt at overføre flyfragttransport over korte distancer til jernbanerne.
+Tak, og det siger jeg uden nogen form for guirlander, hvor relativeringerne gemmer sig.
+Dette er orwellsk newspeak, og det er uacceptabelt.
+Mener man virkelig, at vi er så dumme?
+Selvfølgelig skal dette forbud være veldefineret.
+Tusindvis af nonner og munke forfølges, fængsles og mishandles stadigvæk.
+Han har nu tænkt sig at lede en politisk sprængfarlig regering.
+Hvordan påser vi, at børn har adgang til relevante oplysninger?
+Det er nødvendigt med større støtte til bomuldsavlerne uden yderligere beskæringer af produktionen.
+Mange af brøndene måtte lukkes.
+Derfor duer det ikke med en løsning, der er baseret på eksklusive krav.
+Vi kan således se, at den urbane dimension nu indtager en betydeligt større plads.
+Det guineanske styre er det mest korrupte regime i verden i dag.
+Mine damer og herrer, jeg vil ikke give ordet til alle med blåt kort.
+Ville en tese om større forbrug løse problemerne?
+Mellemamerika er lagt øde, genopbygningen vil vare årtier.
+Ikke desto mindre har jeg lyttet til kolleger, som har fremsat uhørte teorier.
+Vi gennemgår blot forslag i en bleg skygge af et parlament.
+Sprogudbuddet bliver hurtig begrænset, hvis eleven vil fokusere på naturvidenskabelige fag.
+Jeg skal minde om, at en taxavognmand, som kører os hertil, tjener ca.
+Løsningen er ikke rotation, men vægtning.
+De er utilstrækkelige og drukner i de såkaldte nationale interesser.
+For os er det uomgængeligt, at de også er integreret i videreudviklingen af strategier.
+I sidste måned blev kanalen efter retslig ordre fjernet fra æteren.
+Jeg blev specielt rørt ved det digt, det ærede parlamentsmedlem oplæste.
+I dette tilfælde ville virksomhedernes sociale ansvar blive fup, fordi det ikke var ægte.
+Jeg håber, at dette grundlag vil udmunde i en fornuftig og brugbar lovgivning.
+Modermælk er tydeligvis det bedste for nyfødte børn.
+Rom blev som bekendt ikke bygget på en dag.
+Nu booker folk ofte selv rejser via internettet, hvilket giver smuthuller i systemet.
+Klimaet ændrer sig med hedebølger, storme og pludselige oversvømmelser.
+Vi tilskynder til udvikling af økologisk akvakultur.
+Det drejede sig primært om de lande, vi udtalte os om i fjor.
+Det internationale samfund vil ikke længere lade sig narre af denne siksakkurs.
+Fiskeriet skal begrænses, så der sikres en bæredygtig og naturlig fornyelse af laksebestandene.
+Fem års universitetsuddannelse kan ikke pludselig pakkes ind i en treårig bacheloruddannelse.
+De er påfaldende uimødekommende.
+Nisin er et antibiotikum, der måske på længere sigt kan give medicinresistens.
+Derfor foreslår vi, at denne begrænsning til eksotiske dyr eller selskabsdyr udelades.
+Schweiz ved, at lokalkendskab er nøglen til indvandringspolitikken.
+Der er opstillet fem betingelser, de famøse fem kriterier, som ikke kun er referenceværdier.
+Europa skal udelukkende baseres på solidaritet og gavmildhed og ikke på egoisme og smålighed.
+Vi plyndrer alt det, der er, og tager alle rigdommene.
+Det er desværre mit indtryk, at de fleste evalueringer bliver arkiveret lodret.
+En anden opgave kunne være at forsøge at forhindre våbensmugling til den kosovanske befrielseshær.
+Derudover udtrykker industrien bekymring over forbuddet mod pvc, navnlig inden for kabelindustrien.
+Vi er vidne til et hidtil uset voldsniveau med et hårrejsende antal ofre.
+Det er et centralt aspekt for strategiske investorer såsom dem på bilmarkedet.
+Det er interessant for seeren.
+Nogle vil le ad dette, men faren er tættere på, end man tror.
+Den prekære pengesituation truer til dels også accepten af de hidtil yderst populære programmer.
+De skal være sikret uhindret adgang til telekommunikationsmidlerne.
+Enhver skødesløshed fra vores side kan have uigenkaldelige følger.
+Spar os for de politiske montager i medierne, der fandt sted under golfkrigen.
+Honeyballs betænkning er en af disse.
+Et eksempel er forskelsbehandlingen på lønområdet over for kvinder på arbejdsmarkedet.
+De har korrekt anvist den vej, der skal følges i sagen.
+I nord bruger de stadig liraen.
+Den findes i den kristne religion, hinduismen, den jødiske religion og islam.
+Jeg ville bare sige, at jeg er bonde og har interesser på dette område.
+Jeg har øvet mig på det i nogen tid nu.
+Det var bioklimatiske huse.
+Dialogen er ikke en gade med ensrettet færdsel.
+De er lige så slemme i dette tilfælde.
+Samtidig bør denne andel kunne kumuleres over en periode af højst fem år.
+Det er muligvis masochisme.
+Den srilankanske hærs angreb på civilbefolkningen kan endog betegnes som en massakre.
+Fri bevægelighed for læger og gensidig anerkendelse af deres eksamensbeviser
+Denne betænkning kunne have undgået offentlig bevågenhed.
+Vi griber ikke ind, men græder og råber i stedet som gamle kvinder.
+Vi mener, der er brug for en europæisk bompengetjeneste.
+Vi vil fortsat presse de tunesiske myndigheder for hurtigt at ophæve denne blokade.
+Betænkningens udsagn om det gnidningsfri samvirke er simpel juridisk nonsens.
+I de senere år har den europæiske biovidenskab og bioteknologi allerede haft succes.
+De opnåede resultater skal befæstes gennem passende politiske og lovgivningsmæssige initiativer.
+Vi vil ikke have noget med en mindstetjeneste for mindre bemidlede at gøre.
+Jeg har spurgt afdelingerne.
+Tøjfabrikanter og førende globale mærker forudser allerede en stigning i prisen på bomuldsvarer.
+Det er måske et lille stykke afbureaukratisering, som vi altid kræver på forskellige områder.
+Gennemførelsen af disse beslutninger vil kræve benhårdt arbejde.
+Med en chokerende kynisme foreslår ordføreren at liberalisere og deregulere markedet fuldstændigt.
+Siekierski tillykke med en fremragende betænkning.
+Det førte til, at priserne på mejeriprodukter ganske enkelt røg i vejret.
+Sidste år nævnte jeg echinacearoden som eksempel.
+Det vigtigste er, at pengene yngler.
+Frihandel er ikke noget uartigt ord.
+Jeg oplever, at slagterierne ganske enkelt vægrer sig ved at slagte dyr.
+En sådan strategi er ikke længere velegnet.
+Grooming blev nævnt af ordføreren.
+Kommissionen støtter også adskillige bluetongueforskningsprogrammer.
+Også revisionen af lovgivningen om dæks rullemodstand er vigtig.
+Trods utallige svulstige hensigtserklæringer er der endnu ikke sket nogen virkelig ny begyndelse.
+Deres udtalelser var imidlertid som altid meget afmålte, men dybest set meget overdrevne.
+De har givet mange tips om misforhold.
+Nogueira, hvis det skulle være nødvendigt.
+Omsættelsen af det saharanske folks selvbestemmelsesret har for os altid haft førsteprioritet.
+Det er bestemt tilladt at forske i cellelinjer, der allerede er blevet udtaget.
+Medlemsstaterne har gennemført deres egne nationale folketællinger i mange tiår.
+Indien forsvarer sine nationale interesser og oldgamle værdier.
+Formatet kan være dramaserier, konkurrencer, film, nyhedsrapporter, men også debatprogrammer o.l.
+Stamceller fra navlestrengsblod er et eksempel på, hvor der er sket fremskridt.
+Der kan også opstå stor afstand i et årelangt venskab.
+Tajani, mine damer og herrer!
+Hun brugte disse penge til at renovere en ødelagt bygning i byens centrum.
+Jeg kan ikke bare dele penge ud til en hvilken som helst ngo.
+Den økonomiske og finansielle krise medførte også et brat fald i verdenshandelen.
+Man ignorerede forbuddet mod anvendelse af animalsk mel som foder.
+Indtagelse af berigede fødevarer i en varieret diæt kan supplere indtagelsen af næringsstoffer.
+Crowleys spørgsmål, ville det ikke være diskret.
+Det er uimodsigeligt, at dyr udsættes for unødige lidelser.
+For mig som proeuropæer og føderalist er protektionisme antieuropæisk.
+Det bilbaserede samfund, som vi kender i dag, har således fået en betinget dom.
+Jeg tror faktisk, at kernen lå i første del af mit svar.
+Jeg vil dog ikke skjule, at vi ikke overlykkelige, når det gælder cabotageordningen.
+Vi ønsker at sikre bæredygtig udvikling, ikke ubæredygtig fattigdom.
+Samtidig dør dusinvis af millioner mennesker uden at kunne få behandling.
+Sexmisbrugere skal nægtes mulighed for at udøve erhverv, som indebærer kontakt med børn.
+Parlamentet har altid krævet, at babymad skal være uden pesticider.
+Allahs parti nævnes simpelthen ikke!
+Disse skyer vil overskygge vores økonomiske landskab i de kommende år.
+Winkler i denne forbindelse.
+Jeg er selv blevet stukket af potentielt inficerede nåle og instrumenter.
+Der skal drages omsorg for, at de kan identificere sig med deres eget sprog.
+Der er derfor intet at bekymre sig om, kære frue.
+Har den britiske regering søgt om finansiering til hjælp til revaluering af pundet?
+Det sker også i andre områder, som ikke befinder sig midt i urskoven.
+Det drejer sig om ting, som ligger mellem ørerne.
+Afsmeltningen af polarisen skaber nye muligheder for nye skibsruter og udnyttelse af naturressourcer.
+Debatten om faste bogpriser trækker i langdrag.
+Makedoniens stabilitet hænger stærkt sammen med udviklingerne i nabolandene.
+For det fjerde er en ny bilteknologi kun mulig med lave svovlindhold.
+Muligheden for at etablere en togkorridor er også blevet fremlagt.
+Politik uden finansielle ressourcer er kun tom gestikuleren.
+Forureningen med fint stof og ammoniak er meget hårdnakket.
+Dermed undgår vi, at dæklagre skal destrueres, hvilket ville skade miljøet yderligere.
+Situationen er helt kafkask.
+Myanmar fjerner sig fra demokratiske værdier med alarmerende hast.
+Kun en ambitiøs og fælles fremgangsmåde kan bevare den europæiske kulturs særkende.
+Doceren og lappeløsninger uden en egentlig undersøgelse nytter ikke noget.
+Bygningers energimæssige ydeevne
+Konsekvensen heraf ville blive en yderligt dalende valgdeltagelse.
+Princippet med dobbelt flertal er ikke et sagnvæsen.
+Når der tales om tyrekampe, tænkes der naturligvis på tyrefægtninger.
+Falconer, den er ført til protokols.
+Sexindustrien udnytter internettet og den seksuelle vold, som mange kvinder og børn udsættes for.
+Jakartas modforanstaltninger, især militære, har hidtil haft den modsatte virkning.
+Det er upraktisk, bureaukratisk og unødvendigt for at beskytte miljøet og sundheden.
+Af politiske årsager bør vi ikke støtte denne dosis.
+Derfor er det så tragisk at se landet styre lukt imod afgrunden.
+Linkohr så rigtigt har udtrykt det, er heller ikke blevet udviklet.
+Prisen på slagtesvin følger den sæsonmæssige nedadgående tendens.
+Bankerne er blevet rekapitaliseret, og den finansielle stabilitet er blevet prioriteret.
+Forhåbentlig kan vi få en god nats søvn i den nærmeste fremtid.
+Hvis det var så enkelt at lave politisk kirurgi, ville vi gøre hurtigere fremskridt.
+De begynder at hælde barnet ud med badevandet.
+Mit spørgsmål vedrører de europæiske sikhers rettigheder.
+Flag og hymner er for nationer, ikke for økonomiske sammenslutninger for samarbejde mellem stater.
+Landbrugerne, som i forvejen er ved at bukke under for det aktuelle bureaukrati.
+Jeg mener også, at uorganiske stoffer skal håndteres anderledes end organiske kemikalier.
+Ifølge de seneste informationer har han fået kraniebrud og lidt et stort blodtab.
+Og forklaringen, måske den eneste, er den messiaslære, der er bag alt dette.
+De har da vist brug for et par tilsætningsstoffer for at køle lidt ned.
+Jeg gad vide, om det er til stede under forhandlingen i aften.
+Denne ubalance giver unægtelig også stof til eftertanke.
+Køer, får og grise er mere end bare produktionsenheder.
+Så et andet punkt, nemlig kadmium.
+Lighed defineres på forskellig vis alt efter, hvilke briller man kigger igennem.
+Det er ikke nødvendigvis protektionisme, men ind imellem er de kun en hårsbredde derfra.
+Skifer er ikke kun sort, skifer er hvidt og sølv og grå.
+Hvad skal vi gøre for at komme igennem med vajende faner?
+Horrible hændelser af denne slags kan ikke tolereres.
+Så stiger nervøsiteten og væddemålene om, hvem der først når målstregen.
+Revanchisme og rethaveri er kontraproduktive nu.
+Det er en eufemismernes traktat.
+Beazleys spørgsmål, som var meget specifikt.
+Aftenens forhandling udviklede sig desværre til en maratonforhandling.
+Klausulen indeholder forslag til yderligere foranstaltninger.
+Er den datobaserede eksportordning tilfredsstillende, hvad angår kødets og kødprodukternes sikkerhed?
+Det er svært at garantere en sikker og risikofri håndtering af madaffaldet.
+I bedste fald har de en fod på speederen og en på bremsen.
+Paradoksalt nok kan man sige, at des flere klager, jo bedre.
+Kommissionens forslag er noget af et tilbageskridt fra sidste års reformer, undtagen for humle.
+Et sådant bondefangeri bør ikke gå upåtalt hen.
+Ubøjelighed er det eneste sprog, disse mullaher forstår.
+De rapporterede, at folks lemmer lignede knækkede kosteskafter.
+Det er kæmpe luns af skattegrundlaget.
+I den aktuelle vanskelige og udfordrende økonomiske situation kan vi ikke tillade sådanne hæmsko.
+Arbejdet blev også rost flere gange.
+Små og svage partier, der udelukkende sværgede troskab mod deres ledere, blev skånselsløst udrenset.
+Jeg lever i en jægerfamilie tæt på den hollandske grænse.
+Srebrenica er et symbol på etnisk udrensning.
+Når fattigdom bliver til dyb armod, bliver det en trussel imod freden.
+Men det er kun toppen af det isbjerg, som må blotlægges.
+Fra at landet havde en kvindelig premierminister, går premierministerens hustru i dag med tørklæde.
+Kyoto har givet os en platfom.
+Man mister penge ved at privatisere golden share.
+Hvem har nogensinde hørt om, at enmotores fly er mere sikre end tomotores fly?
+Parlamentet træffer imidlertid beslutning herom, og den beslutning vil jeg bøje mig for.
+Den ydede bistands kvalitet og effektivitet er mindst lige så vigtig som dens kvantitet.
+Nu er vi alle dækket med ar og overdynget af dekorationer.
+Transportens forurening af miljøet er uomstridt.
+Vi skal bevare disciplinen, og det skal ske på bagrund af de samme prioriteter.
+De forsøger også at opildne forbrugerne til at tage del i deres kampagne.
+Putin er ikke en lydefri demokrat.
+Det er berettiget, for fedtholdige kroketter bliver ikke sunde ved at tilsætte nogle vitaminer.
+Fatuzzo, der repræsenterer pensionisterne, er overordentligt tilfreds.
+Der er tilfælde, hvor den ene forælder stjæler barnet fra den anden.
+Mener udvalget ikke, at disse krav ofte er kamuflage for den rene skinbarlige protektionisme?
+Det næste forhold vedrører anvendelse af lysdiodebaseret belysning, der er energibesparende og varig.
+Moderen løj, og det fædrene ophav var også en løgn.
+Der hersker verden over en ruinerende konkurrence inden for fødevaresektoren.
+Diskrimineringen og undertvingelse af kvinder har rod i selve islams hellige tekster.
+Den fælles fiskeripolitik bør ikke mere fungere som et lindringsmiddel eller middel til dødshjælp.
+Og den kan ikke iværksættes, sålænge medlemsstaterne ikke ratificerer dem.
+Frygten for en lavine af billig arbejdskraft har vist sig at være ubegrundet.
+Jeg vil også gerne fremhæve et andet aspekt, hvor vi ofte trækker en nitte.
+Det åbnede sluserne, og intimidation har vundet troværdighed.
+Dette har resulteret i prissvingninger og store økonomiske tab for bønderne.
+Liikanen, så vi bliver konkurrencedygtige og kan tage denne globale udfordring op.
+Da der kom flere radarer på de franske veje, faldt antallet af dødsofre straks.
+Et stort antal mennesker lider af astma og andre lidelser.
+Jeg tror, vi bliver nødt til at mase på.
+Flere andre ting er iøjnefaldende.
+Det drejer sig om æg, skaldyr, bløddyr, fisk, nødder eller andre ting.
+Den foreliggende udgave af pakken skal derfor ombearbejdes væsentligt.
+Papuas ledere og befolkning ser det anderledes.
+En vis tolerance og en vis sløvhed havde grebet politikere og myndigheder.
+Dette forslag er for mig et udtryk for de eurofiles umættelige fanatisme.
+Den udskydelse, man har foretaget, er ikke retmæssig.
+Men også bestanden af sild og brisling er fortsat i en udmærket forfatning.
+Vi ser disse personligheder foran os og midt iblandt os her i dag.
+Jeg synes, at vi skal hæfte os ved de fremskridt, der er sket.
+I morgen skal du stå din første prøve.
+Forsikringer om, at det altsammen ikke er noget problem, klinger mere og mere hult.
+Sars er desværre kommet for at blive.
+For andre, til gengæld, er det en farce af næsten surrealistiske dimensioner.
+Disse opskrifter har været en total fiasko.
+Livtaget med den er først og fremmest en opgave for de arabiske samfund selv.
+Beskeden eksporthandel bygger på salg af landbrugsprodukter til nærområderne.
+I øjeblikket kan jeg stadig drikke vandet fra søen ved mit sommerhus.
+Der er busser, som er til at komme ind i.
+Derved frigives der metan fra tundraen, og det kan også blive frigivet fra havbunden.
+Jeg mener ikke, at det er konstruktivt at fastsætte en deadline på dette tidspunkt.
+Egypten er et stort og vigtigt land med en rig historie.
+Endvidere er der den nærmende indføring af euroen og informationssamfundets oprykning.
+Oplysningen må imidlertid ikke være begrænset til plakatkampagner eller ministres besøg på skoler.
+Nu bliver den dem tildelt uden affyring af et eneste skud.
+Vi er kommet videre, så vi er nødt til at sætte det i datid.
+Det er hævet over enhver tvivl, at denne geschæft er svær.
+Det drejer sig altså om en tiendedel af budgettet.
+Måske skulle det være en turbodieselmotor.
+Botswana er et eksempel på dette.
+Jeg tror, at denne kvalitetsgraduering opad ville være meget vigtig for forbrugerne og borgerne.
+Vi må derfor tage pulsen på ligestillingspolitikken, måle og veje den.
+Jeg håber, at budgetmyndigheden vil være mere behjælpelig og øge tildelingen.
+Denne metode ville være meget mere enkel og givtig.
+Qimonda er ikke blot en hvilken som helst virksomhed!
+Konflikten har ulmet i årevis.
+Er foranstaltningerne for gennemførelse af sviende sanktioner nu på plads?
+Men forbrugernes begejstring for grønne varer mangler stadig at blive matchet af industrien.
+Desuden er fiskeriet meget vigtigt for de tyndtbefolkede kystområder.
+Det er nødvendigt at tage situationen på medlemsstaternes gasmarkeder i betragtning.
+Vi bør se kritisk på den sydkoreanske domstols beslutning.
+Desertecprojektet er særlig betydningsfuldt, fordi det peger mod fremtiden.
+Sikke noget vrøvl, fuldkommen og ren og skær vrøvl!
+Situationen er jo en smule bizar, hvis jeg må udtrykke det sådan.
+For det tredje er tiden ved at rinde ud.
+Fåresektoren har alt for længe stået dårligt.
+Dette er en permanent ulempe for øerne, som går ud over mange områder.
+Men jeg vil gerne rejse et par spørgsmål om boardingafvisning.
+Jeg kommer ikke med en udtalelse vedrørende nulkvoter eller lignende.
+Jeg forkaster den krig og den heraf følgende todeling mellem sejrherrerne og de besejrede.
+Næsten alle chefredaktører blev fyret samtidig.
+Pyongyang søgte længe at benægte denne frygtelige virkelighed.
+Hvilken begrundelse er der for denne ågeragtige stigning?
+Katiforis ganske rigtigt understregede.
+Jeg kunne næsten røre ved smerten, virkelig føle denne kvindes smerte.
+Jordskælvet og tsunamien har skabt utænkelige ødelæggelser.
+Det skyldes dets amfibiske væsen.
+Det har ikke skortet på tomme trusler og sabelraslen.
+Der er behov for farbare veje, som giver adgang til skole og arbejdspladser.
+På den måde jager vi togpassagererne over i flyene, når det gælder mellemlange afstande.
+Vi ønsker med andre ord at skabe et egentligt marked for clearing og afvikling.
+Der er i forbindelse med udvidelsen allerede sagt meget om tidsplaner, datoer og årstal.
+Den pågældende rapport er i det store og hele deskriptiv.
+Det drejer sig ikke om at kickstarte den økonomiske vækst i den sædvanlige retning.
+Shakespeare, men det tykkes mig, at betænkningen bedyrer for meget.
+Chip er farlige, når børn putter dem i munden.
+Antallet af ulykker til havs er uacceptabelt højt.
+Vi bifalder den robuste måde, hvorpå han har forsvaret balancen i dette direktiv.
+Den etiopiske lærerforening chikaneres og forfølges til stadighed.
+Overalt forværres denne vold af opkomsten af ekstremistiske bevægelser.
+Salim for en uges tid siden, da han var på gennemrejse.
+Med klimaændringerne og klodens opvarmning ser fremtiden ikke lysere ud.
+Hver part har spillet sine trumfer.
+Nulemissionsmålet kan ikke være et mål.
+Aftalen viste sig blot at være en lap papir.
+Vi er kommet ind i en ny politisk epoke.
+De fælles strategier bygges op, larvefødderne findes frem og sættes på.
+Overtræthed, nervesammenbrud, hjerteanfald og selvmord er ikke noget opdigtet, men realiteten.
+Hvis hendes kat drikker øl, er det nok det, der gør den syg.
+Dernæst viser den økonomiske situation en række lyspunkter.
+Hvem tog civile gidsler for at forhandle med den lokale guvernør?
+Det var floskler fra den socialistiske mølkiste, som overhovedet ikke bringer os videre.
+Eller tag den såkaldte hørsag.
+Nu er vi gudskelov kommet videre.
+Virkeligheden må vige for det liberale dogme, når kapitalens globalisering står på dagsordenen.
+I dag vil mange huske stunder i hendes livlige og altid stimulerende selskab.
+Denne liste har også vidtrækkende bivirkninger.
+Landmændene har brug for såsæd.
+Dette har ligeledes en stor betydning for virksomhedernes genplacering.
+De nuværende bestemmelser om fjernsyn bør fortsat være i kraft vedrørende lineære tjenester.
+Men den foreløbige version af denne beskæftigelsespagt er ærligt talt noget tam.
+Vi er nødt til at satse på træholdig snarere end flydende biobrændstof til transport.
+Indien vil femdoble sin bioteknologisektor i de næste fem år.
+Så ville de seneste ugers opstandelse virkelig kun have været spil for galleriet.
+På den anden side minder det os livagtigt om valg i totalitære stater.
+Ulæseligheden af vores lovtekster er desværre ikke kun de europæiske institutioners problem.
+Jamen, det er i stykker, og det skal repareres.
+Tyrkiet respekterer heller ikke de værdier, som vi anser for umistelige.
+Dræber jeg da ikke allerede?
+Fremover vil der kun være ideologiske skænderier om ufleksible tekster.
+Ligeledes ønsker jeg, at det spanske formandskab får succes og handler med stor kløgt.
+Topmødet er et tidspunkt for nogle drøje sandheder.
+Forbud mod kørsel i weekenden og kødannelser generer vejtransporten.
+Guillotinen eller den elektriske stol er symboler på den moderne tidsalder.
+Vi skal vedtage denne beslutning, som rummer tre noble forhåbninger.
+Det kan ikke gøres ad hoc.
+Efter evne skal denne støtte give den algeriske pressefriheds vågeblus den uundværlige ilt.
+Tsatsos, med den betænkning, de har præsenteret i dag.
+Bekymringerne for ulandene er hul.
+Jeg nævner kun stikordet prydplanter.
+Naturligvis kan vi kun fordømme disse voldshandlinger og dette hærværk.
+Barmhjertighed, når det gælder modtagelse af flygtninge, som er fordrevet fra deres hjemlande.
+Derfor er vores vurdering kritisk, og derfor mener vi, at resultaterne har være magre.
+Santers forslag og den underliggende rationale bag hele forslaget.
+Men for at kunne gøre det skal det korresponderende udvalg rådføre sig tidligere.
+Der er langt fra sko og støvler til mobiltelefoner.
+Det ser ud til, at søkortene er forsvundet.
+For det andet koster madlavning penge.
+Spiritus som whisky bliver destilleret ved lav alkoholprocent og får smagen fra råstofferne.
+Hvor en enkelt sovepille er udmærket, kan mange sovepiller være dødsensfarligt.
+Også bygherren og underentreprenørerne har deres egne tvister.
+De blev hurtigt og resolut frosset ud.
+Jeg mener, at verden ikke skal producere mere aluminium og stål, end man behøver.
+Min far døde sidste år, men hans visdom er næsten profetisk.
+Fru formand, kære kolleger, jeg vil tale rent ud af posen.
+Landarbejderne på de hvides farme må ofte leve under uacceptable sociale forhold.
+Et bestrålet æble kan se frisk ud, men i virkeligheden være en gammel sag.
+Det tilfældige ved undfangelsen er den største oprindelige beskyttelse af den menneskelige frihed.
+Hvad med æg, ost, grøntsager eller frugt?
+Krisen ramte først de europæiske banker i slutningen af juli og starten af august.
+Klimakrisen, fødevarekrisen og den sociale krise kan stadig mærkes med usvækket styrke.
+Det tilbydes generøst og uden beregning, utvungent og uden betingelser.
+Måske viser sådan en reportage, at det er nødvendigt med nogle vedtægter.
+Det, vi diskuterer her, er ikke uvæsentligt.
+Dvs., at de forskellige retsmyndigheder virkelig begynder at arbejde sammen i et tillidsforhold.
+Personer, som døde ensomme og overladt til sig selv.
+Nu er der ikke tid til mere fjumren og forsinkelse.
+De samme piktogrammer anvendes til at vise de samme oplysninger.
+Bogbrændinger hører til dagens orden.
+Jeg synes ærlig talt, at den indflydelsesrige avis er lunefuld.
+Ved at forbedre tilgængeligheden for døve styrker vi demokratiet.
+Vi har haft en budgetprocedure, som hidtil er forløbet bemærkelsesværdigt glat.
+Baglandet, de mennesker, som sejler, spørger, hvornår vi gør noget konkret.
+Vi må også erkende, at denne betænkning kun er en brik i et puslespil.
+Endelig har jeg også selv modtaget spam.
+I forbindelse med samme operation blev alfonserne anholdt.
+Det første er medlemsstaternes forpligtelse til at udforme nødplaner til brug i foderstofkriser.
+Der er ikke religionsfrihed, der er ikke laicisme efter fransk forbillede.
+Bontempis betænkning om korruption.
+Jeg synes, at det så afgjort er rationelt og bestemt ædelt.
+Udpiningen af fiskebestandene er et miljøproblem, men også et socialt problem.
+Rulletobaks bufferfunktion er afgørende for at undgå en stigning i smugling på europæisk territorium.
+Der er for det første et enormt behov for omskoling af en hel faggruppe.
+Hun må føle det, som om hun netop har modtaget en buket blomster.
+Man kan ikke bede et skelet om at spænde livremmen ind.
+Hovedparten af handelen udgøres imidlertid af pattedyr, som i reglen vejer over et kilo.
+Jeg tænker med glæde tilbage på den vedholdenhed, hun lagde for dagen under trilogerne.
+Det gik lige så godt, så hvorfor spolere det?
+Toulouse har brug for finansiel og logistisk bistand.
+Den aktuelle modus vivendi er efter alt at dømme ikke tilfredsstillende.
+Kalandia, som ligger midt i det palæstinensiske område, er netop blevet omdannet til grænseterminal.
+Der kan man se, hvilket niveau vi er sunket ned på.
+Ved reorganisationer bestemmer aktionærer og chefer, og arbejde er den sidste post.
+Shippingindustrien er den første til at erkende dette.
+Jeg vil understrege, at det er den engelske udgave, der er den autentiske tekst.
+Ganske vist står det tilstræbte mål i spagat, som derfor skal kunnes.
+Skal lærere eller læger tage stoffer, der virker opkvikkende?
+De er nødt til at vide, hvordan man forkuller træ, inden det brændes.
+Bilfabrikkerne er rigeligt bevis på, at princippet om kooperativt ejerskab brydes.
+Det er desværre ikke et nyt råb.
+Konkurrencepolitik og lige muligheder skal være adækvate.
+Det kommer vi til at gå noget i clinch med i den kommende tid.
+Jeg håber, det er et hypotetisk spørgsmål.
+Ja, interessen for de tre kaukasiske lande er stor.
+Episoderne i forbindelse med betænkningen var alt andet end flatterende.
+Jeg er bestemt ikke klar til at sige adieu.
+Samtidig tager dokumentet ikke tilstrækkelig højde for andre beplantningsmuligheder.
+Vi må sørge for, at de bliver mætte.
+Parlamentet har stået i spidsen på dette område mere end en gang.
+Så det er et hegelsk problem.
+Afstemningsanlægget fungerede desværre ikke på daværende tidspunkt.
+Vi har en kolossal overforsyning på vores marked for ufaglært arbejdskraft.
+Der er forsat problemer med at finansiere fælles projekter virkelig ukompliceret.
+Alzheimers sygdom er ansvarlig for over halvdelen af tilfældene.
+De er ikke omkostningssparende, og de er uøkonomiske med hensyn til personaleressourcer.
+Man må ikke pukke på gamle rettigheder.
+Vi er ikke regeringskonferencens hofpoeter.
+Ingen af disse tal giver anledning til jubel.
+Den nyomvendtes nidkærhed, uden tvivl.
+Det er også meget vigtigt at bevare sammenhængen mellem anprisninger og ernæringsprofiler.
+Vi skal ikke først reagere, når man når en grænseværdi eller en sumgrænse.
+Jeg er dog ikke enig i udeladelsen af solmoduler fra direktivet.
+Fru kommissær, det drejer sig om en ubåd.
+Buzek og alle mine andre kolleger.
+Der er også indledt et intensivt penduldiplomati.
+Menneskenes huse er sammen med deres hukommelse eroderet.
+Den omhandler obligatorisk registrering af alle ombordværende på passagerfærger.
+Forslaget gælder kun de tre første år for nyetablerede små og mellemstore virksomheder.
+Skyhøje priser og kompenserende lønstigninger er velstandens værste fjender.
+Der er desværre en makaber grund til det.
+Ligesom der findes inflatorisk stabilitet, kan der også findes deflatorisk stabilitet.
+Afslutningsvis vil jeg sige, at vi ikke må spille politisk hasard med passagerernes sikkerhed.
+Den skal forbyde uredelige forretningsmetoder.
+Denne gamle lærdom er stadig gyldig.
+Jeg vil gerne takke ordføreren og fremhæve hendes fortrinlige timing.
+Vi skal ikke slynge hinanden alskens ubehageligheder i ansigtet.
+De skal stadig bære den middelalderlige burkha.
+Det er ikke en rar følelse.
+Taler vi om en toårig tidsramme eller en treårig?
+Det bekræftes nu også af forskellige vallonske politikere og fremtrædende økonomer.
+Europa som vejviser er ikke nok til at overbevise resten af verden.
+Fedme betyder for store fedtdepoter i kroppen.
+Det er ikke godt nok, at vi vrider vores hænder og siger undskyld.
+Juntaen har ganske rigtigt annonceret nyvalg.
+Folk på stedet ved, hvor skoen trykker, og hvordan den kan tilpasses.
+Jeg vil dog erklære, at jeg er imod støtten til selve olivenoliedyrkningen.
+Afghanistans kvinder er blevet frarøvet deres stemme.
+Men mange bække små gør en stor å.
+Med hensyn til kvoter har vi sagt, at der bør indføres lovkrav.
+Det betyder ikke så meget, hvilket emne amatøren behandler med sine ideologiske skyklapper på.
+Vi må naturligvis lære heraf, men vi bør ikke lade os kyse.
+Derfor går vi i princippet ind for en afgift på flybrændstof.
+Et parlament, der går industriens ærinde, vil hurtigt tabe troværdighed og miste borgernes tillid.
+Og alt dette har vi under vores fødder.
+Det vil være en vanære, der vil vare i flere årtier, hvis det vedtages.
+Udviklingspolitik er ikke kun uselviskhed, det er interessepolitik.
+Enhver delforanstaltning vil skabe utilfredshed og uretfærdighed.
+Derfor har jeg stillet et lille ændringsforslag til stk.
+Det er derfor helt afgørende med et internationalt samarbejde for at kontrollere infektionssygdomme.
+Samtidig går der en kokainsmuglerrute gennem landet.
+Der findes ikke noget undskyldning for denne obskøne praksis.
+De er gået bankerot på grund af deres egne stupide ledere og politikere.
+Vi er i dag i færd med at finde massegrave og identificere ligrester.
+Jeg vil endnu en gang takke fr.
+Jeg glæder mig især over, at betænkningen i mange tilfælde irettesætter den irske regering.
+Jeg så gerne, at bestemmelserne går let henover operationelle risici.
+Men det vigtige er, at kimen findes, at muligheden eksisterer.
+Hele familier ofres på asfaltens alter.
+Men dette må ikke udelukkende blive en angelsaksisk affære.
+Store og små bør i denne forbindelse være i samme båd.
+Her er jeg ved et ømt punkt.
+Der er mange årsager, først og fremmest den bitre nød, manglende oplysning og grunduddannelse.
+Det håber vi at kunne råde bod på med denne betænkning.
+Barcelonaprocessen bør tilføres en frisk drivkraft for at opnå optimal virkning.
+Det gælder ligeledes inert affald.
+Der er behov for handling, ikke for papir og poesi.
+Vi må ikke producere tomme hylstre, det opdager vores borgere jo for øvrigt alligevel.
+Dette formandskab udspiller sig nemlig på baggrund af en omfattende bevægelse, som er tosidet.
+Der er ligeledes blevet vedføjet en særlig protokol herom til traktaten.
+Derfor er et up to date legitimationsbevis en ubetinget nødvendighed, både visuelt og teknologisk.
+Denne subjektivitet relativerer denne rets prætention om at være universel.
+Omtrent en tredjedel blev afvist.
+Hidtil har vi kun hørt bag kulisserne, at man konstant diskuterer den øvre grænse.
+Og virus og bakterier i minimale doser bliver til vaccine.
+Udviklingen af stærkt integrerede spintroniske anordninger er et eksempel herpå.
+Vi har den hjælpeløshed og håbløshed, som vi måske var fælles om.
+Vi mener, det er vigtigt, at kvinder ikke udsættes for vold eller sexhandel.
+Her ødes der mange penge bort, som ikke bliver investeret bæredygtigt.
+Jeg synes, at den santerske rådgivningsgruppe om etik virker lidt dubiøs.
+Jernbaneselskaberne skal også være på dupperne, så de kan konkurrere med lastvognene.
+Den hidtidige lønpolitik har nemlig også forvredet branchen.
+Kraften fra de faldende ståldragere og murbrokker knuste sæderne nedenunder.
+Grænseoverskridende bankgebyrer var astronomisk høje.
+Det er ikke noget, jeg finder på, speakeren erklærede dette uden de mindste skrupler.
+Den, som følger krigens vej, er villig, og den, som ikke gør, er uvillig.
+Gud velsigne vores fælles indsats.
+Jeg er beæret over, at jeg har haft mulighed for at drøfte disse spørgsmål.
+Der sad de fast og kunne ikke komme fri.
+Men denne tænkepause må ikke blive til en mexicansk siesta, kære kolleger.
+Det medfører stor utryghed hos dem, der skal udføre arbejdet.
+I samme forordning begrænses de typer druer, der skal angives på etiketten, til tre.
+I denne forbindelse er der også bud efter offentligheden.
+Kommissionen sponsorerede en analyse af kulturøkonomien, og vigtige oplysninger er kommet frem.
+Det er en altomfattende bestemmelse, som forværrer den humanitære krise.
+De kan måske bruges til at yde kompensation for løntabet.
+Det er som et juletræ, hvor vi har hængt vores ønskeliste over dyre smykker.
+Der er ikke nogen kunstige grænser i luften, og aeromekanikkens love gælder alle vegne.
+Det kan man ikke engang bygge en faldefærdig rønne med.
+Det er imidlertid uvist, om kontrollen overalt er optimal.
+Flyrejser er ikke det samme som busrejser.
+Det er kapitalisme, dit fjols!
+Det er da næppe passende at udvælge blot et fåtal lande.
+Det ville nemlig være fuldstændig forkert og overordentlig uklogt.
+Darfur har været et åbent sår alt for længe.
+Vi må ikke sende irakere tilbage til den sikre pine og undertrykkelse.
+Storøjet tun og gulfinnet tun er truede arter, som indgår i fangsterne.
+Programmet skal i sin nuværende form finjusteres på en række områder.
+Det er på det nærmeste kommunismens sidste bastion i verden.
+Citrusfrugter, frugt og grønsager
+Begrebet bæredygtighed behøver ikke hele tiden at blive opfundet på ny.
+De stimulerer, informerer om og henleder et bredt publikums opmærksomhed på teater.
+En anden gang kunne vi måske lade stemningen ebbe ud, inden vi genoptager afstemningen.
+Denne mødedag er viet til menneskerettigheder, og sådan har vi også villet det.
+Fayot, der vil oplyse os i forbindelse med dette vanskelige emne.
+Det afgørende er, at denne mur er en anneksion.
+Napolitanos betænkning og forslag.
+Misbrugen af internettet påkaldte sig ligeledes manges vrede.
+Til det formål er årsrapporten med den højtstående repræsentants udtalelser et godt skridt fremad.
+Vi har det mest solvente indre marked i verden.
+Europa er karakteriseret ved stor territorial mangfoldighed og polycentrisk udvikling.
+Jeg ønsker ikke, at denne uhyggelige og korrupte institution får mere kontrol.
+Vi kan ikke lade økonomisk fremgang være et figenblad for reformfjendtlige regeringer.
+Der er snesevis af rørledinger, der krydser vores have uden nogen problemer.
+Der er både positive og negative sider ved methan.
+I det store hele har kun få lande tyet til handelsprotektionisme.
+Jeg vil være taknemmelig, hvis formanden ikke bruger hammeren, før min tid er gået.
+Det er ikke overraskende, at de mest indædte diskussioner har drejet sig om budgetspørgsmålet.
+Phthalaters akutte giftpåvirkninger er ubetydelig, og de irriterer ikke slimhinder eller huden.
+Det internationale finanssystem er i sandhed amoralsk og umoralsk.
+At beskytte livet er at give håbe for børn, der lider af cystisk fibrose.
+Som en af medunderskriverne glæder jeg mig over, at hovedændringsforslaget er blevet vedtaget.
+Det er vanskelige valg, men de kan ikke opsættes længere.
+At tale om en beskyttelse af forbrugerne her er pure bedrag!
+I de nye retningslinjer blandes det sammen med lavdispersionsmateriale.
+Hele føderationen lader sig trække rundt ved næsen af krigspropaganda.
+Jeg har sagt, at alle, der stiller spørgsmål, er skurken i denne debat.
+Størstedelen af samhandelen med træprodukter er ikke genstand for mistanke om ulovligheder.
+Jeg er enig i, at faste anlæg og solcellepaneler bør udelukkes fra direktivets anvendelsesområde.
+Ifølge ændringsforslaget til listen anvendes det til at bevare skumkronen i cider.
+Jeg tror ikke, at megatopmøder af denne slags kan fungere fremover.
+Det vil også bidrage til, at der foretages uopfordrede vurderinger.
+Libyen er et land, der kræver en del arbejde.
+Det er den ene anmærkning.
+Chassez le naturel, il revient au galop.
+Vi vil gerne have, at der er sofaer, barer, luksusrestaurant og fjernsyn i togene.
+Det skal også siges, at bushmeat udgør en vigtig proteinkilde.
+Schiedermeier har arbejdet hårdt på for at få en god betænkning ud af det.
+Forbrugerne fik ganske enkelt ikke smæk for skillingen.
+Der er ikke nogen klar definition på europæiske havområder.
+Det betyder, at der raser en klassekrig.
+Ja, det mener jeg også, men man kan ikke improvisere på den måde.
+Det vil kun sinke beslutningsprocessen.
+Resultatet er demokrati og borgere over for dette kontinents solkonger.
+Det første vedrører de animalske biprodukter.
+Parlamentet skal anlægge en mere håndfast holdning i kampen for at standse ukontrolleret rydning.
+Det er ikke pacifisme, det er demagogi og uansvarlighed.
+Deraf den bekymrende nedgang i kødforbruget.
+Vi kan ikke bruge denne debat til at mele vores egen nationale politiske kage.
+Jeg kommer selv fra et område med små rejefiskere.
+Der er dog et par problemer tilbage, især for småfiskere og traditionelt fiskeri.
+For mælkeproduktionen har ikke en hane, vi bare kan åbne og lukke for...
+Der findes måske ingen sikre duftstoffer for nogle allergikere.
+De kan da ikke bilde mig ind, at der ikke findes retsgrundlag herfor!
+Medordførerne behandler deres eget område.
+Sumværdien er udtryk for, at der ikke må være pesticider i drikkevand.
+Den første bropille vedrører teknologisk forskning.
+Meget af det nuværende vejnet blev skabt for flere årtier siden.
+På den måde kan vi mindske emissionen af kuldioxid og syreregn.
+Der tales om pars barnløshed, som om homoseksuelle par kan være fertile.
+Men kig en gang på manglerne, hullerne i denne nye sociale dagsorden!
+At handle smart vil sige at ramme to fluer med et smæk.
+De vil sleske for ham og være rigtig søde og rare og venlige.
+Harmoniseringen af elnettene indebærer også en harmonisering af elpriserne.
+Vi støtter den gradvise afskaffelse af salget af blyholdig benzin.
+Bilkonceptet startede godt.
+Nokia er et godt eksempel.
+Hele dette arbejde skal foregå i tæt samarbejde med fagudvalgene.
+Vi har for øvrigt agiteret herimod sammen med mange kolleger.
+Alle medlemsstaterne bør være særlig opmærksom på restauranter, cateringvirksomheder og hoteller.
+Unionen må finde instrumenter til at kontrollere eller aftvinge sanktionerne med.
+Kommerciel kommunikation er et ømfindigt område.
+Det ene er bestemt gennemførelsen og anvendelsen af det europæiske semester.
+Watson og alle, der har bidraget til udarbejdelsen af denne betænkning.
+Et andet vigtigt spørgsmål er fosfaterne.
+Derfor passes der på det som en øjesten.
+Men vi kan ikke a priori bare forbyde indførsel af most.
+Denne erklæring genlyder af dette mål, og derfor er den anløben.
+Blak om, at få dette cirkus afbrudt.
+Stubb meget taknemmelig for betænkningen og glæder sig over muligheden for en forhandling.
+Derfor er denne tvedeling bestemt en tvedeling, vi støtter fuldt ud.
+Stockholmprogrammet vil åbne op for nye muligheder.
+De ville faktisk sabotere en del af katalogiseringen og gøre det kompliceret.
+Jeg bifalder, at der i betænkningen tages højde for migrantfamilier og uledsagede mindreårige.
+Kun da vil vi være agtværdige partnere.
+Kommissionen lever i et elfenbenstårn.
+Den japanske regering reagerede på det tidspunkt med en stejl afvisning af disse krav.
+Et af de mest afgørende aspekter ved østpartnerskabet bliver visumfriheden.
+Jo flere penge en fange kunne betale, jo mindre skar kirurgen af øret.
+Folk med multipel sclerose er syge i mange år.
+Især kvinder og børn kommer i klemme, når det drejer sig om arbejdstid.
+Man vil have forbedret proceduren for bilæggelse af stridigheder.
+Uden skovbrug er der ingen træindustri.
+Kun hvis dette er et must, kan andrageren være beskyttet i sin retssikkerhed.
+Der er røde streger på vejen.
+Det er et gammelt tema, men alligevel højaktuelt.
+Ved at skrabe midler sammen på en usystematisk og uorganiseret måde?
+Økofin, finansministrene, har allerede fået kolde fødder.
+To eksempler på dette er hårtørrere i en frisørsalon eller udstyr i et motionscenter.
+Eller er det måske politikerne, der har mistet følingen med almindelige mennesker?
+Sukker kan anvendes til andet end slik.
+Mit næste punkt vedrører væsker.
+Debatten har især udkrystalliseret sig omkring de kombinerede forbrændingsanlæg.
+Endnu en gang tak og okay, jeg går med ud og får en drink!
+I kampen for afskaffelsen af dødsstraf skal vi finde et fælles moralsk fodslag.
+Virkningerne af forurening og rovdrift på naturressourcer er grænseoverskridende.
+Når man graver ud til fundament til et hus, skader man ormene.
+Molukkerne skal hurtigst muligt hjælpes.
+Bestandene inden for vores sømilegrænser kan også blive berørt af aktiviteter uden for grænserne.
+Det er ikke rigtigt at slå rasicme i hartkorn med såkaldt homofobi og islamofobi.
+Det ligger ganske enkelt i semantikken.
+Det er ikke en eksklusiv klub.
+Stivhed og bureaukrati ligger efter min mening altid på lur.
+Der bliver allerede gjort et vigtigt stykke arbejde på at styrke vores bånd igen.
+Og siden da er den europæiske økonomi uafbrudt blevet bedre.
+Letland var udsat for risiko for at gå bankerot uden finansiel bistand udefra.
+Dette forbud indbefatter også pædofile blade.
+Der er blevet udsendt et vademecum.
+Så amerikansk politik er israelsk politik, og vi europæere trasker efter vores ledere.
+Chirac ved besvarelsen af spørgsmålene også anvendte denne benævnelse.
+Lovgivningen er særligt vigtig for spædbørns sundhed i forbindelse med amning.
+Det er endnu en gang mellemhandlere og de dominerende fødevarekæder, der skummer fløden.
+Better ballots than bullets , som englænderne siger, kunne man høre rundt omkring.
+Alt dette fører også til wildwestpriser, om jeg så må sige.
+Ordføreren og andre talere nævnte spørgsmålet om økomærkning.
+Der er ikke råd til nonchalance.
+På denne måde lader vi ulven vogte fårene.
+De var ikke blandt hooliganerne!
+Jeg kan nævne den svenske sexkøbslov og naturligvis den østrigske lovgivning.
+Hvad angår adgangen til gastransmissionsnet, er målene i den tredje energipakke blevet opnået.
+De bliver ved med at skøjte uden om spørgsmålene om menneskerettigheder og demokrati.
+Buttiglione diskriminerede alenemødre på den måde.
+Endelig er det påkrævet at revidere den internationale havret, der er klart utidssvarende.
+Folgorefaldskærmstropperne.
+Og længe leve ensstemmigheden!
+Den strategi, som den havde lagt, var reelt set farlig og har sået splid.
+Den mand har været min ven i meget lang tid.
+Jeg medgiver, at det er meget, og at tallet måske er arbitrært.
+Måden, hvorpå denne traktat blev markedsført, var sløset, amatøragtig og fuldstændig uintelligent.
+Jeg tror, at der er ved at ske det samme med den bærbare udvikling.
+Ethvert monetært duopol gennemgår regelmæssigt paritetstilpasninger, som ofte sker ganske pludseligt.
+Med den yderligere regulering vedrørende private equity forhindrer vi tømning af porteføljeselskaber.
+Kystområdernes udkomme er ofte afhængig af dette ene erhverv.
+Teknologi til reduktion af kvælstofoxiderne findes også allerede i dag.
+Frygt er i øjeblikket altdominerende i dette land.
+Kommissionen for sit vedkommende affinder sig udmærket med denne situation.
+Vi ved i dag, at gravide, som får zidovudin, sætter raske børn i verden.
+De har ødslet fondene væk, og de har raget arbejdstagernes penge til sig.
+Hory vil tage ordet om lidt.
+Gerningsmændene skal pågribes og stilles for en domstol.
+Dem, der holder af at se god fodbold, får helt sikkert en herlig tid.
+Hvorfor indeholder de ikke en målrettet jobindsats for unge?
+For det niende kræver den fokus på erindring, så ofrene ikke glemmes.
+Medlemmerne skal holde op med at slæbe på fødderne og ratificere konventionen hurtigst muligt.
+Synet er begrænset af et gitter af stof, svarende til et bur.
+At dette skråleri ikke kun lyder i mit land, er ikke særlig beroligende.
+Jeg kan huske, at han lå op ad rattet og angsten i mit bryst.
+Den enkelte og partnerskabsprincippet er blevet efterladt i vejkanten i denne reform.
+I stedet ævler hun løs om solidaritet.
+Den bymæssige dimension må blive obligatorisk.
+Giansily ikke kan være til stede her.
+Naturligvis er ingen af os usårlige over for overtrædelse af bestemmelser.
+Dette er næsten et mirakel, der sommetider tvinger dem til at arbejde mange nætter.
+Der er konkurrence i pipelines, det var der allerede, da monopolerne eksisterede.
+Wales producere fantastisk godt oksekød og skal kunne mærke det som walisisk.
+Den giver i det mindste nogen struktur og retssikkerhed inden for olieog gashandelen.
+Trods alle de fine ord og retorikken står vi tomhændede, hvilket er meget tragisk.
+I generationer er vin blevet modnet i træ, og vinens sundhedsmæssige virkning er uomtvistelig.
+Alle ved, hvad der skete, så det vil jeg ikke dvæle ved.
+Desuden er der en meget hårfin grænse mellem information og reklame.
+Vi har bevæget os fremad i snegletempo.
+Slots skal sælges ligeligt også til udenlandske selskaber.
+Virksomheder er ikke længere kun gearet til profit.
+Dette er ikke science fiction, men virkelig nødvendigt.
+Solana nævnte mange af, og traf beslutninger med et klart udsagn.
+Bæredygtig pesticidanvendelse er til gengæld en blåstempling af spreding af gift.
+Lad os altså forsvare ytringsfriheden med næb og kløer.
+I samme ånd støttede jeg den femårige udelukkelse af solpaneler fra direktivet.
+De europæiske myndigheder må afgjort betegnes som recidivister.
+Regionerne, fagforeningerne og avlerne er imod dem.
+Det sker selvfølgelig ikke, hvis ikke der eksisterer en god dagpleje.
+Pastys forklaring, og jeg skal ikke stille spørgsmålstegn ved den.
+I dag foregår der noget lignende mutatis mutandis.
+De er den rette til jobbet.
+Også for at opfordre til, at der indføres strengere krav til campingpladsers placering.
+Den zimbabwiske befolkning lider i forvejen alt for hårdt.
+På den måde kan vi blive spydspids i reformen af det internationale finansieringssystem.
+Det drejer sig naturligvis om titusindvis.
+Der findes ingen udødelige diktatorer, men frihedens ånd er tidløs.
+At holde fast ved denne udgave ville være en pyrrhussejr.
+Igen kunne et regionalt samarbejde afbøde virkningerne af sådanne naturkatastrofer.
+Dette bevidner vores menneskerettighedsdialog med alle grene af de israelske myndigheder.
+Aznar, gjorde jeg det objektivt og tydeligt.
+Clarke og det britiske formandskab har i sinde at gøre.
+Vores empati er ikke tilstrækkelig.
+En fildeler får undersøgt sin computer, og alle vedkommendes private oplysninger granskes.
+Skal vi så blot slå os til tåls med dødvandet i fredsprocessen?
+Vi ønsker, at de skal blive til integrerende mørtel.
+Det system, som nu bliver foreslået, er ikke en døjt mindre kompliceret end forgængeren.
+Lækagen af information er yderst beklageligt, men det er jo sket før.
+Hahn, mine damer og herrer!
+Det samme problem gælder standardiseringen af værdier for kystvande og ferskvand.
+De fleste husmødre kender ikke forskel på en kvie og en stud.
+Jeg traf samme beslutning med hensyn til præimplantationsdiagnostik.
+Det samme gælder for hedgefonde.
+Det er forkasteligt, svigefuldt og fejt.
+Stadiet for lapværk og halve foranstaltninger er forbi.
+Endelig hævede den embargoen mod gelatine.
+Hvis de var bekendte med det, blev der brugt uvederhæftige argumenter.
+Kvinder er i størst fare inden for deres egne fire vægge.
+Ud over litterære værker vil det omfatte tekniske, juridiske, journalistiske og audiovisuelle værker.
+Det er ligesom med kolesterol, hvor der er en positiv og en negativ markør.
+Kigalierklæringen var særlig tung og afgørende.
+Beslutningen dækker midler til nødarbejde i en tremåneders periode.
+Naturkatastrofer indtræffer stedse hyppigere i kølvandet på klimaændringerne.
+Son nævnt er det blevet drøftet ved adskillige lejligheder.
+Det blev foreslået for lande, som har et currency board.
+Jeg tænker på bymiljøet, boliger og socialt boligbyggeri.
+Ordførerens redigering har altså, efter vores mening, været for afgrænsende.
+Vi må undgå den fejltagelse at gøre tænkepausen til en inaktivitetspause.
+Jeg var ved stranden, og jeg blev brun.
+Der er stadig to timer til midnat nu, men vi opbygger fremtiden.
+Rapkays betænkning er vedtaget.
+Det er, som om vi befinder os i en labyrint.
+Kommissionens forslag om reformer af vinsektoren er et skridt i den rigtige retning.
+De havde en meget vanskelig rolle, men udviste dygtighed og udholdenhed.
+Også i denne sammenhæng gælder det, at man må krybe, før man kan gå.
+På denne måde vil vi kunne reducere den administrative segmentering.
+Dykke ned i fleksibilitetsinstrumentet?
+Nåletræerne er betydeligt blødere end løvtræerne, hvilket gør deres støv mindre risikabel.
+Bahai, fagforeningsfolk og kvinder trues af fundamentalisterne.
+Her skal der foretages et radikalt snit.
+Det drejer sig om tørret frugt, kornflager, kylling, indmad, æggehvide og gummi arabicum.
+Vi må i øvrigt sørge for, at oplysningerne er læsbare.
+Sammenklistret kød og tilsætningsstoffer må ikke sælges som bøffer ved disken.
+Reformen er bygget op om tre akser.
+Lewandowski, mine damer og herrer!
+Dette er et citat fra selve teksten.
+Min tjenestegren er ved at undersøge de to andre forsikringsselskabers krak.
+Tindemans betænkning giver anledning til at reflektere over dette.
+Maastrichttraktaten var også en beskeden optakt til den politiske union.
+Turmes var for eller imod afstemningen om uopsættelighed.
+Jeg forstår, at disse politiske argumenter fyger gennem luften.
+Det er derfor, jeg er sur.
+Superior stabat lupus longeque inferior agnus.
+Drab på syge børn med en overdosis af sedativer er en ubeskriveligt barbarisk handling.
+Skægt nok kunne jeg have forudset det uden noget besvær overhovedet.
+Det er ikke småreformer, men virkelige reformer, der er brug for.
+Sainjon virkelig et sådant koncept, hvor myndighederne kan ændre samfundet, for at være realistisk?
+Parlamentet lavede al fodarbejdet, og det udarbejdede alle kompromisforslagene.
+Vi kom ud i uføre, fordi vi ikke fokuserede på problemerne.
+Der manglede kun een stemme.
+Grækenland er forpligtet til at klø på med omfattende strukturreformer og privatiseringer.
+Kendsgerningen er, at den samlede globale ismasse stort set er konstant.
+Her må der findes en ny approach.
+Ottowakonventionens forbud mod dem er en sejr for menneskeligheden.
+Det vil samtidig betyde bedre sundhed for børn og færre problemer under opvæksten.
+Vi hører ikke længere lyden af klokker eller gøende hunde.
+At redde menneskeliv må altid komme før doktriner om intellektuel ejendomsret.
+Således kan overlapninger eller afvigende strategier undgås, og et optimalt rendement kan opnås.
+Dette direktiv er absolut nødvendigt, især for de store vejinfrastrukturprojekter.
+Jeg siger, at de ikke bare kan verfes væk med en let håndbevægelse.
+Vi har stillet forslag om rettigheder og pligter for herboende tredjelandsborgere.
+Det er dokumenteret, at andre elementer i solsystemet ligesom jorden er blevet varmere.
+Markederne for telekommunikation, post, el og togtrafik samt landbrugsmarkederne blev liberaliseret.
+Det er ganske givet nødvendigt at styrke europæiske samproduktioner.
+Hvor er det stærke engagement med hensyn til at fjerne skattelyer og offshorefinanscentre?
+Og nu må jeg tage en dyb indånding!
+Folk uden humor kunne endda opfatte det som en fornærmelse.
+Flisebelægninger på åbne områder blev synligt misfarvet af en rustfarvet substans.
+Derefter var der endnu alvorligere problemer som følge af uroen på tilhørerpladserne.
+Jeg mener ikke, det er plausibelt at tale om udryddelse af det tibetanske sprog.
+Jeg vil begrænse mig til spørgsmålene om frø og handel med frø.
+Dentalt kviksølv infiltrerer også atmosfæren under kommunal affaldsforbrænding.
+Schlyter for deres støtte.
+Også her gælder det om at sørge for, at disse to aktiviteter bliver synkroniseret.
+De holder den gående med narkotikahandel, tyverier og småkriminalitet.
+Kommissionen forsøger på sin vanlige facon at standardisere i stedet for at harmonisere.
+De betalte pengene tilbage, og det er sådan, klaveret spiller.
+Vi kan ikke være som de frøer, der krævede en konge.
+Bertens til lykke med hans betænkning.
+I første omgang skal data om højvolumenkemikalier indsamles og analyseres.
+Den, der fusker, mister kunder.
+Det hører egentlig til den sædvanlige forretning, og beløbet burde ikke slå os omkuld.
+Den aktuelle israelske politik er grotesk og virker mod hensigten.
+Kommissionen anmoder om, at de reducerer deres fiskeri, deres tonnage og deres fangster.
+Vi skal i ro og mag opveje plusserne og minusserne.
+Rådet lænker sig selv med enstemmighedsproceduren.
+Endvidere vil elmarkedet ikke fungere ordentligt, hvis gasmarkedet ikke fungerer ordentligt.
+Der er beretninger om, at der finder totur sted.
+Denne atavisme må overvindes hurtigst muligt.
+Dertil passer samtidig et uegennyttigt og mere afbalanceret udvalg af de regionale bistandsprojekter.
+Lad os tage tyren ved hornene i forbindelse med det, borgerne ønsker.
+Også det må vi kritisk tage på vores egen kappe.
+California is turning dramatically left.
+Nassauer, har fremsat nogle gode forslag, som vi hilser velkomne.
+Vi ved alle, hvad denne holdning i sidste ende betød for økonomierne i østblokken.
+Vi har klynket i årevis, da det eneste valg stod imellem diktaturer eller teokratier.
+Det postkommunistiske regime er blevet uudholdeligt.
+Vi modtager det budskab, at folkets vilje måske vil blive knægtet.
+Tyrkiet har i snart to år befundet sig i en yderst kompliceret politisk situation.
+Men de småpenge, de får, kan måske lette deres trængsler.
+Disse dyr lever under skrækkelige forhold, og mange bliver flået levende.
+De franske lastbilchaufførers vejblokade
+Troende, præster, munke og høje gejstlige honeratiores chikaneres, forfølges og spærres inde.
+I praksis opmuntrer de en hæmningsløs sort økonomi.
+Dette er et sensitivt stadium i børns intellektuelle, fysiske og kognitive samt sproglige udvikling.
+Desværre er det kun amerikanske westernfilm, der ender lykkeligt.
+Tilladelser til dybvandsboringer skal kontrolleres nøje.
+Kommissionen har begået en stor fadæse her.
+Jeg ønsker ikke at give dem et urigtigt tal.
+Det skal tages med i overvejelserne om den gavnlige effekt af anvendt ikt.
+Vi kan her se deres tørst efter magt.
+Libicki, dette er et fundamentalt spørgsmål om menneskerettigheder og grundlæggende rettigheder.
+Hvordan genopretter man husfreden?
+Åbenhed er ærlige magthaveres bedste redskab til at værge sig mod egne venners pression.
+Hvad har de nye medlemsstater fundet i deres fagre nye verden?
+I den foreliggende betænkning behandler man nogle af problemerne, omend noget ensidigt.
+Jeg mener, at dette vil afsløre mange af de vigtigste patogene stoffer i cigaretter.
+Transmissible spongiforme encephalopatier
+Lukasjenko bør heller ikke kaldes for præsident her i salen.
+Det er lykkedes ham at give sobert udtryk for udvalgets holdning.
+Europol må ikke blot blive et bureaukratisk departement.
+Det er en præcisering, som har oplivet vores aften.
+Bevaringen af vådområder stiller os rent faktisk over for en stor udfordring.
+Det er tydeligvis et røgslør.
+Den fælles landbrugspolitik er dybt usolidarisk og skal reformeres omgående.
+Det handler til dels om jonglering med uklare fordomme.
+Alligevel er erhvervstraditionen i de sydeuropæiske lande ikke mindre udpræget end i nord.
+En sådan hotline bør i grunden være et permanent tilbud.
+Læs dog venligst først teksterne!
+For købmanden betyder det merudgifter og besvær, men det er til gavn for forbrugeren.
+Det er en retlig ramme, der ikke slides op af denne type afgiftsmæssige foranstaltninger.
+Jeg er også klar over, at der er problemer i bærsektoren.
+Den aktuelle krise er så dramatisk, at den retfærdiggør en sådan utraditionel indsats.
+Det, der skulle have ført til en grænseoverskridende egnsudvikling kom aldrig.
+Vi skal stille strenge krav til dæmningers sikkerhed og bæreevne.
+Det optræder ihvertfald i den skriftlige betænkning.
+Selv det vand, der indvindes fra slammet, renses for rester af cyanid.
+Det ville også være en hån mod den vestsaharanske befolknings legitime frihedskamp.
+I den nye aftale var der fastsat krav om peer review.
+Vinbøndernes interesser er indlysende, men det er folkesundhedens i lige høj grad.
+Ve os, hvis vi ikke gør dette!
+Denne udtalelse er ikke fremsat i lyset af verdensmesterskabet i ishockey.
+Jeg vil gerne fremhæve to ting, først definitionen af vodka.
+Vi må skære tingene ud i pap på en åben og tolerant måde.
+Clamydia fører i hvert tredje tilfælde til ufrugtbarhed.
+Der er ikke nok rastepladser for chauffører, der er ikke nok incitamenter til uddannelse.
+Det afvises, mens disse fester, hvor vi fremstår som ådselgribbe, tillades uden videre.
+Vi bør sørge for, at der ikke bliver leveret flere alibier.
+Hvor håner og hænger man en dukke, der skal forestille den økumeniske patriark?
+Hvis vi ønsker regionale økonomiske cyklusser, skal vi fokusere på kvalitet og ikke bøjningsgrader.
+Jeg ser imidlertid ingen grund til at boykotte ceremonien eller legene på dette grundlag.
+Der er desuden andre farvestoffer end azofarvestofferne.
+Derfor bør der tilskyndes til åbne debatter på weblogs.
+Vores bidrag i dag er baserede på to fuldførte regnskabsår i en syvårig periode.
+Vi skal undgå at blæse, mens vi har mel i munden.
+Soldrevne elværkers produktion svinger derfor betydeligt i løbet af en dag eller et år.
+Det skylder vi det ukrainske samfund og dets gryende demokrati.
+Der er også snak om letvægtere og sværvægtere.
+Indre erosion og ørkendannelse skyldes brugen af vores land.
+Disse foranstaltninger har båret frugt.
+Der er tusinder af tons til rådighed nu, og vi øger lagrene.
+Hvordan ser situationen ud med hensyn til det europæiske lokomotivførercertifikat?
+At subsidiere nationale aktioner er i virkeligheden intet andet end at pumpe penge rundt.
+En national alenegang i forbindelse med billetafgifter og kerosinskatter er ikke formålstjenlig.
+Der bibringes nyttige præcisioner, og endelig lægges der særlig vægt på de små operatører.
+Denne manøvre forekommer os at være yderst dadelværdig set fra et juridisk synspunkt.
+En trejdedel af den algeriske befolkning er berbisk.
+Det har været en lang drægtighedsperiode.
+De kendte fordele ved at spise en portion fed fisk opvejer alle mulige risici.
+Dette folkemord havde karakter af genocidum atrox, brutalt mord, begået med ekstrem grusomhed.
+Han har afsonet sin straf og bør nu være fri.
+Svarene på disse spørgsmål er stadig meget svævende, endog slørede.
+Bahrain indtager en nøgleposition og formodentlig nøglepositionen i hele regionen.
+Ingen blev ladt uberørt af dette valg.
+Vi mangler stadig et kæmpestort stykke arbejde, hvis vi skal opfylde målene for pasningstilbud.
+Jeg vil kort ridse op, hvad det drejer sig om.
+I øvrigt har flere talere fra samtlige fløje takket ham.
+Pujol og de andre ministerpræsidenter.
+Objektiv, fordi den er baseret på uanfægtelige beløbsopgørelser.
+Det gjorde det ikke, med mindre der henvises til æraen for ren skamløshed.
+Kallas, mine damer og herrer!
+Vi bør støtte bestræbelserne på at gøre bøger søgbare, læsbare og overførbare.
+Screeningsprogrammer ved hjælp af mammografi bør være obligatoriske i alle medlemsstater.
+Hvad det angår, begynder vi ikke på nulpunktet!
+Det er, som jeg før har sagt, den moderne version af tantaluskvalerne.
+Først og fremmest vil jeg takke vor kollega for hendes arbejde og ildhu.
+You have done some excellent work.
+Det kræver en større grad af integration og sammenkædning af energimarkedets delmarkeder.
+Vecchi får min fulde tilslutning.
+Kommissionen påtog sig dernæst hele processen internt.
+De havde helt sikkert ikke til hensigt at begå harakiri.
+Injurier er en lovovertrædelse.
+Bursenge og lignende hører ikke ingen steder hjemme i den moderne psykiatri.
+Jerusalem er en by, som appellerer til verdenssamfundet.
+Oliepriser og valutakurser er kommet på en veritabel rutsjebanetur.
+Hvordan håndhæves disse rettigheder blandt singaleserne i den nordøstlige del af øen?
+Indførelsen af elbiler på markedet kan give den europæiske industri konkurrencefordele.
+De vil ikke tolerere nogen form for tøven eller bare tegn på ufrivillig magtesløshed.
+Vi har flere fattige husstande end vi nogensinde før har haft.
+Politik er dog altid et spørgsmål om bricolage.
+Jeg har netop fået at vide, at der er en stavefejl.
+Sidst, men ikke mindst hylder jeg modet hos det østtimoresiske folk.
+Bølgerne er gået højt, og der kar været beskyldninger om åbenlys partiskhed.
+Det er blevet foreslået, at vi afskaffer tofaseforhandlingerne.
+Gaddafi afviser demokratiet til fordel for streng overholdelse af sharialovgivningen.
+Der er nok, som allerede er sivet bort.
+Teenagere er typisk korttidsansatte, deltidsansatte, uuddannede og uinformerede arbejdstagere.
+Dyrets slagtning bogføres som reduktion af mælkeproduktionen, og der inkasseres igen for dette.
+Det vil være et af omdrejningspunkterne for min indsats.
+Pludselig bliver døren rykket op, og hendes mand, børnenes far, står i døråbningen.
+Derfor må folket gå modstandens, ulydighedens og opsætsighedens vej.
+Man skal ikke af ovenstående udlede, at vores holdning er ubetinget ukritisk.
+Der er da nu sat lidt kulør på debatten.
+Tomlinson, som jeg lykønsker med arbejdet.
+Der er behov for yderligere forskning inden for føtalt alkoholsyndrom.
+Endvidere blev disse kulturers forskellighed og identitet negeret.
+Pengene skal investeres i virksomheder, der garanterer, at nyuddannede kan finde arbejde.
+Verden fortjener mere end testosteron på den ene side og hånlighed på den anden.
+På længere sigt kan dette sågar medføre præmatur ældning af lungerne.
+Forskellige gasrørledninger, havvindmølleparker og kraftværker i dusinvis er på tegnebrættet.
+Rådet har traditionelt haft to kasketter på, både den udøvende og den lovgivende.
+Mitchell allerede har været inde på.
+Som læge er jeg fuldt ud klar over de skadelige virkninger ved ludomani.
+Sarajevo kigger frem mod sin europæiske fremtid med stor entusiasme.
+Disse vacciner kan medføre uønsket cirkulation af vaccinevirusset hos uvaccinerede dyr.
+Coveney ikke vover at nævne ordet i sin betænkning, vidner herom.
+Jeg vil bede kommissæren om at tage imod denne lejlighed med kyshånd.
+At medlemmer af et erhverv fastsætter fælles salærer strider principielt mod konkurrencereglen.
+Når markedets usynlige hånd fungerer, virker dette tilnærmelsesvist.
+De afgivne tilsagn må absolut honoreres på mødet i september.
+Vi ved alle sammen, hvad der er sket med de korte hørfibre.
+I øjeblikket er denne fabrik lagt i mølpose, og de ansatte er på ventepenge.
+Det er det, vi kalder en palimpsest.
+Det er atomlobbyen, der på lumsk vis sniger sig gennem bagdøren.
+Hvad sker der, hvis hjorte, vildsvin og geder smittes?
+Hvad er den langsigtede vision for vores rumpolitik, og hvad er formålet med den?
+En atomulykke er ikke det samme som en togulykke.
+Durban var ligeledes lejligheden til at se vores fælles fortid i øjnene.
+Katyn, der viste, at man kan befri og ødelægge samtidig.
+Smeartesten har bevist sin værdi for så vidt angår livmoderhalskræft.
+Det er ikke døgnfluer, som skaber overskrifter i en dag og så forsvinder.
+Resultatet er de grimme arbejdsløshedstal, vi ser for universitetskandidater.
+Mit sidste punkt er offentlig licitation og offentlige indkøb.
+I øjeblikkets eufori må vi ikke lukke øjnene for en række problemer.
+Sådanne forsamlinger bevæger sig i det hemmelige diplomatis tusmørke.
+Det vigtigste mål er at sikre momentum på dette område.
+Er det ikke så kujonagtigt, som det kan være?
+Det er gennemførelsen, det kniber med, og som forårsager problemet.
+Jeg har min yndlingschokolade, som vi alle har det.
+Kina og andre stater vil hale mere ind på os.
+Nogle lande tier stadig og deltager ikke.
+Allierede, men ikke afrettede, som vi sagde.
+I alt for mange medlemsstater er pensionssystemer grundlæggende pyramidesystemer.
+I virkeligheden er der således kun tale om en brøkdel af det oprindelige beløb.
+Dernæst en hysterisk besættelse af den menneskeskabte globale opvarmning.
+Det inkluderer gnubbesyge.
+Hvis der ses sådanne pletter, kontrolleres de pågældende passagerer separat på stedet.
+Trods denne positive emotionelle holdning skal vi imidlertid også være åbne og ærlige.
+Alle bør have en barndom fyldt med leg, glæde, håb og lykke.
+Men det er virkelig ikke min kop te.
+Dette system gør producenterne dovne.
+Akronymerne er angivet i omvendt rækkefølge.
+Vedvarende energikilder omfatter ikke forbrænding af de ikke bionedbrydelige dele af affald.
+Det nuværende system med domænenavne og registreringer fungerer fantastisk godt.
+Vi ønsker ikke, at de også skal inspicere fedesvin og kalve.
+Europæiske partier, lad os prøve ikke at holde hinanden for nar!
+Man forbyder det, og så vasker man sine hænder.
+Hvad angår indvandring, er signalet fuldstændigt under lavmålet.
+Sundhed har noget at gøre med life science, med bioteknologi.
+Kort sagt er disse biler for lydløse i bymiljøer.
+Det etiske digebrud må forhindres.
+I det nye gasdirektiv tillægges gasmyndighederne og agenturet stor betydning.
+Tudjmans reaktion synes at tyde på en tilbagevenden mod de kommunistiske tider.
+Et andet aspekt, som jeg gerne vil have med i debatten, er dyrplageri.
+Den første var rationalisering af informationspolitikken, agenturerne og nomenklaturen.
+Jeg nævte tidligere samhørighedsbetænkningen.
+Jeg savner en hurtig udfasning af pvc og phtalater i direktivet.
+Jernet skal smedes, mens det er varmt, sammen med den nye regering.
+Needles forslag til beslutning.
+Med den blev åbningen af markederne for godstransport en realitet pr.
+Garnene blev indført i handlen, som så senere blev udvidet.
+Nu kommer turen så til ris.
+Tillad mig her at iføre mig min institutionskasket.
+Slovakiet ligger, som det har redt, efter at et ekstremistparti er kommet til magten.
+I en uge er der ikke sket nogen lovændringer eller ændringer i valgkommissionens sammensætning.
+Decharge, ledsaget af en række bønfaldelser, er ikke et sådant magtmiddel.
+En detalje kan være harmløs, men den kan ogå være betydningsfuld.
+Disse mennesker bør ikke betale prisen for, at andre har ødelagt moserne.
+Det pågældende anlæg leverede glukosesirup eller melasse til hollandske foderproducenter.
+Vi har udvist lederskab og løst den gordiske knude.
+Åbn alle møder for offentligheden, medmindre et flertal af landede aktivt siger fra.
+Et enkelt land er letpåvirkeligt, men ikke en union af lande.
+Afslutningsvis er der spørgsmålet om afvandringen fra landområderne.
+Der er ingen grund til en opdeling i en offentlig og en privat sfære.
+Vi har lært at være kreative med arven, der består af suverænitet og symboler.
+Fremtiden udgøres af et miks af energiforsyninger.
+Vi håber, at den bliver vej og ikke kro.
+Kort sagt skal vi i dag sige et rungende nej!
+Jeg vil kort omtale direktivet, der er opkaldt efter en tidligere kommissær.
+I dagevis blev klostret hermetisk afskåret fra omverdenen.
+Vi enedes om at arbejde sammen i et partnerskab.
+Ved begyndelsen af strejken angreb politiet arbejdstagerne med tåregas og vandkanoner.
+Men nu hører jeg, at man vil lægge forfatningen, de finansielle overslag på køl.
+Lavspændingsdirektivet og maskindirektivet dækker allerede mange spørgsmål i denne henseende.
+Brugen af antibiotika er bestemt en torn i øjet på både dyr og mennesker.
+Den lille røde bog fik tilsyneladende kolossal betydning, enorm betydning.
+Til trods for kritikpunkterne er den generelle retning fornuftig og målsætningerne ædle.
+For os er der to primære målsætninger for denne euopæiske politik for søhavne.
+Når dens opgave er afsluttet, visner den stille bort.
+Jeg samler alle de nødvendige bidder af informationer.
+Med et forslidt udtryk vil jeg sige, at spejdertroppens moral er bedre nu.
+For det andet ønsker vi at understrege, at omplacering ikke er noget entydigt fænomen.
+Den irakiske soldat havde brækket hver eneste knogle i mandens krop.
+Pack, og vi skal sørge for, at det bliver rettet.
+Tingene er gået gruelig, gruelig galt.
+Der mangler gode årsevalueringsrapporter.
+Novo om at indgive skriftlige bemærkninger om dette spørgsmål.
+Denne strygning kan jeg ikke tilslutte mig.
+Mearbejderrepræsentanterne skal have tid til at komme med en udtalelse, inden beslutningen træffes.
+Det er den bedste og sikreste måde til at kontrollere et visums ægthed.
+Jeg nævner ingen navne for at undgå røde kinder.
+Tidligere har den ikke gjort sig den ulejlighed at søge denne støtte.
+Papirøkonomi er bobleøkonomi.
+Der findes velmenende forslag om at tage hensyn til særgrupper.
+Efter det smittede benmel vil man en dag se flyene falde ned.
+Præstation og ansvar er fremmedord for dem, slendrian hører til dagens orden.
+Burtone, for hans indsats.
+Fourniretsagen er et sørgeligt og smerteligt eksempel herpå.
+Den skotske selvstyreregerings støtte til mellemlange uddannelser på gælisk bør også roses.
+Det er jo en imponerende clairvoyance, som lover godt for projekterne.
+Ahmadinejad endnu ikke er faldet.
+Jeg tænker her på bilolieprogrammet og nu revurderingen af det femte miljøhandlingsprogram.
+Derimod vil vi blive fattigere ved at vælge etsprogethed.
+Sellafield er det mest berømte.
+Reuls betænkning indeholder de redskaber, som er nødvendige for at løse problemet.
+Hurtig kunstig opdrætning af kyllinger og kalkuner skal ophøre.
+Sådanne konflikter kan ikke løses med militære metoder eller med kugler og krudt.
+Man røber meget mindre, hvad der foregår i nabolandet.
+Jeg er fortaler for miljørigtige elpærer, men det er slet ikke nok.
+Jeg er selv tilhænger af atlantismen.
+Vi ønsker på ingen måde et nyt skisma mellem vest og øst.
+De er interesserede i det politiske outputs kvalitet og produktivitet.
+Vi måler, om vi rent faktisk har emitteret færre drivhusgasser eller ej.
+Der kan så komme to eller tre yderligere, så det bliver tolv eller tretten.
+Og lad os nu tale om safe harbor.
+Her skal især sperlingefiskeriet nævnes.
+Og den algierske befolkning vil være enig i dette.
+Men der var en tid, hvor løven og lammet faktisk levede sammen.
+I stedet blev princippet om positive comity , det vil sige positiv høflighed, indført.
+Mudderet oversvømmede med sit yderst giftige kemikalieindhold de omliggende marker og landsbyer.
+Den europæiske landbrugspolitik sluger som sagt halvdelen af vores budget.
+Men jeg blev bearbejdet ret intensivt af almindelige udøvende kunstnere.
+Men dette faux pas er gået igennem med flertal.
+Han kaldte det the gap of ambition.
+Vi ønsker ikke at give vores sovende kæmpe et gok i nødden.
+Deri findes derfor årsagen til den gennemsnitligt meget lave hastighed i myldretiderne.
+Wurtz, endelig at bryde den onde cirkel med frygt, vold og had.
+Jeg er også glad for muligheden for dyb geologisk deponering og reversibilitetsprincippet.
+Jeg tror ikke, at den europæiske rumsektor lider under øgede kompetencer, tværtimod.
+De irakiske familier er ved at have tømt fødevarelagrene.
+Alligevel er beslutningen stadig kendetegnet af at ville dirigere.
+Det er klart, at dette forslag til direktiv ikke ændrer denne forfærdelige uvane.
+Det er der ikke stillet krav om for andre grupper, så hvorfor for bloggere?
+For det andet er der den asiatiske tiger.
+Her var en innovativ producent, der udviklede en inhalator til astmatikere.
+Jeg opfordrer også til, at denne pulje udvikles og øges i fremtiden.
+Nordkorea er et sølle land, som har både klimaet, kulturen og historien mod sig.
+Sharon gør den israelske befolkning en bjørnetjeneste.
+For de naive var det forgæves møje.
+Er den hidtil anvendte model stadig bæredygtig på lang sigt, denne hardwareorienterede model?
+Nu skal vi have en idiotsikker analysemetode til bestemmelse af ingredienserne.
+Jeg vil gerne minde om, hvor vi står med hensyn til bekæmpelse af havforurening.
+Jeg er glad for og respekterer konstitutionelle monarkier.
+Den væsentligste overførselskilde var heteroseksuel kontakt, sådan som kommissæren sagde.
+Hvis nogle af disse ting bliver undergravet, vil vi komme svagere ud af kisen.
+Hvis vi sørger for, at cykelsmeden har overkommelige priser, fremmer det cykling.
+Resultaterne er særdeles pauvre.
+Det er endnu en temmelig sart plante, som kræver vores fulde opmærksomhed.
+Weber for hans vilje til at opnå dialog og enighed.
+Chokerende er ligeledes teksterne i antiungarsk graffiti.
+Den globale opvarmning har fået isen til at trække sig kraftigt tilbage.
+Jeg var forbavset over, at vulkanudbrud ikke blev afskaffet!
+Internationale udviklingsmidler blev brugt på at bore mange dybe brønde.
+Jeg er bange for, at juryen voterer i øjeblikket.
+Så længe kravene til vejgreb ikke bliver overholdt, kan disse tre ændringsforslag ikke accepteres.
+København er vores store mulighed for at undgå en katastrofe, sådan som fageksperterne siger.
+Her er forvaltningen derimod vokset i flere lag uden at rette blikket mod fremtiden.
+Et af disse spørgsmål var det østlige partnerskab og alternative gasforsyningsruter.
+Dakar giver en mulighed for at nå mål, som der er international enighed om.
+Det er det socialistiske policy mix.
+De i sommer sete blåalgeblomstringer kommer ikke til at være et enestående fænomen.
+Bekæmpelse af fattigdom har været et af udviklingspolitikkens vigtigste mål i umindelige tider.
+Indtil videre har vi kun en svag gisning om, hvad det kan indebære.
+Med hensyn til spørgsmålet om rygsøjlen skal rygmarven naturligvis fjernes og destrueres.
+Det er særligt tilfældet for medhjælpende hustruer i private erhverv.
+Til sidst vil jeg absolut lige nævne diskussionen om bromerede flammehæmmere.
+Hundredtusindvis blev fordrevet eller flygtede fra optøjerne.
+Det lettede vejen for narkotikahandel, hæleri og menneskehandel.
+Derfor kan cifrene ikke blive helt nøjagtige.
+Fru formand, jeg forstår, at mange morer sig, men det er ikke morsomt.
+Fødevareforsyninger, vand, sanitet, husly og læ, uddannelse har naturligvis højeste prioritet.
+Landene valgte forskellige netspændinger og forskellig typer elektroniske sikkerhedssystemer.
+I dag er social dumping imidlertid eneherskende.
+Vi skal være meget forsigtige her, dersom vi i praksis foregriber dette.
+Vi kan ikke acceptere, at landene oparbejder ubegrænset national gæld.
+Der er stadig ret meget sne.
+Der er behov for risikovillig kapital for at skabe nye arbejdspladser i nystartede virksomheder.
+Vi ønsker ikke, på grund af nostalgi, at skrue tiden tilbage.
+Østrig har i øvrigt de skrappeste bestemmelser mod nynazisme og dens genopståen.
+Mauretanien skal også ratificere de relevante internationale fiskeriinstrumenter.
+Samarbejdspolitikken burde sætte gang i nogle samudviklingspolitikker.
+Vi er en mærkværdig, inhuman og umoralsk generation.
+Sexchikane er et ubehageligt fænomen.
+Dengang blev det foreslået at oprette en fælles markedsordning for ethanol alene.
+Alle de talere, der har talt dunder mod forskelsbehandling, har talt om princippet.
+Man må huske på, at informationskundskab er et redskab, ikke en numerisk værdi.
+Seeber for hans prisværdige behandling af dette direktiv.
+Derfor indtager millioner af europæiske borgere hver dag piller, tabletter og ampuller.
+Forenklingen af webmiljøet vil få flere til at stemme ved valget.
+Desværre forbliver vi for meget i det gamle mønster med paying but not playing.
+Det fastslås også i den ovennævnte ramme, at enhver eksisterende driftsstøtte skal aftrapppes.
+Alt for mange både, der tager alt for få fisk, bliver der råbt.
+For det tredje har vi brug for en nødbremse for videregivelsen af atomvåben.
+Dernæst udstedes et europæisk betalingspåbud, såfremt debitor ikke klager.
+Bourbon og gin behandles ikke på samme måde som whisky og cognac.
+Med hensyn til thoriumreaktorer er thorium et ikkefissilt materiale.
+Jeg har haft lejlighed til at besøge azeriske fængsler.
+På fællesskabsplan skal man kunne tage højde for medlemsstaternes klimatiske særforhold.
+Hvilken hær kan iføre sig blå hjelme og gå ud og beskytte irakerne?
+I disse og lignende tilfælde har småsparere og almindelige skatteydere tabt penge.
+Jeg vil gerne først komme ind på det omstridte spørgsmål i forbindelse med kimcellemanipulering.
+For vi må ikke stikke os selv blår i øjnene.
+Det drejer sig om steriliseret sødmælk, der kun kan tilbydes i flasker af glas.
+Vi bliver nødt til at tage skeen i den anden hånd.
+Hvis de befandt sig på kasernerne, ville tingene uden tvivl se anderledes ud.
+Det er en tidkrævende proces.
+Det er alt sammen noget, der skaber et molboagtigt bureaukrati, som skræmmer erhvervslivet væk.
+Beysen og andre sagde om vigtigheden af praktisk samarbejde.
+Mennesker behandles som skidt på togstationerne og af luftfartsselskaberne og lufthavnsmyndighederne.
+Uden at bagatellisere kogalskab efterlyser jeg sans for proportioner.
+Davies om netop at slette denne henvisning til denne spanske plan.
+Regnskabsvæsen er et teknisk og endog esoterisk spørgsmål.
+En skærpende omstændighed var, at moderen brugte en kobberkedel til at koge vandet i.
+For titusinde år siden boede vi i huler.
+Som eksempel kan nævnes en pub i min valgkreds, som havde frokostretter på menuen.
+Hume, for jeg kan ikke gøre forskelsbehandling mellem de politiske grupper.
+Det er et eksotisk rejsemål for europæere med dets ry som silkevejen.
+Dens uafhængighed er knæsat i traktaten.
+Til trods for alle de sortseende ånder er alle økonomiske spåmænd optimistiske.
+Kommissionen har ikke været uvirksom hidtil.
+I årevis har man tudet os ørerne fulde om, at vi skal liberalisere økonomien.
+De siger det under deres medborgeres hånlatter, sarkasme og undertiden trusler.
+Det er nærmest hinsides vores kontrol.
+Derfor er vores bekymringer koncentreret om emissioner af tungmetaller, dioxiner og furaner.
+Faktisk er det spørgsmålet om tronfølgen, der stilles spørgsmålstegn ved.
+Coreper sagde, at man gik ind for at underskrive resultatet af forhandlingerne.
+Det var ikke vanskeligt at forestille sig oprør og lynchstemning.
+Jeg vil gerne give udtryk for min dybfølte taknemmelighed i denne sammenhæng.
+Det væsentlige er ikke æsken, men æskens indhold.
+Auschwitz, den forfærdende , der viste det værste, mennesket er i stand til.
+Vi er som en lus mellem to negle.
+Medlemsstaterne må afslutte nyopmålingen af deres flåder så hurtigt som muligt.
+Det er et beviseligt empirisk faktum.
+Det er et aleksandrinerversemål med en cæsur.
+Distributionen finder sted gennem ledninger under de offentlige veje.
+Galeotes tre minutter oven i min taletid.
+De har vist betrådt nye stier.
+I de fleste tilfælde forårsages skaderne ikke af nikotin, men af disse tilsætningsstoffer.
+Devisen må være, at vi skal gå i gang.
+For det andet er en specifik støtte til hasselnødder ikke omfattet.
+Fru formand, de mest trivielle politiske debatter er de rituelle politiske debatter.
+Lad os håbe, at lydforholdene i morgen er bedre.
+Det er på murfoden, man genkender mureren.
+Jeg glæder mig over, at han ser så misundelsesværdig sund ud.
+Massedeportationer og koncentrationslejre var en del af begge regimers arsenal.
+Den foreliggende betænkning er en etårsstatus.
+Den anden kæbe er lønmodtagernes andel i den produktive formue.
+Spørgsmålene handler om krumme agurker, snus og andre dagligdags ting.
+Vores kultur er nødt til at tilskynde mændene til at tage deres tørn.
+In vino veritas plejede de gamle romere at sige.
+Sikke noget værre rod, du har fået os viklet ind i.
+Mange spottede ham eller lo ad ham på grund af det, han sagde.
+Den var vores stolthed, vores klenodie, vores pligt.
+Dette indtryk forstærkes af de forslag, som præsenteres for at forhindre omlokaliseringer.
+Mest af alt vil det være semidemokratisk sminke til en udemokratisk institution.
+Vi taler ikke om sproglig mangfoldighed, men derimod om lesser used languages.
+Politikerne kan ikke blive mere inaktive, end de er nu, også efter hans exit.
+Jeg forstår logikken i at foreslå et forbud mod brug af palmeolie.
+Der er efter min mening ingen alternativer til afskaffelsen af ruginterventionen.
+Initiativer som move europe om virksomhedernes sundhedspolitik er naturligvis positive.
+Piratkopierede solbriller kan forvolde skade på bærerens syn.
+Teksten bør være klar, og bør ikke kompliceres af ændringsforslag i elvte time.
+Narkotika kommer ind til lands, ad søvejen og ad luftvejen.
+Vi taler om varig tab af hørelse og tinitus.
+Kopterne ændrer sig ligesom andre borgere.
+Atalanta er en kortvarig foranstaltning for at dæmpe pirateriet.
+De folkevalgte er blevet erstattet af gesandter fra paladset.
+Lægemidlerne koster ofte mere end de derboende menneskers årsindtægt.
+Som afslutning på dette tema vil jeg gerne åbne en kort parentes.
+Jeg mener, de er misinformerede, fordi man aldrig handler mod bedre vidende.
+Det, at atombrændstoftransportbeholdere sveder, indebærer faktisk en risiko for mennesker.
+Vi vil gerne takke ham for det præcise arbejde med et meget komplekst lovstof.
+Hunterston ligger i min valgkreds.
+Næsten hver dag lander bådfulde af ulovlige indvandrere på vores kyster.
+Syvpunktsplanen er heller ikke noget rapseri af fødevarer fra de europæiske landmænd.
+Findes en ko at være smittet, nedslagtes hele besætningen.
+Vi stod ikke klar med en handlingsplan oppe i ærmet.
+Hans revisorer siger, at regnskabet ikke giver et retvisende billede af hans partis aktiviteter.
+Europæisk manna anvendes kun til at forlænge et uholdbart styres levetid.
+Der er et kraftigt uvejr på vej ind over os.
+De indiske raketforsøg er et uanvendeligt pressionsmiddel og en kontraproduktiv provokation.
+Med andre ord drejede det sig om en lille uvarslet demonstration.
+Ud fra det lækkede dokument vil jeg gerne stille ham tre spørgsmål.
+Hos de mangeårige medlemmer dæmrer det formodentligt.
+Rådet bryster sig, fordi det er så god til at håndtere høvlen.
+Der hersker åbenbart et vist virvar de to herrer imellem.
+Vi skal oplyse dem om, at arrogance er malplaceret her.
+Der udbetales ikke kompensation i forbindelse med force majeure.
+Mavrommatis med denne betænkning.
+Skrøbelig på grund af dens store modløshed.
+Det samlede økologisk følsomme alpeområde har brug for vores støtte i henhold til alpekonventionen.
+Vi har brug for et sådant initiativ i de seks amtsområder.
+Og trods alt var europæerne lige så gudfrygtige som virksomme.
+Det var ellers en betingelse sine qua non for godkendelse af den samlede aftale.
+Det ville også gavne yngre, men handicappede personer.
+Den ligger på en ø og har sine egne kajer.
+Min delstatsregering stønner under denne andel.
+Dette gælder også gasning af containere til skadedyrsbekæmpelse.
+Euroens pålydende værdier er velkendte.
+Formuleringen i politik kan være oprørsk, opflammende eller forsonende.
+Østersøen er forholdsvis stor i areal, men den er lavvandet.
+Der er alvorlige bekymringer over uidentificeret kvæg på slagterier.
+Hvordan kan bosserne i virksomhedernes bestyrelseslokaler dog holde sig selv ud?
+Det dualistiske samfund vinder frem, og det skaber udstødte og umennesker.
+Det frådsede vi også godt og grundigt i her denne uge.
+Den betænkning, som jeg har æren af at fremlægge, resumerer disse møder.
+Men der mangler konsekvens, når de samme personer begræder konsekvenserne af deres hidsige ideologi.
+Ved månedens udgang blev det palæstinensiske valg afholdt, og resultatet gav anledning til tumult.
+Dens holdning støttes af indflydelsesrige kirkelige repræsentanter og høvdingernes storråd.
+Produktionsomkostningerne for lange hørfibre er højere end for korte hørfibre og hamp.
+Formanden har givet mig toogethalvt minut, dem vil jeg gerne udnytte.
+Vi har brug for disse instrumenter i en mosaik.
+Lad fiskernes opmænd, de faglige organisationer, tage sig af ålen på tæt hold.
+De nye ministre aflægger ed i dag.
+De illegale jægere har okkuperet en stor del af landet.
+Vi skal i øvrigt også hurtigt genoprette sanmmenhængen mellem arbejde og social beskyttelse.
+Vi ærer ofrene for disse mord.
+Folias er hans ræsonnement derfor ikke i overensstemmelse med virkeligheden.
+Det er ikke tilfældet for ølsektoren og for bezintankaftalerne.
+Dog skal det lærred, der endnu ikke er afsløret, stadig for størstedelens vedkommende males.
+Jeg har dyb respekt for små virksomheder, som imod alle odds forsøger at overleve.
+De fortvivlede grækere har overtaget stafetten fra spanierne.
+Vi bejler til begge lande for at få handel.
+Norge er et godt eksempel på effektiviteten i denne fremgangsmåde.
+Wiebenga taknemmelig for, at han har tilpasset direktivet på den netop nævnte måde.
+Vi slog så at sige virkelig pjalterne samme denne gang.
+Hvorfor lader vi denne galskab fortsætte?
+Børn tilbringer hele deres skoletid i barakker.
+De fleste assyrer er nu internt fordrevet.
+Gennem andele og medejerskab bliver arbejdstagere til medarbejdere og medarbejdere til medejere.
+Dens modstand mod generalernes kupregime er forbilledligt fredelig.
+Målet var at gøre det ved hjælp af rå magt, brutalitet og hensynsløshed.
+Oostlander har også ret i, hvad han sagde derom.
+Transitspørgsmålet bør kunne løses på en anden måde eventuelt gennem en særlig pasordning.
+Her tænker jeg især på kvinder, som er ofre for sexslavehandel.
+Vejen til helvede er imidlertid brolagt med gode hensigter.
+Vi må have midler, udstyr, skibe, helikoptere og fly.
+Den grundlæggende årsag ligger stadig i problemets etnocentricitet.
+For første gang kunne vi se drusere, sunnitter, shiiter og kristne demonstrere sammen.
+Jeg vil tale om de problemer, som stadig ligger tårnhøje på vores bord.
+Rollen som smeltedigel slog fejl.
+Det fører til unødigt merarbejde for privatpersoner og virksomheder.
+Luk pengekassen til propaganda, eller giv kun midler til pluralistiske arrangementer.
+Jeg vil fremlægge det på aristotelisk vis.
+For det tredje er gensidig anerkendelse et kardinalpunkt for de liberale.
+Det er en ironi, der ville være morsom, hvis den ikke var så tragisk.
+Lad os holde op med at køre fast i tovtrækkerier om enkeltprodukter.
+Srebrenica står som et symbol på rædsel og utrøstelig sorg.
+Guatemalas øverste valgret har også bedt om vores støtte.
+Det udgjorde en risiko for andre søgående fartøjer i havnen.
+Vi var netop blevet færdige i gruppen og løb derefter hurtigt herhen.
+Det politiske establishment i landet har på sørgelig vis svigtet sit folk, navnlig ungdommen.
+I forbindelse med cyber war og cyberkriminalitet skal vi koncentrere os om tre punkter.
+Skatteopkrævningen er blevet mere effektiv, og kursen på rubelen er afbalanceret.
+Dette er altså en af grundene til de påsatte brande.
+Ryan træder i stedet for ham.
+Også andre veje bør afsøges, herunder først og fremmest eftergivelse af gælden.
+Kommissionen må her blive mere aktiv som problemløser og angribe obstruerende lande.
+Vi er nødt til at beskytte, værne om og bevare delfiner, hvaler og sæler.
+Vitorino, hvis kompetencer vi har værdsat.
+I denne sammenhæng kommer jeg til at tænke på gospelhistorien om splinten og bjælken.
+Svagheden i betænkningen er dens rigoristiske krav om kapitalistisk og nyliberal tilpasning.
+Vi aner ikke, hvor lang inkubationstiden er.
+Nogle af disse tilfælde omtales meget og ofte, mens andre hylles i tavshed.
+Måske en gevinst, som for en gennemsnitlig husholdning svarer til prisen på en pizza.
+Imens taler folk her som om, at ragnarok var ved at bryde løs.
+Det er en situation med lutter vindere.
+Egunkaria er en nyhedsavis.
+Wynn, og koordinatorerne har udført.
+Racismen suger næring af kriser og arbejdsløshed.
+Var formålet at iscenesætte et blodigt opgør?
+Der skal også kæmpes mod transfersystemets afdrift og især handlen med unge professionelle.
+Naturen formerer sig ukønnet og kloner sig selv, uden at vi foretager indgreb.
+Det er vigtigt ikke at blande nominel og reel konvergens sammen.
+Hvorfor går vi ikke videre med disse homøopatiske lægemidler?
+London er verdens ledende finanscenter, og engelsk er det fælles forretningssprog i verden.
+Cubas årlige bogmesse er en kulturel og informativ begivenhed med stor international anseelse.
+I den region har der altid været en interessekonflikt mellem nomader og fastboende landbrugere.
+Det gælder såvel majoritet som minoritet.
+Der anvendes ingen køller eller knipler, idet der i stedet anvendes geværer.
+Vi er ineffektive og dysfunktionelle, og vi svigter borgerne.
+Nu er det nok med lappeløsninger og rækker af aggiornamento.
+The point of no return ligger definitivt bag os.
+Corticoider og andre hormoner kombinerede eller ikke tjener til at oppuste kødet.
+Tillykke og bravo, kære kollega.
+Der skal luges ud i lovgivningen.
+Learning tilbyder nye pædagogiske modeller til undervisning og læring.
+Det ledes af fire saudiarabiske kvinder.
+Repræsentanterne for ilandene vedtog ingen konkrete forpligtelser.
+Kreml er imidlertid udmærket klar over, at der ikke kan skabes nogen juridisk præcedens.
+Læg tallene på bordet, og det hurtigt!
+Jeg ved, at den australske regering har fået meddelelse.
+Hvis de viser sig, mødes de med verbal eller endog fysisk aggression.
+De har alle været de sidste seks måneders adelsmærker.
+Buttiglione, det vigtigste er, at han fanger mus.
+Hvem pokker tror de mennesker lige, de er?
+Vil de ikke blive belånt fra starten?
+Japan hamstrer i stor stil.
+Vi beklager nok alle, at det oprindelige forslag om totredjedelsflertal ikke kunne gennemføres.
+At forhale direktivet ved at kives om urealistiske mål hjælper ikke nogen.
+Kommissionen har evalueret medlemsstaternes nationale allokeringsplaner.
+Vi så ikke bålene i fjernsynet, men på den anden side af hækken.
+Størstedelen af den tunesiske befolkning har ingen tillid til denne midlertidige uvalgte regering.
+Rugova er det i lang tid lykkedes.
+Orlando, en stor tak for kvaliteten af deres betænkninger.
+Lad os forsøge at gå videre allegro vivace, ma non troppo.
+Bemba, har, men det er ikke det hele.
+Jura skal ikke besvares large, men med jura.
+Hajdari blev udsat for et attentat.
+Der erhverves viden, opøves færdigheder og indøves social adfærd og vilje til integration.
+Rocard havde for øje, og jeg komplimenterer ham for initiativet.
+Når det gælder et så vigtigt emne, burde usle kneb ikke forekomme.
+Den første er til de specialiserede producenter af oksekød med besætninger af ammekøer.
+Efter lyrikken over til faktaene.
+Kært barn har mange navne.
+Jeg gror, at der stadig er gennemført særdeles lidt på disse tre områder.
+Skam over troldmandens lærlinge!
+Jeg mener, vi bør se nærmere på, hvordan vi kan udjævne kløften.
+Nederlandske byer er allerede blevet oversvømmet af horder af polakker, rumænere og bulgarer.
+Det er sådan nogle uroplevelser, man har med bureaukratier.
+Men nej, jeg vil ikke være med til at plukke de europæiske skatteydere.
+For dette efterlader sandelig et grumset billede.
+Roth, give sin mening til kende.
+En forøgelse af udbuddet gavner ikke per definition landbrugsindkomsterne.
+Den glemmer sit proletariat.
+Det står dog klart, at der skal holdes konstant øje med grænseværdierne for karcinogener.
+Jeg kan desværre ikke svinge en tryllestav, fordi jeg ikke har nogen.
+Derfor taler vi ikke om quid pro quo, men om et forhandlingskapitel som sådan.
+Mascarpone skal nu en gang ikke være en kur mod halsbetændelse.
+Jeg skal sørge for, at spørgeren får denne brochure.
+Dette er ikke bare alvorligt, kære venner, det er uhæderligt og meget trist.
+Jeg har i høj grad nydt at arbejde sammen med hende.
+Stalinismens tvillingebror var nazismen.
+Vi skal være retfærdige, men ikke salomoniske.
+Der skete ikke mændene noget, men pigen blev dømt for hor efter sharialoven.
+I denne sal bør den italienske præsident altid kun omtales med respekt og ærbødighed.
+Det vedrører oftest en skade på bulkskibenes skrog, som skyldes forkert lastning eller losning.
+Hutchinson og jeg selv havde den fornøjelse af besøge.
+Det udgør efter vores opfattelse et stort problem i forhold til soft law.
+Man bør naturligvis på sigt forbyde æglægningsbure.
+Det er et højpolitisk projekt, højpolitisk!
+Ingen ved, hvor råvarerne kommer fra, og hvordan de er blevet udvundet.
+Skyldes det færre pushfaktorer eller strammere indvandringskontrol i visse lande?
+Vi vil alle opleve vores nemesis, når tiden er inde dertil.
+Der foreligger dog ikke nogen sådan ansøgning p.t.
+Medlemsstaternes bidrag udgør en fyrretyvendedel af deres nationale udgifter.
+Det er i grundskolen og gymnasieskolen, der skal undervises i den nye teknologi.
+Det, der bliver tilbage, kan såmænd blive vanskeligt nok endda.
+Der er en økonomisk pol, og der er en monetær pol.
+Kuzniecovs liv være i fare, fordi han er homoseksuel.
+Dette er en usocial, om ikke endda asocial politik.
+Ustemplede æg er en gave for en svindler.
+En undertiden dvask dømmende magt og mistanker om selvcensur giver grund til bekymring.
+Emigration er et gammelkendt fænomen, som for nylig har ændret karakter.
+Der er tale om en binational debat.
+Der ligger mange skoler i området med et forøget radonniveau.
+Den er vi hoppet på for ofte.
+Jeg mener ærlig talt, at formandskabets svar ramte sømmet på hovedet.
+Errare humanum est, perseverare diabolicum.
+Vi kan besmykke fordomme, eller vi kan modvirke dem.
+At der skabes et fait accompli, undergraver chancerne for en forhandlingsløsning på konflikten.
+Under det gamle zarregime og sovjetånden har det været svært at lære reelt demokrati.
+Mange virksomheder bliver opkøbt eller modtager finansiel bistand gennem disse fonde.
+Markedsprisen fastsættes på engrosbørserne for strøm.
+Fremmedhad og racisme er uvelkomne bivirkninger af, at forskellige kulturer lever sammen.
+Vi mødte de russiske, ingusjetiske og tjetjenske ledere og medlemmer af deres regeringer.
+Jeg kunne være fræk og sige, at det er åndssvagt!
+Talibanernes magtovertagelse stiller udviklingen århundreder tilbage til den mørkeste middelalder.
+Formålet med dette forslag er at beskytte bankafregningssystemerne mod deltagernes insolvens.
+Kibakis ministre, der håbede at blive medlemmer af parlamentet, forkastet ved valghandlingen.
+Gevinsten fra en større lastvogn vil blive ædt op af den stigende transportmængde.
+Motordrevne køretøjer og påhængskøretøjer
+Allerede i går ville jeg dadle udtrykket cirkus.
+Begrænsning af markedsføring og anvendelse af pentabromodiphenylether
+Tutsierne fra niloticfolket udgør mindretallet, men de dominerer regeringen og hæren.
+Derfor er der behov for at indbygge et early warning system.
+Bygninger, der ligger øde hen, vil uvægerligt blive syge, hvis de ikke kontrolleres regelmæssigt.
+Der er forskel på, hvordan medlemsstaterne håndterer leasingaftaler.
+Vi har ment, at vi meget nemt kunne få gas fra det kaspiske område.
+Den foreskriver, hvordan man skal spise, klæde sig og endda gå på toilettet.
+At gøre noget retrospektivt og gældende for fortiden er dårligt.
+De sammenligner det med eugenikken i første halvdel af sidste århundrede.
+En sådan adfærd ville medføre en ret stor badwill.
+De maoistiske guerillaer fortsætter deres ødelæggende hærgen.
+Jeg har indtryk af, at vi køber katten i sækken.
+Sahelområdet kan kun gøres sikkert ved at forbedre befolkningens situation.
+Det har ikke noget med den ofte misforståede keynesianisme at gøre.
+Samtidig kan man absolut se et lysglimt i denne fase.
+Man frygter hyperinflation og massiv forarmelse.
+Et andet punkt, jeg vil skabe klarhed over, er diskussionen om vin, whisky etc.
+Rådet er jo ikke engang parat til at nægte denne klike indrejsevisum.
+Man har stadig ikke løst problemet med tilsætningsstoffer, aromastoffer og ekstrationsmidler.
+Et bedre resultat kan opnås med den chilenske encaja.
+I de nationale afrapporteringer mangler der for det meste en inddeling efter køn.
+Jeg ved, at ulovlig skovhugst blot en den synlige top af isbjerget.
+Det er kort sagt en ommer.
+Betyder det, at alle eksterne konsulenter er stygge?
+Busfabrikanter beviser jo allerede i dag deres store kapacitet, hvad angår sikkerheden.
+Jeg skal udtrykke mine bedste lylønskninger for det østrigske formandskab.
+De nedbrændte skove bør retableres under hensyntagen til de klimatiske og økologiske særpræg.
+Kørsel med tændte lygter i dagtimerne og brug af sikkerhedsbælter resulterer i færre trafikulykker.
+Erhvervsuddannelse skal også omfatte sprogkurser inklusive fagsprog.
+Denne nye teknologi fører også til en dataudveksling af uanet omfang.
+Jeg har derfor absolut ingen hard feelings over for nogen som helst.
+Jeg støtter ikke en etbarnspolitik!
+Tallet er betydeligt lavere end i slutningen af firserne og begyndelsen af halvfemserne.
+I de seneste år har denne type arbejde vundet frem med syvmileskridt.
+Vi tabte vores sidste søslag for hundrede år siden.
+Kasakhstan er nemlig et land, man næsten kan betegne som eksplosivt.
+Sammen med kalium danner dette et saltstof, kaliumbitartrat, der udfælder ved påvirkning af kulde.
+Vores vinfremstilling har rod i ældgamle kulturer og traditioner.
+Det gælder restauranterne, souvenirbutikkerne, modebutikkerne.
+Der fortsætter landmænds og dyrs pinsler uformindsket.
+Mit indlæg handler om den nordiske pasunion.
+Se på, hvor let det er nu om dage at downloade musik fra internettet.
+Jenin er uden tvivl et dramatisk eksempel.
+De er normalt gemt bort i budgetposterne for reserveoplysningstjenester.
+Bed ikke de europæiske institutioner om noget, som de ikke kan levere.
+Deres efterfølgere har rejst væggene, købt reoler og stillet mapper på plads.
+Et godt eksempel er magneter i legetøj.
+Det kunne måske være en god ide at tage fat på denne debat.
+Det indre marked er ikke årsag til omstruktureringerne, det er modgift mod disse.
+Denne forklaring er en kimære.
+En gletscher smelter hurtigere, end stålet til skinner størkner i støbeformen.
+Almunia er blevet mødt med.
+Det er bestemt ikke en politik, der primært er baseret på lønbegrænsninger.
+Perler er små og svære at finde.
+Det er sådanne beslutninger, der har bragt hele den fælles fiskeripolitik i vanry.
+Godt, lad os tage guderne ud af spillet.
+Taler vi egentlig om lån, hvor hver eneste øre skal betales tilbage med renter?
+Deepwater er bare et symptom på peak oil.
+Dyrlægerne får hjælp fra offentlige assistenter.
+Amsterdam er ingen fiasko, det er et lille skridt fremad.
+Skadefryd er den eneste ægte fryd, siger kynikeren.
+Det ophidsede i hvert fald fonde og forskere på sundhedsområdet.
+Mine damer og herrer, vi skal afmystificere økologisk landbrug.
+Gulliver troede dog, at han var kommet til giganternes land.
+Papadimoulis for det udmærkede arbejde, han har udført.
+Tænk, hvis hans koncept virkede lige så godt på casinoet.
+Satyagraha er en ikkevoldelig kollektiv aktion.
+Det påpeges, at vi nu skal stille krav om afmilitarisering af tre grundlæggende årsager.
+Mumias juridiske muligheder for at undgå døden er meget begrænsede.
+Dette udgangspunkt er typisk marxistisk.
+Farage for ikke at respektere det irske demokrati.
+Jeg mødte familierne til de kuwaitiske fanger.
+Tilgiv mig, men jeg har lidt mavepine.
+Vi skal alligevel ikke stikke en kæp i hjulet for vejtransporten, tværtimod.
+Cunha for at have erindret os om dette.
+Kinnocks reformplan er som helhed både visionær og realistisk.
+Vi bør ikke diskutere et så følsomt emne som britisk oksekød så lemfældigt.
+Det handler om kalorieoutput, ikke blot om kalorieinput.
+Der er dog ikke nogen af os, der har grund til at være kæphøj.
+At påpege dette er ikke at føre stereotyper til torvs.
+Det andet er at hindre udbredelsen af atomvåben og naturligvis også af spaltbare stoffer.
+Nedbringning af gasemissioner fra husholdningsaffald er en af de uudnyttede muligheder.
+Forslaget til betænkning om grønbogen er et vigtigt bidrag til spørgsmålet om byudvikling.
+Det er grunden til, at ordningen kun gælder for nyansatte.
+Såvidt min funktion som ordfører.
+Det første er forordningen om ulovligt, urapporteret og ureguleret fiskeri.
+Så er det det rene bluff for forbrugerne.
+Det var dog mere en dyr og mondæn hobby end en økonomisk aktivitet.
+Den er dog ikke alene om dette comeback.
+De hidtil usete stigninger i oliepriserne tvinger en hel erhvervsgren i knæ.
+Dette fjerner en evindelig kilde til konflikt.
+Jeg tror, at der er store potentielle muligheder i bioplast.
+Kofoed vil jeg sige, at vi fuldt ud tilslutter os hans udtalelser om kvoteringen.
+Dalitterne er nærmest ikke blevet nævnt.
+Disse mennesker har brug for mere end words.
+Selv en lille fødevarevirksomhed ved, hvilke ingredienser brød eller snacks indeholder.
+Howitt og andre har fremført.
+Det skal være en enstemmig beslutning i henhold til wienerkonventionen om traktatret mellem stater.
+Der er brug for en grundig undersøgelse af markedet for credit defalut swaps.
+Milosevic var ikke uvidende om, at det var det, der kunne blive konsekvensen.
+Vi har ikke opstillet særlige genvindingsmål for glødelamper, kun for lysstoflamper.
+Alle sprang for livet, og det var børnene, der blev hårdest ramt.
+Interessenterne inddrages aktivt i alle stadier af dette feasibilityprojekt.
+Anastassopoulos, endnu bedre!
+Syrien forbliver en etpartistat, selv om man taler om at ændre denne situation.
+Skal vi sætte en etiket på hvert enkelt riskorn?
+Vi afviser et ubremset skub i retning mod integration.
+Størstedelen af markedet er sikkerhedsudstyr til køretøjer som airbags og sikkerhedsseler.
+Vi har en proklamering af, at de ønsker at opsige rumvåbenaftalen.
+Han valgte et æsel som partisymbol.
+Som trofast europæer må jeg derfor stemme imod denne betænkning.
+Derved sættes der måske spørgsmålstegn ved det, som dr.
+Hamas vil formodentlig komme ud af konflikten militært svækket, men politisk styrket.
+To af mine sønner taler polsk.
+Også det tærer på de videnskabelige ressourcer.
+Det betyder altså, at irerne og belgierne har begået en brøler i denne sag.
+Europa har nogle fordele, der giver en vis pondus i den globale debat.
+Jernbanerne eksisterer allerede, men skal udstyres til lyntogstrafik.
+I den første fase er der tale om feber og svækkelse.
+Bautista, med hans betænkning, som har opnået enstemmighed.
+Vi er mange, der husker vores afdøde kollega.
+Den kan derfor betragtes som et passende refinansieringsinstrument.
+Påny viser det sig, at der ikke er grundlag for en positiv menneskeopfattelse.
+For det tredje skal vi lancere en stor europæisk plan imod afindustrialiseringen.
+Han gentager nu sit gamle refræn med nye ord.
+Vi må også kunne leve med denne højfornemme foranstaltnings nonsens.
+Kommissionens nye forslag indeholder en god ordning for samforbrænding af byaffald i cementovne.
+Om en time vil jeg kontrollere, om taxierne igen må køre ind.
+Desværre er listen over fobier længere end som så.
+Der er medlemsstater med moderselskaber og medlemsstater med datterselskaber.
+Alle vandlevende organismer blev udryddet i en afstand af op til flere hundrede km.
+Maat interesserer sig herfor og udarbejder en betænkning om emnet.
+Mombaur, for det fantastiske arbejde.
+Landet skal genindføre drakmen, fordi landets medlemskab af euroområdet er uholdbar.
+Hun har ikke ladet sig aflede af al ståhejen omkring sig.
+Jeg har astma, og jeg fik to anfald i denne bygning under sidste mødeperiode.
+Der vil ske en delvis ophævelse af forbuddet for gelatine, talg og sæd.
+Dengang måtte man stadig spille hårdt bagfra.
+Anvendelse af silikone gør det muligt at rekonstruere kroppens ydre.
+Vi har nu fundet det design, som forhåbentlig dur til de fleste medlemsstater.
+Gnisten går ikke engang videre til medlemmerne her i mødesalen.
+Det understreger, at man har gjort knæfald for industriens interesser her.
+Vi har tiet alt for længe i denne sag.
+Formandskabet glæder sig over, at protokollen for ueksploderet ammunition er trådt i kraft.
+Tovbaner er løbende underlagt højt specialiseret nytænkning.
+Ordføreren nævnte, at yngre og yngre mennesker rammes af forskellige former for tumorer.
+Jeg troede, at verden havde fået nok af smarte finansielle fiduser.
+Gibraltar er rent faktisk et oversøisk territorium og ikke en britisk koloni.
+Det trækker store veksler på en sådan arvs bæreevne.
+Bruegheløkonomerne har mistet troen og går nu ind for øgede udgifter.
+De var meget klogere, meget mere snedige end som så.
+Sørøveri er ved at blive en trussel for skibstrafikken på verdensplan.
+Mens vi taler om datapakker, vil jeg komme ind på spørgsmålet om netneutralitet.
+Fru kommissær, tøv ikke, gør noget ved sagen!
+Det er et orkester fra den tyske hær, der spiller.
+Es un gran placer contar con su presencia.
+Cornelissen for hans fremragende betænkning.
+Et lyssignal kan være i orden, men et lydsignal er måske lidt tvivlsomt.
+I en udateret meddelelse hedder det, at det alt sammen ikke var sådan ment.
+Heri fæstes der særlig opmærksomhed mod sexturisme.
+Dess for hans fremragende stykke arbejde.
+Hvad folkets repræsentanter har gjort, må de også kunne gøre ugjort.
+Vi nød en hyggelig sen middag sammen.
+Aviær influenza fremstilles som en yderligere rytter i åbenbaringen.
+Rutinemæssige obduktioner gennemføres af ministeriets dyrlæger på alle slagtede dyr.
+Aha, der er et øsamfund, altså er det en øregion!
+I dag er mange lægemidler, der ordineres til børn, ikke udviklet specielt til dem.
+Det sidste punkt er kuriøst.
+Kystvagten skal være søfartssikkerhedsagenturets lange arm.
+Man får ikke løfter ført ud i livet ved at tale fabelsprog.
+Belders betænkning er ingen undtagelse, men den rummer vigtige og relevante punkter.
+Og også tak for dine venlige ord.
+Diskussionen om, hvordan evalueringen skal foregå, er unyttig og desorienterende.
+Undersøgelsesudvalgets indsats har pirket til dem, der foretrak at lukke øjne og ører.
+Også egreneringsfabrikkerne er i fare.
+Dens valuta, tolaren, kan betragtes som en af de hårde europæiske valutaer.
+Det er en forkert måde at tænke på, og den er ødsel.
+Parlamentet er sprunget op som en tiger og landet som en sengeforligger.
+Alligevel støtter vi tobaksdyrkning og skærer ned på cannabisplanter.
+Trods problemerne vil vi gerne gøre vejen til fred lidt mindre ujævn fremover.
+Luftruter, færgeruter, togruter og busruter i og til disse fjerne områder udliciteres.
+Nogle synes, at en lille gruppe af de såkaldte vismænd skulle fremlægge forslag.
+Det er afgørende, at det grundlæggende kemalistiske tabu brydes.
+Lanzarote er ikke det eneste eksempel, der er mange flere.
+Yassin havde modbydelige forbrydelser på samvittigheden.
+Det andet spørgsmål er den europæiske flyindustris fremtid.
+I henhold til rapporten er det forhold, der gælder for blåhaj eller forkert.
+Selv mistænkte forbrydere har krav på en rettergang, på en fair trial.
+Som skyggeordfører for min gruppe fik jeg rollen som opmand.
+En sidste bemærkning om klisterskinke.
+Jeg fniste ikke over bemærkningen.
+Og jeg har stadig ikke fået min kuffert!
+Senere, mens hun var under stuearrest, deltog hun i demonstrationen og blev arresteret igen.
+Jeg har mit tomatsikre tøj på, hvis nogen har noget i tankerne.
+Af en jomfru at være, var det en meget livlig jomfru!
+Der er en telefonlinje for nødopkald i en række lande nu.
+Mange af de velkendte antibiotika er i dag enten blevet ineffektive eller upålidelige.
+For det første spørgsmålet om price improvement.
+Først i dag reagerer vi på en af det kommunistiske diktaturs mest grufulde forbrydelser.
+Denne finkæmning lover ikke godt for fremtiden.
+Det er et uopdyrket, jomfrueligt land.
+Vi har allerede haft et kejserligt mare nostrum.
+We can work it out, we can work it out!
+Der kommer stadig større tabstal.
+Asien ligger måske langt væk, men områdets fremtid vil påvirke os alle.
+I flere medlemsstater er der et særligt tillidsforhold mellem klienten og den juridiske rådgiver.
+Prækommercielle indkøb giver mulighed for at tage denne anormalitet op.
+Den må ikke dolke de demokratiske kræfter i ryggen.
+Kasjanov, for at forberede topmødet.
+Men sejren har en bismag for mennesker i hele verden.
+Man hører snakken i krogene og venter.
+Denne fremgangsmåde lugter næsten af deling af rovet.
+Ej heller er fædrene uarbejdsdygtige som følge af fødslen.
+Under den nordlige dimensions auspicier kunne vores fælles søstrategi blive noget endnu større.
+Jensens udmærkede betænkning medtager meget af det, mit udvalg har foreslået.
+Men vi skal stadig have vedtaget mål på delområder som fiskeri, landbrug og skovbrug.
+Disse produkter bør ikke blive et dyrt nichemarked.
+Det var et uhæmmet angreb på arbejdstagerne.
+Er det politisk nærsynethed eller enfoldig hævngerrighed?
+Tværtimod er vi begyndt at gøre det for den kommende round.
+Vi har også ofte flakket omkring.
+Dette skal gøres klart, ellers bliver det bare en kakofoni om traktaten.
+Ingen dele af det menneskelige legeme, ingen celler, ikke den mindste molekyle kan patenteres.
+Fontana, har haft en personlig indflydelse på dette gode samarbejde.
+Hovmod står for fald, og vi bør nok ikke være alt for hovmodige.
+Der bruges kemiske stoffer eller teknikker til vores hudpleje, fødevarer og sundhedsprodukter.
+Kravet om stærkere finansielt fodfæste skal derfor afvises på denne baggrund.
+Man føler, at man står foran en væg fyldt med brevordnere.
+For os skal der være databeskyttelse, ellers er aftalen dødfødt.
+Også blandt rektorer og i skolevæsenerne kan der herske stor usikkerhed.
+I mange år arbejdede han med sikkerheden på havgående fartøjer.
+Hussein er en uappetitlig, men åbenlyst nu også militært svækket diktator.
+Derfor kan vi ikke støtte dette gensidige rygklapperi.
+En forudgående obligatorisk briefing er derfor et mindstekrav.
+Tilskyndelser til avling har aldrig vist sig at fungere.
+Den sociale misere i storbyer er grobund for organiseret kriminalitet.
+Hvorfor så ikke frugt til saftfremstilling?
+Det kan man opnå ved at sætte grænsen ved max.
+Betænkningen lader det være usagt, hvilke motiver der ligger bag en nærmere samordning.
+Fiji risikerer at miste investorernes tillid.
+En kinesisk leverandør leverede en maling, som den ikke burde have leveret.
+Det omfatter alt fra lastbiler til jetmotorer til fly og telekommunikationsudstyr.
+Samtidig ties kvinder simpelthen ihjel i de fleste af vores partnerlandes strategiske programmer.
+I enkelte af disse lermineraler har man rent faktisk fundet forhøjede dioxinværdier.
+Altædende dyr er virkelig altædende.
+Frihandel er ikke det samme som laissez faire.
+Vi har brug for en håndværker, en altmuligmand, ikke en statsmand.
+Der var lidt uenighed hist og pist, men hvor er der ikke det?
+Det er rart at se ham rødme.
+Her fremmer jobrotation udviklingen af kvalifikationer.
+Det er årsagen til, at vi ønsker at placere byaktioner centralt i samhørighedspolitikken.
+Amerikanske arbejdstagere skifter i gennemsnit profession tre gage i løbet af deres levetid.
+Men det estiske samfund er blevet opdelt i vindere og tabere.
+Men jeg noterer mig det og vil ved først givne lejlighed indhente det forsømte.
+Der vil blive gjort forsøg på at pådutte alle investeringstraktater den fulde grønne dagsorden.
+Den, der ikke vil anerkende det, indtager et ret provinsielt sysnspunkt.
+Der er minimum behov for to beddinger til at kunne fortsætte en indbringende skibsværftsaktivitet.
+Gyanendras demokratiske sindelag har aldrig været særlig indlysende, tværtimod.
+Det er virkelig dråben, der får bægeret til at flyde over.
+Det fører til, at døtre bliver udstødt, og pigefostre bliver aborteret.
+Enkle smertestillende midler, hostemedicin og vitaminpræparater er sådanne tilfælde.
+Det andet vigtige punkt vedrører bobehandlinger ved insolvens.
+Måske er dette en meget uromantisk ting at sige på en sådan formiddag.
+For højintensive sonarer er prisen for høj.
+Fra en enmandsgruppe til en anden skal der derfor lyde et stort tillykke.
+To elementer er væsentlige, hvis vi skal redde de sidste fiskeområder fra total udfisken.
+Hvis en chauffør kører i beruset tilstand, mister han kørekortet umiddelbart.
+Dimas, at det ikke er tilfældet.
+Der manglede jo sågar data for nogle sektorer, pikant nok også for uddannelsesområdet.
+Den afgørende europæiske merværdi er tæthed på borgerne.
+Først kaster man helt tilfældigt økonomisk stærke og økonomisk svage økonomier i samme gryde.
+Det er et meget kompliceret spørgsmål om, hvordan man fræser kød af knogler.
+De europæiske institutioners politiske interventionisme udvikler sig med lynets hast.
+Det kan opjustere sine finansielle behov for at gennemføre sine nye beføjelser.
+Izquierdo taknemmelig for, at han har behandlet et bredt spektrum, der imponerer.
+Overraskelsen var, at hunden var der og ikke gøede.
+En hel vrimmel af medlemsstater samarbejder kun modvilligt.
+Det er en mulighed for at omorganisere hele den paneuropæiske og globale finansielle arkitektur.
+Man bør nøjes med et lavere istandsættelsesniveau for de gamle kraftværker.
+Angrebene og episoder med journalister, der fik tæsk, mangedobledes.
+Er en sådan dynge papir nu også den mest effektive kontrolmekanisme?
+Vi skal gennemsøge alle krinkelkroge for at finde dem og begrænse dem mest muligt.
+Zoologiske haver er enten privat eller offentligt ejede, og standarden kan svinge meget.
+Det ville utvivlsomt forøge visheden om korrekt lovvalg og forventet udfald af tvister.
+Barometre kan gå i stykker eller blive utætte, så kviksølv havner i miljøet.
+Normalt skal bilerne være registreret i den medlemsstat, hvori ejeren er bosat.
+Ryd op i junglen af personaletilskud!
+Alligevel oplever vi i dag en nævekamp, som ikke respekterer særlig meget.
+Fru formand, jeg vil gerne have, at min tilstedeværelse igår fremgår af protokollen.
+Vi taler ikke længere om en bue, men derimod om et frit fald.
+Sydøsteuropa er et knudepunkt for flere hovedforsyningsledninger for energi.
+Forbuddet imod tinholdige forbindelser er efter min mening forhastet.
+Så lad os ramme en pæl gennem det argument.
+Nogle mener også, at markedsordningen for sukker er en dinosaur.
+De har løjet og fundet på.
+Det er ofte også vigtigt for paftienterne.
+På lægmandssprog betyder det, at jeg kan skelne mellem en bordeauxvin og en rhinskvin.
+Etableringen af gode relationer er en tovejs proces.
+Laos er et af verdens fattigste lande.
+Det svirrede med rygter om april.
+Et ton hvede kan blive solgt flere gange, inden det når frem til møllen.
+Jeg stemte også for fleksible rater.
+For det andet skal de forebygge antændelse af eventuelle atmosfærer af denne art.
+Det var bramanernes kampråb.
+I nogle lufthavne behandles passagererne nærmest som ubudne gæster.
+Demokratiske nationalstater bør have enebeføjelse på dette område.
+Begge forældre skal være bærere af dette gen, ellers forekommer defekten ikke.
+Min gruppe afviser en sådan rabiat løsning.
+I det forrige århundrede lærte man fem officielle sprog i den lavere karpatiske region.
+Det er påvist, at det høje niveau af blypartikler i atmosfæren påvirker børns intelligenskvotient.
+Med hensyn til bioovervågning er vi helt enige.
+Titanic var bygget til at være et skib, der ikke kunne synke.
+Det angår også det jugoslaviske område.
+Vores frygt stammer også fra en gådefuld selvmodsigelse.
+Det er ikke lykkedes, alligevel har den afsvækket denne beslutning.
+Jeg mindes, at der i de græske krukker ikke var olie, men olivenolie.
+Konflikten brød ud i lys lue i marts sidste år.
+Men de er notorisk ineffektive i dag.
+En fed hamburger bliver jo ikke sund, fordi der tilsættes nogle vitaminer.
+Dette er et gammelt opråb, for problem har eksisteret i lang tid.
+I modsat fald skal man straks holde op med dette pjat.
+Udviklingen af opsendelsessystemer er en nødvendig forudsætning for enhver anden aktivitet i rummet.
+Det gælder ikke mindst reglerne for metylbromid.
+Fru formand, det er ved at blive ensformigt at tale om de tyrkiske grovheder.
+Hvad havinspektionerne angår, er tallene temmelig rystende.
+Der bliver europæiske skolemestre i atletik, fodbold, basketball, kampsport eller svømning.
+Turkmenistan er afgørende for sikkerheden i regionen og kampen mod narkotikahandel.
+Rådet har blokeret for adskillige planer for ansjosfiskeri.
+Jeg har endnu aldrig mødt en forbruger, der er vildt bekymret over carrageenan.
+Efter min mening er dette en meget burokratisk ændring.
+Det er min antagelse, at byggespekulanterne udnytter den skrøbelige valencianske autonomi.
+Et år senere er det nu en fuldstændig uappetitlig slimet klump.
+Vi har allerede oplevet store prisstigninger på madvarer sidste år i august.
+Fiberemballage, f.eks., kan let fremstilles af fornyelige råstoffer, der kan genvindes.
+Gayssots kommunistiske lov er i den forbindelse den første af slagsen.
+Set i bakspejlet var den sidste udvidelse, uden uddybning, overilet.
+Det tredje politiske fagområde, som jeg vil berøre, er arbejdstiderne.
+Hætteklædte demonstranter kastede med brosten mod politiet og smadrede butikker uden at blive fanget.
+Grosch i denne forbindelse.
+Dounreay er blevet lukket af nuklearinspektoratet.
+Denne agreement kan kun være en overgangsordning.
+Der skal være en diligenspligt.
+Forordningen er også vigtig for de unge, der sender en sms til deres kæreste.
+Og vandets kvalitet og renhed skal også forbedres.
+For arbejderne er der imidlertid sulteløn og evig nøjsomhed.
+Den må ikke være hullet som en si.
+Sydsudan skal støttes på alle tænkelige måder.
+Nogle kommentatorer har omtalt disse bestræbelser som politisk nekrofili.
+Rusland har også en stor betydning som brobygger mellem de europæiske og asiatiske lande.
+Tobak af høj kvalitet etcetera, og mindst mulig støtte til den.
+Det er en anmassende, hovmodig og arrogant holdning fra den tyske forbundskanslers side!
+Straffen bør udmåles i form af strafferetlige sanktioner, ikke civilretligt ansvar.
+Det indre markeds undertiden meget snærende regler finder anvendelse på skovprodukterne.
+Et af de hotteste emner i denne diskussion er spørgsmålet om grænseværdier.
+Medmindre vi, som jeg har sagt, vender bøtten.
+Se ud over det store ocean!
+Det styres af hemmelige udvalg, brovtende ansigtsløse bureaukrater og foregivet ansvarlighed.
+De indeholder meget lidt pcb og andre farlige stoffer.
+De tilhører en svunden tid.
+Kinesiske internetbrugere skal kunne få adgang til ucensurerede informationer.
+Fremtiden er æg fra fritgående høns.
+Forfalskninger er big business.
+Og vi må ikke gøde jorden i denne sag.
+Det er jo det problem, vi i stigende grad blamerer os med!
+Sudan er stadig et urocenter, og mod nord er der den allestedsnærværende yderligtgående islamisme.
+Vira kan have uforudsete konsekvenser for computerbrugere.
+Jeg går helt ind for at løse anakronismer.
+Fjernsynets subkultur, sport præget af hooliganer, narkoens pseudoparadis.
+Terningen er ikke altid så smuk, fordi man kan se skillelinjerne.
+Fangsten foregår under anvendelse af en slags nylonstrømpe, som fisker hele områder tomme.
+Hadjigeorgiou, som også er til stede.
+Uangribelige regionalt fremstillede produkter sælger heller ikke længere.
+Jeg vil gerne have, at vi ikke skærer alle over en kam.
+Sidste år fortalte videnskabsmændene os, at kullerbestandene var ved at svinde ind.
+Emma er lige kommet tilbage.
+Madrid er en vanskelig part i denne sag, i sagen om regionerne.
+Det blev sammensat af finansministre, som var truet af en nedjustering af deres statsgæld.
+De ubenyttede bevillinger skal ikke hver gang overføres til efterfølgende år.
+Når en tyv bliver arresteret, bliver alle oplysninger om vedkommende offentliggjort øjeblikkeligt.
+I det konkrete tilfælde drejer det sig om sønæringsbeviser.
+Internettet har en aura af fremskridt.
+Tillid kan hverken dekreteres eller købes.
+I mange franske og engelske byer er der allerede slum, som medfører mange problemer.
+Vores topidrætsfolks sundhed og ydeevne påvirkes på afgørende måde af, hvad de spiser.
+Alle i dette lokale ved, at sådanne sanfundsprocesser tager deres tid.
+Det andet spørgsmål er specielt, og det går på beskyttelsen af den hvide haj.
+Dijkstal for deres støtte til vort år mod racisme.
+Denne del af monitoreringen er derfor også meget, meget vigtig.
+På alle tunbåde er der uddannede statslige observatører om bord.
+Direktivet begynder imidlertid at knirke, og en revision kan ikke udskydes i det uendelige.
+De sænkede bomlængden, men de øgede deres aktivitet.
+En knast, som vi stadig har tilbage, er lønnen.
+Macartney sagde, var det et offer for barbariske konservative nedskæringer.
+Et sidste element, som visse parter insisterer på, er dræn til drivhusgassen.
+Middelhavsskoven, der udgør et afskærmende bælte mod dette fænomen, ødelægges nådeløst af skovbrande.
+Hvordan forholder det sig helt konkret med loins af tun og tunkonserves?
+Glorværdig er sejren, ærværdigt er nederlaget, siger man.
+Voggenhubers advarsler til side.
+Der skal i byer, kommuner og amter ansøges om et utal af vejrettigheder.
+Det kræver en tidobling af de nye installationer snarere end andelen af energiforbruget generelt.
+De langsigtede virkninger af ecstacy er stadig ukendte.
+Amerikanerne bruger et tilsvarende beløb til vedligeholdelse af plæner!
+Takket være bioteknologien produceres insulin nu på en meget sikrere, homogen og stabil måde.
+Min hustru er formand for sognerådet.
+Det fremgik også i går på seminaret om cyber crime.
+For i vandbassinet skulle der jo også være andre isotoper end cobalt og caesium.
+Her bør vi i endnu højere grad have opmærksomheden henledt på træbyggeri.
+Økonomisk vækst og jobvækst nedbringer ikke fattigdommen.
+Borchert og de øvrige europæiske landbrugsministre har svigtet.
+Pat, vi er sultne, vi er meget sultne, og vi har appetit på forandring.
+Det er punkter, man skal bide mærke i.
+Vi er blevet legitimt rørt over de rwandiske flygtninges skæbne gennem de seneste år.
+De nye grænseværdier betyder, at sodpartikelfiltre i praksis bliver obligatoriske.
+Jeg har set, at de første bugseropmudringsfartøjer nu er sat i gang.
+Vi har tygget drøv på denne sag i årevis.
+Der er spørgsmålet om forvaltning, det, som nogle kalder gouvernance.
+Caudron, for at han kan stille et supplerende spørgsmål.
+Har han tænkt sig at spille i lotteriet eller hvad?
+Hemmelighedens dyne er løftet.
+Vi behøver ikke skabe mere papirarbejde og administrativt bøvl for de allerede betrængte landbrugere.
+Goepel hjertelig tillykke med hans afbalancerede betænkning.
+Det skal også gøres klart, i hvilket omfang nyskabelser såsom elmotorer faktisk dækkes.
+Men også dette argument gendrives og væltes af den bestemmelse, der indfører tværnationale medlemmer.
+Kommissionen skal her kort før jul roses for nogle gode og upåklagelige forslag!
+Derved bliver udviklingen af nye former for uægte selvstændighed sandsynligvis fremmet.
+Whitehead for deres konstruktive bidrag til direktivets forbedring.
+Kouchners indflydelse, måske ikke har haft den effekt, som vi alle kunne ønske.
+Jeg vil give endnu et svar på spørgsmålet om en ny standard for akustik.
+Danmark har mistet sin selvstændige veterinære status.
+Der er myg over det hele, og stanken er uudholdelig.
+Mælkeoverskuddet skal opdæmmes på nationalt plan ved at indføre europæiske krav.
+Mindretal som uigurer og mongoler begrænses i deres rettigheder og mister kulturel identitet.
+Altså ingen skænderier om parmaskinke og svenske modeller.
+Jeg har ikke været ude for sure miner.
+Jeg tilslutter mig andres lykønskninger til ordføreren for en så bredt favnende betænkning.
+Markedsmisbrug og insiderhandel har givet mange småaktionærer tab.
+Men champagnen, med eller uden zero rate , kan vi godt lade blive hjemme.
+Sikke noget sludder og hvilken geskæftighed!
+Først det teologiske problem.
+Kalveboksene skal være indrettet således, at kalvene har et tørt areal at ligge på.
+Jeg er ikke selv spartaner, nok snarere athener!
+Wolfs betænkning i den foreliggende form ikke går ind på det i tilstrækkelig grad.
+Men jeg tror ikke på bilen som en fetich.
+Det er simpelthen uspiseligt.
+Set fra mit synspunkt skal denne nye procedure finpudses.
+Visse byregioner, især i forstæderne, har behov for støtte.
+Disse læskedrikke sælges frit på steder såsom skoler, sportsklubber eller diskoteker.
+Rajoelinas regering overtræder menneskerettighederne og undertrykker sine egne borgere.
+Maoriernes børn klarede sig væsentligt dårligere i skolen.
+Opmærksomheden har især været rettet mod hijab, det muslimske hovedtørklæde.
+Timor er mærket af skadernes og voldens omfang og den særlige politiske situation.
+Det er forskellen på at bruge træspåner og træfade.
+Det findes lande, hvor grundvandet hører til jorden og dermed totalt ejes af private.
+Vi ser de kinesiske uldhåndskrabber.
+Ferreira med deres betænkninger.
+Men de er naturlige stoffer og ikke farlige, syntetiske cocktails.
+Man har måske også gjort fremskridt med henblik på chaptaliseringens religionskrig.
+På tre år er omfanget af bedrageri blevet syvdoblet.
+Det ville resultere i ghettodannelse.
+Tejkowskis neonazistiske gruppe er synlig, ifølge avisen, men hvor er vi?
+Det er den grønne nevrose og optagetheden af nitrogenoxid, svovldioxid og drivhuseffekten.
+De steder, hvor situationen er vanskelig, kan man benytte definitionen af bylufthavnen som middel.
+Halogenholdige kulbrinter er meget farlige.
+Det er et kompliceret svar, og derfor er det også vanskeligt at kapere.
+Vi gider ikke høre på den slags historier!
+Dette ligner en nykolonial tankegang.
+Det er det, han kalder riot guns eller sådan noget.
+Det er en farisæisme, som hurtigst muligt må bringes til ophør.
+Gerningsmændene efterlod deres offer liggende på jorden smurt ind i blod.
+Vi hverken fremstiller eller sælger infanteriminer.
+Vi kan ikke høre tolkningen tydeligt på grund af det stærke ekko i salen.
+Gollnisch var formand for.
+På den anden side vil matroser igen blive brugt som syndebukke.
+Lønkløften har også individuelle dimensioner.
+Projektet bør opgives eller omarbejdes, så det beskytter vores nationale monumenter.
+Der har lydt et nej fra alle sider.
+Deres bekymringer over kvoteoverførslerne er ikke gået ubemærket hen.
+Rengøringspersonalet var før i tiden altid tidligt på færde.
+Udviklingen af samhandel på subregionalt plan bør ledsages af et større subregionalt samarbejde.
+Dette er vigtigt for unge søtunger, fordi denne art har en temmelig stor overlevelseschance.
+Her til morgen kikkede jeg på det websted, som rådsformanden nævnte.
+Ingen er så døv, som den, der ikke vil høre.
+Der kan ikke oprettes et bæredygtigt netværk, hvis dets knudepunkter er ramt af ælde.
+Hvilken atlet vil bevidst skade sit hjerte, lever, nyrer eller reproduktive organer?
+I de seneste tre år har en enkelt person administreret webstedet www.bankovnipoplatky.com.
+Nu bliver kødsektoren kontrolleret.
+Sker dette ikke, kan der også være behov for lovindgreb her.
+Den eneste hage er, at det ser anderledes ud i den virkelige verden.
+Siden da ser det ud til at have mistet noget af sin glans.
+Desværre vokser valmuer særdeles godt i tørke.
+Det ville være som at forsøge at bygge et murstenshus uden at anvende mørtel.
+Anoreksi og bulimi er indlysende eksempler herpå.
+Jeg vil gerne komme med en lille joke her.
+Jeg vil gerne nævne, at der er dryppet en dråbe malurt i bægeret.
+Det er så sikkert som amen i kirken.
+Det var denne grundtanke, der optog mig i interviewet.
+Helmer tager ganske enkelt fejl.
+Euroområdet har givet klippefast makroøkonomisk stabilitet.
+Jeg vil også omtale de lejre, som man på mit sprog kalder for omgrupperingslejre.
+Hvis alle udvalg havde udfyldt skemaet, ville evalueringen have været mere omfattende.
+Ingen behøver frygte for deres urtete.
+De to andre nye features er tilføjelser til proceduren.
+Man har indtryk af, at ploven er spændt for okserne.
+Jeg er derfor en arg modstander af kernekraft, når den praktiseres på denne måde.
+Vi siger, åh, infrastrukturen er ødelagt.
+Med en sådan opførelse vil der kun blive handlet med hajprodukter fra bæredygtige bestande.
+Ha, så meget for den gennemsigtighed, man hele tiden prædiker!
+Bliver kritik kvalt under en kåbe af tavshed eller ganske enkelt fjernet?
+Jeg henleder opmærksomheden på, at vores konkurrenter ikke læner sig tilbage og triller tommelfingre.
+Fem mennesker fik hænder eller fødder hugget af.
+Efter min mening er denne omrokering og forhøjelse af budgetressourcerne ikke selvbetjening.
+De har glemt de rødhårede!
+Trods visse oratoriske forholdsregler er denne tekst faktisk ikke afbalanceret og retfærdig.
+Disse problemer skyldes en hedonistisk og utilitaristisk holdning til det enkelte menneske.
+Den importerer bauxit til produktion af aluminium.
+Oxfam har erklæret, at uhæmmet liberalisering vil skade de mest sårbare.
+Moscovicis velvillige indstilling.
+Der er naturligvis stadig nogle uafdækkede områder, som for enhver pris skal belyses.
+Selv afgrøderne skal affugtes.
+I fægtekunsten er undvigemanøvrer effektive.
+Det er stadigvæk ost, og dette er stadigvæk tang.
+Gidseltagerne har været skruppelløse og har allerede pryglet eller skudt nogle mennesker.
+For det andet suggererer disse forslag indirekte, at der findes en menneskerettighed til abort.
+Selv solen blev fjernet fra vores åsyn.
+Med andre ord kræver det dunkelhed og hemmelighed.
+Akin, vi beder dig blive rask igen!
+Hvorledes forklarer vi det til husbyggerne i medlemslandene?
+Ankaras politikker kan fungere som model for de arabiske lande i regionen.
+Sassolis ord, og han burde retfærdigvis være en af mine politiske modstandere.
+De små nærbutikker er en del af de samfund, som de betjener.
+Han var galant og venlig i sine lykønskninger.
+Mere end et halvt århundrede senere har arvingerne til den revolution stadigvæk magten.
+Vi kunne også få nejflertal i andre lande, hvis man turde tage en folkeafstemning.
+De er værgeløse, uspolerede og søger tryghed.
+Dette vil bringe den europæiske dækindustri på forkant med teknologien på verdensplan.
+Bolkesteins holdning i det tilfælde, og jeg skal forklare hvorfor.
+Ud over specialfremstillede varer køber de almindelige fødevarer, som normalt ikke indeholder gluten.
+Under alle omstændigheder stemte jeg imod denne betænkning igen med fynd og klem.
+Hvor er åbenheden henne til at vedstå, at reformer gør ondt af og til?
+Perry, at han ønsker, at disse foranstaltninger skal være absolut faste og grumme.
+Disse symbolske gebærder kan få gamle sår mellem mennesker til at bryde op igen.
+Seguro, for deres fremragende betænkning.
+Der skal skabes ligevægt med femogtyve.
+Suharto og andre skal tage sig i agt.
+Syrerne saver på den måde muligvis den gren over, de selv sidder på.
+Vi må udbasunere de gode nyhedshistorier, når vi hjælper borgerne.
+Lokalerne er ikke nødvendigvis uhumske, underjordiske fangehuller med fugtigt halm.
+Der er hurdler, der skal overvindes.
+I fase to optræder der anfald og krampetrækninger.
+Landene forvaltede naturligvis den nyfundne frihed i overensstemmelse med gammel skik og gamle vaner.
+Erika kostede ingen menneskeliv, men kan have ødelagt mange menneskers levebrød.
+Vi kan selvfølgelig allerede tilbyde biler med nuludledning.
+To own the hearth, the stool and all!
+Den skal heller ikke have mulighed for at foretage uanmeldt kontrol på stedet.
+Nonprofitorganisationer blev også involveret.
+I sig selv beriger ozon som bekendt ilten, hvilket er sundt.
+Initiativet kommer sydfra, men det er vigtigt for vores overordnede naboskabspolitik.
+Abrikosen i bollen, schnitzelen i paneringen, frikadellen i paprikaen.
+Der er for det første de lavfrekvente stråler fra højspændingsledninger og heraf afledte frekvenser.
+Valgresultaterne var et nødråb.
+Ved begge lejligheder var jeg fuldstændig lamslået over, hvad de fortalte.
+Stipendierne er lave og fører allerede på den måde til social udvælgelse.
+De har ikke behov for encifrede procentvise forøgelser af indkomsten, mens de er arbejdsløse.
+Endelig skal der findes en løsning på spørgsmålet om offentlige abonnentfortegnelser.
+Jeg finder det uhørt, at fagforeningerne lokkede folk hertil med falske argumenter.
+Derimod er der en meget stærk sammenhæng mellem asbest og mesotheliom.
+Mere gennemskuelighed alene er imidlertid ikke nok, hvis vi vil have øget nærdemokrati.
+Det virker så enkelt ved første øjekast.
+Vi ved f.eks., at en meget stor smittekilde for salmonella aruba er brasiliansk soja.
+Det er konsekvenserne af førudvidelsen.
+Vi bekræftede også behovet for at holde fast ved amibitionsniveauet i forbindelse med konferencen.
+Der findes også ludfattige mennesker.
+Statistisk blændværk har også andel i dette.
+Fasthed betyder ikke rigiditet.
+Det er en af de mest katastrofale og kluntede episoder i diplomatiets historie.
+Denne ækle handel får ikke tilstrækkelig opmærksomhed.
+Det fik vi først i vores dueslag i løbet af formiddagen.
+Jeg kunne fortsætte med folkelige udtryk om bryggerier og fester i dem.
+Beijing er hovedstad i et af verdens mest hårdføre diktaturer.
+Disse små dysser er et synligt monument for loven om utilsigtede konsekvenser.
+Jeg er adræt nok til at gå ned fra sjette eller syvende sal.
+Han har givet ugedagene nye navne.
+Der kan konstateres en særlig aversion mod de slaviske sprog og kulturer.
+Om saksen er en smule polstret eller ej, kreperer dyret ynkeligt i den!
+Der er også behov for handling i tobisfiskeriet.
+Detaljerede ord og hensigtserklæringer om årsdagen i dag er ikke nok.
+Blyniveauet i kosten ligger et godt stykke inden for sikkerhedsgrænserne.
+Andre anvendelsesområder, herunder energiproduktion eller anvendelse som humus, berøres ikke.
+De eksisterer ganske enkelt ikke, og desforuden er der ingen imødekommenhed ved grænsen.
+Skal vi fjerne de store krucifikser på bjergtoppe, der knejser over byer og dale?
+Det er vores opgave at føre klicheen ud i livet.
+Oplysningerne skal være letforståelige.
+Man reagerer sjældent så muntert, som det var tilfældet på det tidspunkt.
+Sygdomme som tyfus og kolera truer, malaria, denguefeber.
+Det gøres helt klart i denne betænkning, og det tager jeg hatten af for.
+Det er sofisternes metode.
+Alle alternativer hertil er blot udsigt til en farligere og mere kværulantisk fremtid.
+Hvad angår adgangen til markedet, så er dette noget lettere inden for busbefordring.
+Der findes aylstatistikker.
+Journalisterne på ugebladet er også blevet dømt for ærekrænkelse.
+Gloser, mine damer og herrer!
+Vi strides om peanuts , hvor det egentlig bør dreje sig om store udgifter!
+I selve aftalen fastlægges den aktuelle finansielle modydelse.
+Dertil kan jeg kun sige, at bjerget lå i veer og fødte en mus.
+Erasmus er bestemt det mest populære program.
+Da de er biokumulative, ophobes de i miljøet og i de levende væsners organisme.
+Men jeg skal ikke repetere forslaget.
+Vi har subarktiske temperaturer om vinteren.
+Faktisk udviste den ivorianske befolkning stor politisk modenhed ved det seneste valg.
+Men dette bryllup er nødvendigt.
+Cherry picking skaber ingen europæisk merværdi, men cementerer tværtimod nationale enegange.
+I den forbindelse bør vi ikke rippe op i gamle sår.
+Især dette vil ved at snylte på universiteter bremse aktiviteter og ikke fremme dem.
+Rack har bedt om ordet angående en bemærkning til forretningsordenen.
+Pronk sagde tidligere, at vi ikke altid kan støtte socialdemokratiske forslag.
+Schmid, og af koordinatorerne.
+Og jeg mener, at vi har fået et godt greb om nælden i dag.
+Fordi løsgængeren mellem aben og den politiske homo sapiens er menneskehedens manglende led.
+Det vil hjælpe millioner af gamle europæere til at få en solrig pensionisttilværelse.
+At nå de mål, jeg har beskrevet, vil kræve et langsigtet udsyn og engagement.
+Nykommunisterne i vores land skyr ingen midler.
+Man må også teste det tappede blod.
+De beskytter hønens velfærd, det kan betale sig, og det er populært.
+Den nordiske svane har opnået forbrugernes tillid.
+Biskoppen præsenterede ham for menigheden.
+Dækproducenterne er lige så hårdt ramt.
+For det andet er overvågningen fortsat akilleshælen ved denne lovgivning.
+Men jeg vil først, som en god gourmet, vide, hvad menuen står på.
+Ellers må man uddele gratis detektorer til falske sedler til de småhandlende.
+Vi går nur over til afstemningen.
+Her må man nænsomt vejledes af eksperter.
+Det er det, der menes med udtrykket close to zero.
+Der er heller ikke sket fremskridt, hvad indførelsen af tingbøger for risdyrkningsområder angår.
+Nikkel kan, hvis det kommer i berøring med menneskers hud, fremkalde allergiske reaktioner.
+Det europæiske demokratis fremtid hviler tungt på irlændernes skuldre.
+Opel er jo ikke fabrikant af store køretøjer, men af energieffektive køretøjer.
+Vi har altså i årtier spillet russisk roulette med vores sundhed og miljøet.
+Jeg vil imidlertid være helt klar i mælet i denne sag.
+Det er let at være bagklog.
+Problemet er blot, at det ikke engang har spande til at øse vand med.
+Vage, ubestemte, uverificerbare begreber.
+Vi fokuserer derfor på teknologien til at reducere svolvindholdet i skibsbrændstoffer.
+Fruteau, fordi de har håndteret et yderst kontroversielt og vanskeligt spørgsmål så godt.
+Europa fører an inden for satellitteknologi og i teknologien for bemandede rumraketter.
+Den giver i nonfoodproduktionen mulighed for at producere nyt biobrændsel, plastic osv.
+Regeringskonferencen risikerer, som den tager sig ud, at være et stort pulterkammer.
+I dag forårsager økonomiens afkøling imidlertid sociale spændinger, også i de nye medlemsstater.
+Men stramninger og især bevidstløse stramninger og ensporede udgiftsnedskæringer kan vi godt undgå.
+Men der ville blive et ramaskrig, hvis vi ikke gjorde os umage.
+Hurra for miljøoplysningerne!
+Hvor befinder en oase sig?
+I aftes blev jeg kørt hjem af en ghanesisk taxachauffør.
+Skal vi hver gang spille denne komedie?
+Denne betænkning berører detaljer inden for risproduktion.
+Imidlertid findes der også uoplyste forbrugere.
+Dette sammenfattes ved den kradsen i overfladen, som kendetegnes af den genforhandlede konvention.
+Endelig er vi i dag ved at komme ud af denne ubegrundede dvaletilstand.
+De sættes ofte i bås som kriminelle.
+Mållandsprincippet skal også håndhæves konsekvent.
+Denne støtte til frø eksisterer allerede for ris, kikærter og linser.
+Anvendelse af strukturfonde er hæmmet af metodens byrokrati og indviklethed.
+Deres slægtninge kæmper med et rystende bureaukrati, som de skal pløje sig igennem.
+Derimod er tatoveringer langt mindre tilfredsstillende.
+Sådan en rapport er ude på at trække det politiske primat gennem pløret.
+Så vidt så godt, men så kommer den giftige pil.
+Vi kender endnu ikke de enkelte medlemsstaters holdning til spørgsmålet om genhusning af indsatte.
+Alt dette vil øge konkurrenceevnen for vandvejstransporten og dens aktraktivitet.
+Srilankanerne nusser stadig rundt med papirer, mens befolkningen bor i telte.
+For det første er der forsigtighedsprincippet, det som vi kalder precautionary principle.
+Hele forslaget stinker af skjult protektionisme.
+I rigtigt mange lande er rørsystemet til drikkevand på nuværende tidspunkt af kobber.
+Disse køretøjer er særligt velegnede til bykørsel.
+Det er nødvendigt med særforanstaltninger for at håndtere de fribytteragtige forhold.
+Et andet eksempel er kravet om løbende målinger af ammoniakindholdet i røggas.
+Jeg vil kalde det et swedish paradox.
+Unionen er bedrøveligt uinspirerende.
+Con questo si conclude il turno di votazioni.
+Gerningsmændene frifindes, og undertiden rejses der ikke en gang sigtelse mod dem.
+Chichester, i, at der opstår et overdrevet bureaukrati.
+Det samme gælder de sibiriske skove.
+Letaliteten af nogle vira er enormt høj og kræver en anden fremgangsmåde i fremtiden.
+Det sidste håb består i, at den turkmenske statspræsident benåder dem.
+Jugendamt favoriserer i sagsbehandlingen forældre af tysk afstamning.
+Jeg har ikke noget imod calvinistisk afkaldsetik.
+Endelig vil også forsøgsfiskeriet blive fremmet, og det bliver udvidet til cephalopoder og muslinger.
+De har nu selv anlagt sag imod den franske skiorganisation.
+Tålmodighed i alle spørgsmål er en dyd, ikke mindst i udenrigspolitik.
+Jeg vil endnu en gang takke begge formænd for deres ukuelige personlige engagement.
+Hvad skete der rent faktisk med de italienske handicappede fans?
+Toubon for det meget flotte stykke arbejde, som han har udført.
+Piecyk taknemmelig for at have fremsat dette ændringsforslag.
+Skibsrederne mener ikke, at en black box har noget med sikkerheden at gøre.
+En lampe er tændt, men den er endnu ikke rød.
+Love skal da være den svages våben mod de mægtiges ubillige krav!
+Ecowas er aktiv som en regional organisation i kampen mod børnearbejde.
+Moorhouse meldt sig angående dagsordenen.
+De bryder sig ikke om quota hopping ved hjælp af flagskiftfiduser.
+Vi har brugt lang tid på at smøle og komme med undskyldninger.
+Viola for de betænkninger, de har udarbejdet.
+Det hjæper ikke at fordele fattigdommen, sådan som denne betænkning lægger op til.
+Offentligheden er vant til, at enhver organisation har et logo.
+Desværre kan vi konstatere, at denne farlige tankegang stadig er meget gængs.
+Obamaregeringen blev tvunget til indrømmelser som følge af katastrofens omfang.
+Vi må gardere os imod at blande tingene sammen.
+Jeg forstår ikke blåøjetheden i visse ændringsforslag.
+Souladakis, at stabilitet i denne sag ikke er en reel støtte til demokratiet.
+Hele betænkningen er ukreativ, og jeg vil endda vove at kalde den ubrugelig.
+De har en nybegynder i sædet.
+Det er den gamle teori om et skjold.
+Flourholdige gasser er meget stærke drivhusgasser.
+Buckfast vin bør angiveligt forbydes, fordi den indeholder både alkohol og koffein.
+For vi er sobre, fordi vi er ambitiøse.
+Men fordi vi havde et konvent, fik vi minsandten en.
+Men under de nuværende forhold presses de knugende af den amerikanske filmindustri.
+Hajer, skildpadder og delfiner risikerer at blive omringet og indgå i fangsterne.
+Kerneenergi og kul er således en del af mixet.
+Pollackbetænkningen er indrettet på luftforurening, som er en trussel mod borgernes sundhed.
+Det flertal, valgresultatet viste, angav, at præsidenten så absolut var valgt.
+Ingen dikkedarer må ikke være ensbetydende med ingen bekymring.
+Kadima og arbejderpartiet kan være en mulighed.
+Heller ikke den sømand, der vasker dækket, og heller ikke lederen af bjærgningsselskabet.
+Det fik sin ilddåb med denne krævende sag.
+Disse politiske numre er nemme at gennemskue, men det gør dem ikke acceptable.
+Sådan var det allerede i antikken, men også i den tyske mytologi.
+Eurodebatten handlede for meget om biting.
+Fru formand, lad mig indledningsvis takke samtlige ordførere for et gedigent arbejde.
+At det så også medfører en økologisk bieffekt, er så meget desto bedre.
+Nu har begge kamre godkendt ratificeringen.
+De er ikke så almægtige, som de giver udtryk for.
+Amadeo, at vi må begrænse bestrålingerne.
+Vibrationer på arbejdspladsen kan ikke betragtes som direkte grænseoverskridende.
+Hele historien om storgodsejere, af capituleros, strækker sig over en meget længere periode.
+You can get it if you really want!
+Pedanteri om nogle detaljer vil jeg derfor ikke komme nærmere ind på.
+Takket være deres kvindelige intuition beriger de vores forståelse af verden.
+Haider og det, han står for nu.
+Jeg vil stille kommissæren et præcist spørgsmål om rapid alert system.
+Sakharovprisen er ikke tilstrækkelig.
+Pyt med konsekvenserne for realøkonomien og folket.
+Hvem bærer nu egentlig ansvaret for alt, hvad der er blevet ustyrligt?
+Dog kræver omklassificeringen øgede offentlige og private investeringer.
+Nu dingler det lidt i slutningen.
+Men det skal forbydes at anvende flasker beregnet til mousserende vin til kunstig sekt.
+Dette bør være budskabet efter de tragiske flyulykker.
+Siden da har polakkerne været udsat for et uskønt pres.
+Tjernobyl må og skal lukkes.
+Det er imidlertid også ønskværdigt, at vi støtter yderligere bikommunale projekter på øen.
+For det andet bør vi overveje faktorer vedrørende spillere af egen avl.
+Det er en førmoderne opfattelse, som stadig er fremherskende hos de europæiske ledere.
+Men nu får vi at vide, at tiden med junkfood er forbi.
+Huhne ved, fornuftige krav.
+Tallene for spanske operatører er på kun en tohundrededel af de sikre grænseværdier.
+I dag køres coccidiestatika ud med gødningen på markerne.
+Man snublede lidt i starten.
+Det er et spørgsmål om at smadre en rude for derefter at stikke af.
+Rådet har derfor ingen kompetence med hensyn til eutanasi.
+Det generede ham absolut ikke at have en gulag med millioner af fanger.
+Kommissionen vil således fremstå som et svækket organ med national præjudice.
+Den interne revisionstjeneste er kommet godt fra start med sine undersøgelser af counterpartmidlerne.
+Bellacruz er desværre ikke noget enkeltstående tilfælde, snarere toppen af isbjerget.
+I dag er vi nødt til at være hudløst ærlige omkring dette spørgsmål.
+Så kommer vandet til kemisk rensning, som om det var en beskidt jakke.
+Bander af unge mennesker brød ind i butikker og stjal alt.
+Vi gør for lidt for at udvikle ren kulenergi.
+Den pågældende skal kunne påklage beslutningen.
+Equal, og det er min deciderede hensigt, skal leve op til sit navn.
+Man behøver altså ikke omsmelte mønter så ofte og slå dem på ny.
+Arafat forlader den politiske scene samtidig.
+Tillad mig at tilføje et fjerde e, nemlig e for empati.
+For det andet er der to potentielle problemer i forbindelse med hulrum i letmetalvægge.
+Det ville være odiøst, hvis det ikke var så grotesk.
+Elektrisk modstand, eller ohmsk modstand, som er vigtig ved overførsel af elektrisk energi.
+Den opfattelse er efter min mening arrogant og antropocentrisk.
+Flere egne, landsbyer, bydele, bykvarterer og veje er blevet ødelagt af jordskælvet.
+Retssikkerheden vil lide ubodelig skade.
+For det tredje de veterinære og fytosanitære standarder.
+Bianco siger, at der ikke er tale om krig for serberne.
+Venezia vuole vivere e deve vivere!
+Det er naturligvis både for dem og mig aksiomatisk.
+Pimenta konstaterede lige før, at aftalen er dårlig.
+Alt dette bliver budt meget velkommen.
+Danesin med det fremragende arbejde, han har udført.
+Rio, det spørgsmål stiller jeg mig selv, var det stor ståhej for ingenting?
+De rokker for meget ved den oprindelige ligevægt.
+Oppe i logen sidder der nogle gæster og lytter til os.
+De må ikke overbevises af produkter, der sælges med udokumenterede anprisninger.
+Anliggender, hvor mænd står stærkt efter traditionelle ehrvervsvalg.
+Han nævnte urfuglen og den iberiske los.
+Der er også en anden salamitaktik.
+Den britiske eller sågar den amerikanske hund logrer med den europæiske hund.
+Det er som et røntgenbillede af et samfund på bestemt tidspunkt.
+Ingen comoriske indbyggere er blevet ansat som mandskab på bådene.
+Ingen vil kunne sige, at han optræder prangende og ekstravagant.
+Sektoren har et stort vækstpotentiale, hvad angår økoturisme, kulturarv, sport og gastronomi.
+Spørgsmålet om menneskerettigheder er relevant under enhver form for samkvem med tredjelande.
+Jeg vil komme ind på to punkter, tøjring og genteknologi.
+Derfor er nytten af en hundrede og syttende hensigtserklæring ret begrænset.
+Det svejtsiske system kaldes også ofte statsunion.
+But if you try, sometimes you may find that you get what you need!
+Det drejer sig for det meste om sintret eller komprimeret farligt affald.
+I krydsede da af i den forkerte rubrik, ikke?
+Ved at fjerne nogle af disse fridage kunne vi skabe omkring tusinde arbejdspladser.
+Shalits sag må ikke blive et forhandlingsobjekt.
+Det er tydeligt, at nerverne sidder uden på tøjet i dag.
+Med henblik på en ønsket afpolitisering af samfundet er det derimod et probat middel.
+Bærerne af en misantropisk ideologi er fortsat en trussel mod os.
+Bytrafikken spiller en afgørende rolle, når vi taler om klimaændringer.
+Zapatas død er ikke et enkeltstående tilfælde.
+Den, der ikke kan indse det, er uhjælpelig fortabt!
+Der vil ikke være nogen hokuspokus.
+Rådet nåede til enighed om emissionslofter efter lange og seje forhandlinger.
+Sidst, men ikke mindst er der handelen med sælprodukter.
+For bær, surkirsebær og svampe er skærpede krisestyringsforanstaltninger berettigede.
+Savimbis bevæbnede bande, der lever af profitten fra diamanterne.
+Der er trods alt tale om rigtige mennesker, ikke zombier.
+Sådanne købere skal vi vie særlig opmærksomhed, for disse interessenter findes faktisk.
+Men som vagabonderende smådele er det et problem.
+Et nyt orgie af spekulation, hvor lånesatserne når historiske højder.
+Liberal markedsøkonomi er ikke noget fripas til kortsigtethed.
+Det er her, vi skal bekæmpe de ideologiske rødder til wahabitternes fundamentalisme.
+På mange måder er kompromiset imdlertid en fortsættelse af de samme gamle ting.
+Så lad mig se tilbage på noget af den omtumlede historie.
+Den særlige forenklede registreringsprocedure begrænses til oral indgift eller udvortes brug.
+Kære kolleger, jeg har ikke tænkt mig at adlyde.
+Men vores kansler er nu heller ikke kendt som landmændenes ven!
+Reetableringsordninger er allerede gennemført i mindst fem medlemsstater.
+Det lyder ret usmageligt i mine ører.
+Vi kan ikke durkdrevent skubbe det til side.
+Det var især betænkningen om markedsføring af plantebeskyttelsesprodukter, der bragte sindene i kog.
+Områderne kan ikke beskyttes, hvis de er ubeboede.
+Flynn, det skyldes ikke, at jeg er ordstyrer.
+For de voksne ål forholder det sig ikke meget bedre.
+Der sås ingen svindel eller vold.
+Som landmand er jeg overbevist om, at fiskemel ikke hører hjemme i drøvtyggeres trug.
+Nobilia for hans betænkning.
+Heroverfor tager de små highlights sig kummerlige ud.
+De svarer teoretisk og upersonligt.
+For det første er der målvirksomhedernes størrelse.
+Cabrol har stillet, sikrer, at disse sikkerhedskrav opretholdes.
+Rapporten om shortsea shipping påviste dette.
+Deutsch, der udarbejdede betænkningen.
+Den nuværende måde at holde burhøns på kan absolut forbedres eller skiftes ud.
+Jeg mener, at de transatlantiske forbindelsers duelighed løbende bliver sat på prøve.
+Under demonstrationen kom tre demonstranter med bannere ind i mødesalen.
+Skal vi anvende ukvalificerede arbejdere for at opnå bedre resultater?
+Pactio olisipiensis censenda est!
+De ubeføjede klager er faktisk meget vigtige, og vi vil forsøge at reducere dem.
+Gorostiagas venner sender dem til.
+Det er derfor, det er så vigtigt at etablere et europæisk økobeskatningssystem.
+Det er endvidere nødvendigt med flere særaktioner for at ændre mentaliteten.
+Det er flere gange blevet sagt, at justice delayed is justice denied.
+Hacking truer private og offentlige net.
+Sikkerhedsnettet inden for kontrol af lægemidler er finmasket.
+Landet isolerede sig og blev isoleret, da hegnene omkring det blev højere og højere.
+Vi bevæger os på en meget smal sti i denne diskussion.
+Euroens indførelse udelukker enhver letkøbt politik.
+Daphne er en hjælpeforanstaltning, som gør det muligt for os at kæmpe mod problemet.
+Emnet ægdonationer omfatter nogle meget komplekse moralske overvejelser.
+Kuhne for deres omfattende rapporter.
+Nordmændene dyrker laks ved udmundinger af de elve, som har naturlaksebestande.
+Af denne grund synes vi, at denne lakune skal udfyldes.
+Tingene vil ikke gå godt med de nuværende målprocenter.
+Den metode, vi har, er best practice.
+Pacta sunt servanda er ikke noget carte blanche til et efterfølgende spil tarok!
+Hvorfor er samfundet så sygt?
+Det drejer sig først og fremmest om beskyttelse af småinvestorer.
+Som ordfører har jeg foreslået at firdoble det beløb, der skal afsættes på fællesskabsbudgettet.
+Det spreder usømmelighed og vulgaritet.
+Efter denne husransagning har det belgiske politi egentlig ikke fremsat konkrete anklager.
+Ja, jeg ved, at det er et oxymoron.
+Det gælder virkelig om at have antennerne ude.
+De tror, at det også betyder, at kedlen er sikker.
+Det forklarer, hvorfor man ikke finder femhundredeurosedler blandt de forfalskede sedler.
+Europa er ved at blive gammel og gråhåret.
+Desuden har flere programmer lidt under manglende målopfyldelse.
+For det tredje at beskytte miljøet og spare energiressourcer, fordi omfanget af tomkørsel mindskes.
+Som vi har hørt her, er der også behov for isforstærkning i visse havområder.
+Den sygdomsfremkaldende faktor har været af idemæssig art.
+Standarderne har været gældende for alle personbiler uafhængigt af deres cylindervolumen.
+Først om lørdagen får vi så den lækre steg af rigtigt kød.
+Vi krævede ikke, at de blev kendt ugyldige, vi krævede ikke et omvalg.
+Det er en indsats, der fortjener vores fulde opmærksomhed, energi og snilde.
+Det europæiske område er derfor det ideelle udklækningssted.
+Mange kenyanere er bortdrevet fra deres hjem, som efterfølgende er blevet brændt ned.
+Dette er næste afsnit af the never ending story om posttjenesten.
+Gaulieder anonymt er truet, det er alt sammen meget ubehagelige og kedelige ting.
+Svælget i levestandard mellem by og land vokser, og den miljømæssige belastning øges.
+Leadership opstår ikke af sig selv, men gennem overbevisning.
+Papoutsis, men at der endnu ikke er truffet afgørelser i disse sager.
+Hovedproblemet er, at retningslinjerne er ukendte, og ikke webdesigneres eventuelle uvilje.
+For øjeblikket opererer vi i et meget godartet økonomisk miljø.
+Modstand alene og egocentrisk forsvar af ens eget territorium er ikke tilstrækkeligt.
+Her er det snarere burindustriens interesser, der ligger bag.
+Vi var hurtigt ude med at opdele landet i provestlige og proøstlige.
+I praksis støder mange kvinder stadig hovedet knaldhårdt mod det såkaldte glasloft.
+Beaupuy for den glimrende betænkning.
+Beograd skal omgående tage kontrollerbare skridt til en løsning af konflikten.
+Vi støtter demilitarisering og overholdelse af folkerettens principper.
+Urteekstrakter, aminosyrer og vigtige fedtsyrer anvendes også i kosttilskud.
+Derved kan menneskene blive ufølsomme over for humane antibiotika.
+Det såkaldte one man start up er et meget vigtigt anliggende.
+Jeg mener principielt, at der er brug for flere elementer for at inddæmme terorrismen.
+Sådan skaber man ikke fred, kun hadske fjender.
+Niveauet af kommerciel erfaring her i salen er jammerligt.
+Imiteret ost, kød med klister og vaniljeyoghurt uden vanilje er blot et par eksempler.
+Det er ikke et udtryk for vrangvillighed, men er situationen.
+Det er meget kontroversielt i medlemsstaterne, meget få støtter en sådan nødmekanisme.
+For toethalvt år siden begyndte arbejdet med dette.
+Det skal skabes, det kan ikke beordres.
+Forsimplet oppiskning af stemningen, ja tak.
+Hvad er meningen med beslutningsforslagene i morgen, hvis det ikke er politisk rænkespil?
+Google vil åbenbart være mindre ond fremover.
+Jeg smigrer ikke, jeg mener det faktisk!
+Hvordan skal man kontrollere, om denne logbog er korrekt?
+Jeg håber så sandelig, at samtlige kysstater bakker op om initiativet.
+Betænkningen anbefaler, at tørvindustrien tilføjes til denne cluster.
+Oldtidens grækere var allerede klar over betydningen af opdragelse til statsborgerskab.
+Den omfattende uddeling af brochurer trykt på glittet papir har ikke kunnet udligne det.
+Lissabontraktaten kan ikke være et mantra.
+Batom blev slæbt ud af sin bil og gennembanket alvorligt.
+Birgitta er også en svensk skytshelgen.
+Dette direktiv har, som en række kolleger har sagt, en meget langsom lunte.
+Sådan ser det ud efter en første præliminær beslutning.
+Vi fanger flere millioner ton sandål og renser havbunden, og torsk æder sandål.
+Derfor brugte jeg et adjektiv, som måske er lidt stærkt.
+Disse initiativer kan naturligvis ikke i sig selv løse det specifikke problem med alcopops.
+Men desværre bliver højt begavede piger allerede meget tidligt overset.
+Er ibrugtagningen af de nye domænenavne .bytes, .info og .pro blevet forsinket?
+Derfor er en udifferentieret løsning uanvendelig.
+Chesnot, og deres syriske chauffør samt de to italienske hjælpearbejdere, frk.
+They are ready to renationalize.
+Demonstranterne brugte i den forbindelse enorme lydanlæg, nærmere bestemt højttalere.
+Lad os ikke forveksle behovet for en fælles ramme med egalitarisme.
+Cashman med denne betænkning, som jeg med glæde støttede i dag.
+Piloterne, teknikerne og de øvrige fagmænd besidder uundværlige erfaringer på området.
+Mange irske bataljoner har gjort tjeneste i de europæiske stormagters hærstyrker gennem årene.
+Her bliver det tydeligt, at det er ren makulatur, et tågestrejf.
+De er vigtige for en bys attraktion.
+Dette bringer den nordiske pasfrihed i fare.
+Krahmer, det er selvmodsigende at sige, at de ikke også må modtage statslige midler.
+Men da vi var rejst, blev befolkningen alligevel jaget af proindonesiske militser.
+Pittella har udført som ordførere for budgettet.
+Ligeledes bør grunduddannelsen bidrage til at øge alsidigheden i kvindernes fagkundskaber.
+Denne proces omfatter halvkriminelle i ledtog med landets politikere, der snyder iværksættere.
+Det er det rene og skære vås.
+Der er religionsfrihed på den måde, at jeg kan vælge at være ateist.
+Med hensyn til handlingsplanen om energieffektivitet fik vi en temmelig lunken start.
+Energieffektivitet i dækfremstillingen må ikke få lov at gå ud over sikkerheden.
+Jeg håber, at disse bål ikke længere vil være nødvendige i fremtiden.
+Vi viger heller ikke tilbage fra at vaske vores skidne linned i andres påsyn.
+Forskning i optimering og fordeling af dividenden er et andet vigtigt spørgsmål.
+Lamy, er hverken sko eller skruer.
+Der er ikke talt om simpelt gætværk.
+Den pyrenæiske bjergged er forsvundet for altid.
+Hvad skal sømænd, piloter, chauffører, vagtlæger og ansatte på tankstationer så sige?
+I praksis våger medlemsstaterne jaloux over den nationale og regionale kultursuverænitet.
+Vi har ikke brug for dråben, der får bægret til at flyde over.
+Superkreditter, indfasningsperioder og pooling udvander en allerede i forvejen svag grænse.
+Eisma understregede var vigtige for deres stillingtagen, og jeg nævner dem.
+Ingen indgreb i menneskets germinallinje.
+Det gælder både østover og sydover.
+Der må dog tilføjes et stænk realisme.
+Rahed er dybt fortvivlet og befinder sig i det center, vi besøgte.
+Der manglede kun englevinger og harpeklang for at gøre det perfekt.
+Det vil sige den neoliberale dagsorden fuld af almindeligheder og sød tale.
+Det har visse omkostninger at sikre en grundlæggende standard for fodtøj.
+Jeg spørger mig selv om, hvad der er i gære?
+De er umoderne og afspejler ikke længere virkeligheden i sektoren for finansielle tjenesteydelser.
+Kommissionen bærer virkelig det afgørende ansvar for, at denne bommert er blevet begået.
+Der er således arbejde nok til en space advise group.
+Vi bør altså selv smøge ærmerne op og forbedre vores behandling af dette emne.
+For det første er der den globale sundhedsfond mod aids, tb og malaria.
+Jospin sagde sidste uge meget rigtigt, at denne multilaterale investeringsaftale ikke kan reformeres.
+Rådets føromtalte fælles holdning giver den britiske regering medhold.
+Computervirusser, spammail, phishing og trojanere er reelle trusler i de virtuelle datas verden.
+Denne adventive kontaminering kan finde sted under dyrkning, høst, transport, oplagring og forædling.
+Endelig, lykkelige magtesløshed, felix culpa , der sparede os for en sådan fornedrelse!
+Det er vigtigt, at regeringen arbejder på at opbygge en ægte upolitisk statsforvaltning.
+Lad os vogte os for særheder, som er på grænsen til at være fornærmende.
+Kolima, , som viste, hvad den grusomste politiske ideologi er i stand til.
+Corrie og andre, som har nævnt denne misforståelse.
+Dette kan have en særdeles positiv virkning på short sea shipping.
+Den vigtigste kilde til indtægter forventes at blive royalties fra ophavsrettigheder.
+Der er ikke nok brød og marmelade til dem alle.
+Kommissionen må ikke smyge ansvaret af sig.
+De eneste, som stønner over europæiske sucesser, er europæerne selv.
+De ændres under gæringsprocessen og udskilles eller filtreres fra på naturlig vis.
+Disse måneder har været indholdsrige i det internationale panorama.
+Disse små og mellemstore virksomheder skal vi hæge om, fordi de sikrer innovation.
+En revurdering af aspartam er bestemt ikke generende.
+På hvilket grundlag betragtes de som sikre til drift i tætbefolket bymæssig bebyggelse?
+Produktionen af organisk gødning, gylle og slam falder endvidere ikke ind under dette direktiv.
+Vi er det eneste politiske niveau, der har et nulbudget.
+Det er ulykkeligvis især utallige kvinder, som er ofre for denne gemene handel.
+Brazzaville har i de sidste seks dage oplevet rædsler.
+En anden følge for østater er, at flyveomkostningerne kunne stige.
+Med dem ved roret styrer vi direkte mod afgrunden.
+Det er en skam, at der først skulle være en sky.
+Denne reform har primært været til gavn for den store vinindustri samt nogle importører...
+Man skal også være forsigtig med kalcium, og det skal folk som mig vide.
+Der foreslås en europæisk kampagne for at fremme anvendelsen af træ og trævarer.
+Kan vi stadig bruge deca på en fornuftig og seriøs måde?
+Det er vist den korrekte fagterm, der skal benyttes på det sted.
+Det er blevet genstand for sladder, det må ikke få et dårligt ry.
+Wohlfart, som jeg gerne ville have ønsket en god jul og et godt nytår.
+Papæsker og kartoner indsamles og genbruges ofte lokalt for at undgå mange unødvendige transporter.
+Unionens landbrugsudgifter står i tider med slunkne kasser stærkere i folks bevidsthed.
+Det er derfor vores generations fælles opgave at kvæle antisemitismen i dens vorden.
+Myrdende, brændende og deporterende har militserne efterladt landet i et udplyndret og udbrændt kaos.
+Roszkowskis bemærkninger op og fremlægge nogle få kendsgerninger og tal.
+Den aktuelle trussel om en muteret fugleinfluenza viser, hvilken rolle industrien skal spille.
+Ja, vi har brug for kvinder i topjob, men vi må ikke glemme fattigdom.
+Republikkens præsident kan absolut ikke deltage i udfærdigelsen af procedurer og lovdekreter.
+Vi har naturligvis også et par bønner.
+Og det viser hans fleksibilitet, hans politiske tæft.
+De gør det ikke af godgørenhed.
+Christodoulous kvalitetsbetænkninger.
+Det vil jeg gerne kort begrunde endu en gang.
+Madolie ses som et problem efter de seneste års dioxinskandaler.
+Der er børn, der tilbringer flere timer om dagen med at surfe på internettet.
+Giscards forfatningsudkast kan ses som et stort flyttefirma.
+Den samfundsmæssige situation er uklar, og udviklingen af demokratiet går pinagtig langsomt.
+Fodringen af planteædere med kødmel skal principielt forbydes.
+Uregulerede markeder har fået ufiltreret sponsoreret adgang til formelle handelscentre.
+Kashmir tilhører først og fremmest det kashmiriske folk.
+Man sætter lås for sin mund og skyder sig i foden.
+Har ankomstlandet infrastrukturen til at lægge et skib i tørdok osv.
+Disse svenskere synes at være lidt pylrede, lidt hypokondriske og overfølsomme.
+Det pinte mig imidlertid, at forslaget blev forkastet, men det overraskede mig ikke.
+Vi har også satset på evolution frem for revolution.
+Darwin kaldte det naturlig udvælgelse.
+Duisenberg vil dementere pressemeddelelser om, at hans løn skal behandles som en statshemmelighed.
+Casaca, med denne udmærkede betænkning.
+Seychellernes økonomi bygger hovedsageligt på turisme og fiskeri.
+Vedtagelsen af teksten med akklamation har en særlig betydning.
+Her skal man lede længe efter bottom up governance.
+De anholdes, afhøres og idømmes fængselsstraffe.
+Forvirringen i geledderne er stor.
+Forvirring og malthusianisme kører showet.
+Jeg beklager, hvis jeg var lakonisk.
+Unge landmænd er landbrugserhvervets fremtid og vitale for bysamfundene.
+Vi kan ikke nøjes med at stirre på billedet af nutiden.
+Rusland blev regeret af zaren.
+Folkenes selvbestemmelse er et ubrydeligt princip.
+En regnskabsmæssig dumhed i min valgkreds har straffet mine landmænd urimeligt.
+Det er ikke noget, som er udtænkt i en machiavellisk kommissærs hjerne.
+Ssidstnævnte er principielt meget væsentligt.
+Hughes, at spørgsmålet om hjemmearbejdspladser vil være behandlet heri.
+Abyeis status er fortsat usikker.
+Rådet er døvt over for befolkningernes forventninger.
+Det er en cadeau til formandskabet.
+Asturisk og aragonsk anerkendes slet ikke.
+Det får os til at frygte, at hans cirrhose er forværret.
+Alt, hvad jeg kan sige til det, er bvadr.
+Alligevel er midaldrende og ældre kvinder fortsat mere plaget af sundhedsmæssige problemer end mænd.
+Netop hertil er krig det mest uduelige og uegnede middel overhovedet.
+Er begrundelsen den, at begrebet udlænding har en negativ biklang?
+Jeg ved personligt, hvad et gudløst og materialistisk kommunistisk regime er i stand til.
+Hæren og militæret kastede sig ud i den mest sadistiske form for brutalitet.
+Kodeksen er, når alt kommer til alt, det parlamentariske demokratis abc.
+Her fanger vi bare rotter og mosegrise frem for vilde dyr med smukke pelse.
+Derfor er vi nu nødt til at lovgive om lægemidler til pædiatrisk brug.
+Det btyder, at vi helt klart stemmer nej til de to fremlagte betænkninger!
+Med nye testformer er tarmkræft et nyt screeningsområde.
+Det er jeg revnende ligeglad med.
+Techkowskis udtalelse viser, hvor langt ultranationalistiske forvanskninger af virkeligheden kan gå.
+Ikke desto mindre bruger de fleste af dem limousiner med privatchauffører og undgår sporvognen.
+Det er virkelig pindehuggeri.
+De befolkninger, som ilede til hjælp, må ikke tillade, at det sker.
+Vorherre bliver spurgt, om det er passende at betale skat til den romerske kejser.
+De ved alt om de beslutninger, vi træffer bag deres ryg.
+Det betyder, at klyngedannelse, en koncentration af virksomheder i topregioner, er udmærket.
+Cox igennem fem år har vist os.
+Kommissionen foeslår ligeledes, at medlemsstaterne samarbejder om disse ting.
+For det tredje er der spørgsmålet om trihalomethaner.
+Dette er ikke ensbetydende med en omgørelse af afskaffelsen af de nationale grænser.
+Alle har skullet givr indrømmelser.
+Derfor opfordrer jeg alle til at give udvalget et rap over fingrene.
+Isklassificeringen skal også tages i betragtning i den sammenhæng.
+Vi konstaterer også, at byzonerne i nærheden af lufthavnene udvides.
+Men for osts vedkommende har prispolitikken via restitutionstilpasninger medført stadige prisfald.
+Vi bør derfor bevare en agnostisk, kritisk holdning.
+De vil sikre, at madaffald omdannes til energi gennem anaerob nedbrydning.
+En del af siruppen havnede hos sodavandsproducenter.
+Fava og undertegnede har stillet.
+Når man shopper, går tingene ikke altid, som de skal.
+Vi stemmer imod denne nye ode til liberalismen.
+Af praktiske årsager er det nødvendigt, at vi også fremover kan anvende russiske togvogne.
+En krage hakker ikke øjet ud på en anden krage.
+Arbejdstagerne vedtager ved urafstemning de forhold, som de ønsker at arbejde under.
+Der er også et presserende behov for en grundlæggende omvurdering af den politiske situation.
+Det drejer sig om løsarbejde med usikre ansættelsesvilkår.
+Der vil være yderligere halvanden mia mennesker på jorden om tredive år fra nu.
+Leopardi siger i sin fremragende betænkning, et sted i beslutningsforslaget.
+Sådan som det ser ud nu, har jeg stadigvæk problemer med caching.
+Der er talt meget om en såkaldt steering committee.
+Det virker adlende at befinde sig blandt de bedste.
+Elttrafik bør spille en nøglerolle i fremtiden.
+Bæredygtigt skovbrug vil gøre det muligt at producere energi på grundlag af træaffald.
+Vi skal sørge for, at netmaskerne justeres efter disse mindstestørrelser.
+Vi ved alle, at der findes forestillinger, hvor der anvendes falke og andre rovfugle.
+I dag holdes barnet så at sige over dåben.
+Hvis det er tilfældet, er det på høje tid, at der iværksættes en rigsretssag.
+De fleste store årgange er bedre uddannede end de foregående generationer.
+Krigsherrerne er de nye lensherrer.
+Nu da prisen på en tønde olie er steget, bør der være betydelige ressourcer.
+Det er ikke så mærkeligt, at menneskesmuglerne ler hele vejen til banken.
+Hvilke lyksaligheder er der for øvrigt tale om?
+Pinheiro, at han foretrækker andre samlivsformer end ægteskabet.
+Tadsjikistan har stadigvæk træk, der ikke hører hjemme i en demokratisk retsstat.
+De vil kun bemyndige nogle konkrete godkendte organer til at foretage nyvurderingsaktiviteterne.
+Cravinhos seneste besøg fortalte vi, hvornår de næste betalinger kan forventes.
+Ståstedet, det er midlerne.
+Hendes evaluering giver indtryk af, at situationen er noget broget.
+Aznar tilsyneladende er kommet med, sotto voce, men for åben mikrofon, om dette møde.
+De døde lå på gårdspladserne, og til slut blev de i deres hytter.
+Uddelingen af foldere er vel ikke for meget forlangt.
+De europæiske borgere bør ikke betale prisen for erhvervsmæssig og politisk gambling.
+Opiater såsom heroin er den egentlige årsag til de fleste narkotikarelaterede dødsfald.
+De er en delløsning, men de bør aldrig betragtes som hele løsningen.
+Jeg vil gerne udtrykke min respekt for mine medkandidater, som stiller op som gruppeformænd.
+Efter min mening har den egyptiske regering en vattet holdning.
+Der skal naturligvis stå kaptajnens, ellers bliver det noget vås.
+Men som årene er gået, er de sunket dybere ned i ulovlighedens sump.
+Der findes direktiver, som har til hensigt at forbedre dyrvelfærd under transport.
+Kvinder er uerfarne som iværksættere og mangler oplysninger om finansieringsmulighederne.
+Æbler, pærer, ferskner og nektariner
+Vi kan ikke lukke kulkraftværker eller kulminer fra den ene dag til den anden.
+Audy, der har gjort det fremragende.
+Et tredje vigtigt ændringsforslag vedrører byjeeps.
+For det andet skal vi samle rumindustrien.
+Dengang var det indførelsen af sharia i flere nordlige stater, som var detonator.
+Jeg mener, at vi står over for en kulturrevolution, der bevirker dette omslag.
+I virkeligheden var den en gammel krikke.
+Undersøgelsesudvalget fandt, at overvågningssystemet inden for forsendelsessektoren var arkaisk.
+Do not pick the winners and let the winners pick.
+Selv om mange frøer kvækker, så er det stadigvæk kvækken.
+Symmetry skal derfor iværksættes så hurtigt som muligt.
+I flere år er antallet af nysmittede steget med alarmerende hastighed.
+Havde denne fasan måske spist defekt korn, eller var det genetisk modificeret majs?
+Det kan jeg kun beskrive som satire ført ud i det virkelige liv.
+Men det var ikke kun et nødråb fra nogle få poujadister.
+Nogen siger, at regeringskonferencens deltagere aldrig vil blive enige om dette eller hint.
+Fohandlingen er afsluttet.
+Under disse omstændigheder var fristelsen til at give løssluppen kapitalisme frie tøjler for stor.
+Deres gæster vil vide, at de er velrepræsenteret.
+Parlamentet stiller sig tilfreds med en kødløs og nytteløs beslutning.
+Også den næste traktat rummer reminiscenser fra de gode gamle nationalstater.
+Kyprianou, går det meget langsomt med opbygningen.
+Vi skal bruge det imod udvanding fra velmenende godhedsapostle.
+En sådan opdragelse fremmer udviklingen af narcissisme og selvoptagethed.
+Det er jo ikke uden grund, at dyr opdeles i brugsdyr, avlsdyr eller kæledyr.
+Vi skal stræbe efter at opnå national udsoning.
+Ingen af disse medlemsstater kan fortælle os, hvor øksen skal falde.
+Vi foretager ikke omafstemninger.
+Ville variabel geometri ikke være en mere passende løsning?
+Lieses vedholdende indsats.
+Vores samfund blev skabt under indflydelse af de jakobinske stater.
+En sådan systematisk followup er nødvendig.
+Dengang ville det have været business as usual.
+Der er altså udarbejdet et framework , det vil sige nogle generelle rammer.
+Man har ganske vist indrømmet nogle fejl, men den klare vedgåelse mangler stadig.
+Gældende ugandisk lovgivning kriminaliserer allerede homoseksualitet.
+Hutuerne var under deres kontrol.
+Det er for små drenge, som sammenligner deres muskler, men ikke for borgerne.
+Han mente, at vi er lidt for fikserede og enøjede.
+Vi ville ikke have lucerne, som indgår i kvægfoder.
+Oettinger, mine damer og herrer!
+Her drejer det sig imidlertid om andre dyspraxi.
+Knessets godkendelse er en positiv handling.
+Vores store problem er immobilitet.
+Jeg ville være dum, hvis jeg rakkede ned på denne holdning hos nogen.
+Hele den fælles landbrugspolitik er et absurd påfund og skal afskaffes.
+Parlamentets årsberetning er dog speget.
+Det har anrettet store skader på miljø, turisme og landbrug.
+Det portugisiske formandskab er lige begyndt, men har allerede afsat et uudsletteligt mærke.
+Edinburghaftalen, som er en international aftale, er også en del af referencegrundlaget.
+Jeg vil også gerne takke ordføreren i den bayriske dragt.
+Becsey, for hans indsats i forbindelse med spørgsmålet om merværdiafgift og de relevante dokumenter.
+Desuden modsætter vi os en udvidelse af direktivets anvendelse til andre vandaktiviteter end badning.
+Maldiverne kommer delvis til at forsvinde, hvis vi ikke kan løse klimaproblematikken.
+Kultur er altid et tveægget sværd, og det er det, der er særligt interessant.
+Det førte til ugelange ophedede offentlige debatter.
+Kan vi følge denne hastige udvikling, når økonomerne spår os store vanskeligheder?
+Hæmovigilansnetværkene er et vigtigt værktøj for en maksimal sikkerhed i blodtransfusionskæden.
+Der bør heller ikke medtages henvisninger til opfedningsmetoder.
+Jeg vil ikke være apokalyptisk, og jeg vil heller ikke være demagogisk.
+Virgin for hans betænkning, hvis tanker og synspunkter jeg er absolut enig i.
+Unionstoget buldrer af sted uden hensyn til terrænet.
+Europa som gruppe må ikke lade sig kue af medlemsstaterne.
+Bestemmelser om hønsehold på friland mangler helt.
+Jeg vil gerne indrømme, at det ærede medlem har et udsøgt kendskab til vine.
+Vi sigter mod at få andragender, der har substans og er apolitiske.
+Vi hinker altid bagefter begivenhederne i vores naboskabspolitik.
+Europæiske kunstnere lever selv i de bedste tider ofte under beskedne kår.
+Derfor bliver de økonomiske partnerskabsaftaler også så usymmetriske og fremadskridende som muligt.
+På samme måde skal der tages henyn til forbrugernes ængstelse.
+Og det er blandt sådanne skarer af rodløse, at det islamiske parti trives.
+Men der bør mere eftertrykkeligt sættes ind over for hvervning af personer til jihad.
+Ariane er et støtteprogram for bøger og læsning.
+Menneskehandel er en af de hæsligste og alvorligste forbrydelser.
+Dog er der over for kreditsiden en debetside.
+Samhørighedspolitikken er afgørende for samfundene i de underudviklede regioner og delregioner.
+Jeg får endog at vide, at dette er kutyme.
+Samme dag angriber kampvogne hospitalet og ødelægger iltapparatet.
+Endelig sætter vi fødderne på det forjættede land.
+Jasminrevolutionen handlede i høj grad om værdighed og lighed.
+Udnyttelsen af kul kan også omfatte ukonventionelle metoder til underjordisk kulforgasning.
+Bosættelserne skal rømmes.
+Dette direktiv omhandler især strålekilder såsom lasere og infrarøde lamper.
+Men ak, de mange ekstremister opbygger forhindringer.
+Det er virkelig kun en rigtig snue, ikke en politisk snue.
+Et af problemerne er rydning af maki.
+Breyer også understregede.
+Det glæder mig, at vi kan sige velkommen til en ny kvinde på podiet.
+Vi ønsker ikke at leve under et dikatur, heller ikke under et teknokratdiktatur.
+Denne ublu hæmningsløshed er ikke kun permanent, den får faktisk større og større omfang.
+Ahtisaaris bestræbelser uforbeholdent.
+Fernandes har redegjort godt for denne.
+Zaleski lyttede ordentligt til mig i går.
+Men vi har altså vores to pygmæer.
+Den har først og fremmest ramt roeproducenterne og de ansatte på sukkerfabrikkerne.
+Nye arbejdskoncepter blev introduceret abrupt, koncernen blev overcentraliseret.
+Projekterne skal også være tilgængelige på de eksisterende søruter.
+For det første afkobling, decoupling.
+Kirker blev skændet, og vejsidekors og helgenstatuer blev beskudt.
+De to største grupper foretrækker langt et topartisystem.
+Local work for local people using local resources betyder først og fremmest tjenesteydelser.
+Alt for mange instanser er involveret, og nogen skal tage teten.
+Khartoum har protesteret mod denne overførsel og råbt op om et vestligt komplot.
+Kompromissystemet vil ikke gøre det muligt at spore det enkelte fårs bevægelser.
+Det var mere en meget generel udveksling af synspunkter, en slags brainstorming.
+Landbrugsgeneraldirektoratet trænger ganske givet til en ordentlig udluftning.
+Tysklands medlemsindbetaling falder på årsplan med ca.
+Deployeringen af tropperne fortsætter efter planen.
+Ufine metoder tåler ikke dagens lys.
+Formand, jeg finder dette uelegant.
+Blanke eller udgyldige stemmer tages ikke i betragtning ved stemmeoptællingen.
+Jinnah ville være blevet chokeret, hvis han havde levet i dag.
+Buddhismen og jainismen udgør begge en del af den indiske tradition.
+Dette er helt uholdbart, hvis vi skal have en fælles øresundsregion.
+Cappatos retorik lyder altså fuldstændigt falsk.
+Denne omfatter incest, børns vold mod deres forældre og omvendt.
+Antonione for deres indsats.
+Hvem skal have det næste hug?
+Vi ved også, at de mobbede er mere udsatte for stress end andre.
+Hvis det var mænd, der blev gravide, ville abort være et sakramente.
+Cigaretter med et lavt tjæreindhold er lige så skadelige som andre cigaretter.
+Særlig de, der taler urbefolkningens og de fattige samfunds sag, løber en stor risiko.
+Det ville have vakt furore.
+Men her har også altid være medlemmer af det andet bøhmiske folk, sudetertyskerne.
+De ender som fyld i ravioli eller som bouillonterninger.
+Vores kontorer har ingen temperaturstyring eller individuel indstilling af varme og aircondition.
+Der bliver tale om en treleddet repræsentation, som også påpeget af ordføreren.
+Som jeg sagde, er vi ikke gode feer.
+Den emmer af opgivenhed og mangel på entusiasme.
+Vi deler mange synpunkter om dette spørgsmål, og det er et godt udgangspunkt.
+Det er tragisk, at der findes så megen olie i jorden omkring ækvator.
+Tiden er ikke inde til at lege med ægproducenterne.
+Man har vedtaget, at sønderrivning af sener, ledbånd og væv altsammen er acceptabelt.
+Hvordan kan voksne mennesker behandle børn som forbrydere, inden de overhovedet har nået puberteten?
+De dulmer symptomerne, men helbreder ikke sygdommen.
+Fleckenstein, og hendes projekt har vundet en europæisk pris.
+I den sammenhæng synes jeg, at henvisningerne til økokonditionalitet er meget interessante.
+Men hvordan ser det ud med formidlingen af erhvervskvaliteter til unge kirgisere?
+Vi vil drage et lettelsens suk efter otte års tilbagegang.
+Dauls beslutningsforslag, og det vil jeg gerne takke ham for.
+De største risici er rabies, echinococcose og sygdomme, der overføres via mider og flåter.
+Vi husker stutteriforeningerne og golfklubberne og alt det, der følger med.
+Der er stor forskel på transgenese og cisgenese.
+Kommissionen har kvajet sig i denne sag.
+Kvæget brændes efter slagtningen, hvorefter asken henkastes på lossepladser.
+Vi skubber store beløb frem for os som med en stor sneplov.
+Hr.formand, jeg har kun tre kommentarer til denne debat.
+Vi har andre strande, der endnu ikke har fået denne akkolade.
+Trotskisterne blev, om ikke voksne, så dog ældre.
+Endog ikke den amerikanske udenrigsministers mægligsforsøg har kunnet åbne patstillingen.
+Svage foreninger får flere lodder og har dermed større chancer end topklubber.
+De forsøger simpelthen at anbringe en firkantet pæl i et rundt hul.
+Billeder af sultende mennesker og døende børn går dagligt verden over.
+Det betyder rent ud sagt, at alt for øjeblikket kører i tomgang.
+Det er logisk, at dette paradoks beskæftiger de tyske gemytter meget.
+Gangesdeltaet stiger som følge af alluviale dannelser.
+Grænseværdier for benzen og carbonmonoxid
+Praeterea censeo constitutionum esse repudiendam.
+Bomberne splintrer de flere cm tykke armerede plader på de fleste moderne kampvogne.
+Sakchai er en ny skotte og en ny shetlænder.
+Vi er ikke en fanklub i dag.
+Uddannelse, mobilitet og muligheder på arbejdsmarkedet danner i stadig højere grad en kausal kæde.
+Hitler blev gudskelov besejret og måtte aflevere sit bytte.
+Pengene ville være blevet frataget fodbolden, hvis der var blevet ikendt en større bøde.
+Medierne bugner med detaljer om dette vidt forgrenede elektroniske overvågningsnetværk.
+Køberen, forbrugeren af sådanne sjofle ting skal også kunne forfølges strafferetligt.
+First things first, siger man på engelsk.
+Janjaweed er ikke blevet afvæbnet.
+Denne bestemmelse er den eneste måde at håndhæve forbuddet mod store pelagiske drivgarn på.
+Tilskyndes de til at blive blikkenslagere og tømrere?
+Jeg kan blot nævne køomkostningerne som eksempel.
+Pasqua og adskillige andre talere var inde på.
+Det er let at fastslå, om en person er smittet med syfilis.
+Sasi bekræfte, at formandskabet vil udarbejde en sådan formulering?
+De ved, der i denne sammenhæng er fortsatte vanskeligheder med pashtunerne.
+Jeg har nævnt nødhavne og sikre kajpladser i en af mine tidligere betænkninger.
+En fjerdedel af skolerne har ikke vand inden for gåafstand.
+Der er også meget alvorlige miljømæssige følger mv.
+Olssons og mine synspunkter på dette område.
+Lehtinen og skyggeordførerne for det gode samarbejde gennem de seneste måneder.
+Vore bestræbelser i den henseende ænses knap nok i de internationale medier.
+Først og fremmest er årsregnskabet for tredje år i træk blevet påtegnet uden forbehold.
+Kommissionen taler om, at produktionen skal sættes ned, så overproduktion og kødbjerge undgås.
+Det var drømmen om et samfund, hvor hudfarven ikke medførte nogen diskrimination.
+Souchet, som nævnte halvledere.
+Jeg vil imidlertid også gerne bede om, at vi angriber alle disse problemstillinger udogmatisk.
+Jeg bifalder hans afpudsning af det franske forslag.
+Dette er imidlertid en jastemme med et klart forbehold.
+Euroens troværdighed og internationale rolle, navnlig over for dollaren og yennen, afhænger heraf.
+Tidligere hang klasseskel sammen med mængden af ejendom eller penge.
+I de sidste enogtyve år gennemførtes der kun tre europæiske direktiver om samarbejdsudvalg.
+De burde egentlig hives i retten for dette.
+Prissætningen på elektricitet, hvor engrospriserne for el fastsættes af elbørser, bør revurderes.
+Vi taler derfor om valnødder, hasselnødder, mandler, pistacienødder og kastanjer.
+Han insisterede på selv at give hende løkken om halsen.
+I byerne skjuler der sig forfald, misrøgt og fattigdom bag de monumentale facader.
+Men nu er ærtedyrkningen i tilbagegang.
+Dette er snarere guf for satirikere end for politikere.
+Der er navnlig tale om madæbler.
+Plantningen af roer forberedte jorden og gjorde den bedre egnet til korn.
+Havulykker udgør imidlertid en del af den fælles havpolitik.
+Helkropsvibrationer kan føre til lænderygsmerter, diskusprolaps og tidlig degeneration af rygsøjlen.
+Det er endnu mere vigtigt, da de forsøger at gyde olie på vandene.
+Osvaldo selv er på fri fod, og hans familie chikaneres dagligt.
+Godt halvdelen af verdens befolkning i dag lever i områder med seismisk aktivitet.
+Columbia er en strategisk partner for os.
+Dagens forbruger presses til at lave maden hurtigt.
+Via denne vil større selektivitet i fiskeriet og beskyttelse af ungfisk blive sikret.
+Den anden betænkning, som jeg her præsenterer, hænger sammen med denne frøhandelslov.
+Den økonomiske afmatning forværrer de kommende perspektiver for de unge, navnlig dimittenderne.
+De døde på grund af dehydrering.
+Djakourmas løslades hurtigst muligt.
+I nogle tilfælde er der tale om tocifrede procentvise nedskæringer.
+Ukontrollable kropsfunktioner kan være en meget ubehagelig oplevelse i en rumdragt!
+Jeg mener, det er meget godt, at politikken på denne måde bliver lutret.
+Det væsentlige er for mig, at chaufførerne og læssepersonalet omgås roligt med dyrene.
+Agenturerne skyder imidlertid op som paddehatte.
+Målet er, at de små og mellemstore virksomheder skal vies særlig opmærksomhed.
+Den fælles markedsordning for råtobak
+Der er fem års balsamering for alle, der er færdige i deres eget land.
+Ungureanu med betænkningen.
+Der bliver endda argumenteret med schæchtning.
+Udvidelsen øger dette kravs aktualitet tifold.
+Jeg ville have adgang til mine mails.
+For disse lande blev krisen det sidste søm i kisten.
+Paasilinna udtrykke min anerkendelse af hans betænkning.
+Dette emne har livsvigtig betydning for de vælgere, der har sendt os herned.
+Fru formand, i går kommenterede jeg det kamarahold, der havde fået adgang til mødesalen.
+Netop inden for budgetpolitik gælder det om at udfylde disse tre grundprincipper med lødighed.
+Der er faktisk ikke berammet en dato for retssagen.
+Det er lykkedes ham at sy et holdbart kompromis sammen imod alle odds.
+Kom og se en cricketkamp og mød nogle almindelige mennesker!
+Skal de bare stuves ind blandt de millioner af arbejdsløse?
+I denne gruppe finder vi også de såkaldte au pairer.
+Sådan er det ofte med historiske nybrud.
+Denne betænkning dækker over et intellektuelt fupnummer.
+Flodens overflade er dækket af et tykt lag skum.
+Vi ønsker ikke smånusseri, men direkte handling så luftfartsindustrien kan overleve.
+På den måde kan misdæderne få løn som forskyldt.
+Der er en lang række hændelser og fejder.
+Det hedder ikke onthaalcentrum , men opvangcentrum på godt nederlandsk.
+Gazprom er ikke noget privat selskab.
+Bhopals indbyggere forsøgte at flygte fra den giftige sky.
+At gøre handel mindre usmidig er at gøre det økonomiske system mere effektivt.
+Han kan blive den nye vektor for fremskridt sammen med det arabiske fredsinitiativ.
+Den skal optjenes på en måde, som offentligheden kan acceptere.
+Uformel betyder på fransk misformet og ugraciøs.
+Lenins metode byggede på ligegyldighed, men resultatet var det samme.
+Suominen er fremkommet med.
+Uanset hvor fantastisk maleriet er, kan der aldrig blive røget på denne pibe.
+Der er andre udvalg, som har stemt imod ownership unbundling.
+Azambuja er jo et enkelt tilfælde, men det er repræsentativt.
+Dette oldnordiske papirnusseri koster både tid og penge.
+Derfor accepterer vi ikke, at forbrænding af usorteret husholdningsaffald skal have støtte.
+En udglatning af vores uoverensstemmelser vil være et vigtigt bidrag til begge økonomier.
+Det er kun lidt bedre end et ublodigt statskup.
+Finis forslag om at give stemmeret til tredjelandsstatsborgere.
+Ingen brain drain, men brain gain.
+Doorns indlæg, hvor der især blev lagt vægt på statsstøtten i de nye medlemsstater.
+Hvad der er endnu værre, er, at det er de diegivende moderfår, der forsvinder.
+Det samme gælder de franske og de socialister, der førte an i deres heppekor.
+Yd hjælp og fjern ikke børnene fra deres familier.
+Men tjenere og barpersonale har også ret til livet og til sundhedsbeskyttelse!
+Er der måske en ny alarm om nye baciller, som spreder sig her?
+Babel vil utvivlsomt bygge sit tårn.
+Ja, det skal fordømmes, men enhver nyslået politiker kunne have forudset denne udvikling.
+Ordføreren har heller ikke fundet bevis på fumus persecutionis.
+Der er heller ikke angivet nogen scenarier for den sandsynlige fremtidige udvikling på bærmarkedet.
+I ordbogen betyder dette ord fuldstændig forvrængning.
+Følgerne af forbuddet mod subleasing må ikke undervurderes.
+Det vigtige i forbindelse med tildeling af lån er spørgsmålet om cash flow.
+Den keltiske tiger har længe repræsenteret fordelene ved konkurrencedygtighed og økonomisk disciplin.
+Nec spe, nec metu eller uden håb eller frygt.
+Vi har i de seneste år konstant hørt det omkvæd, at forvaltningen skal forbedres.
+Grækenland snød sig til euroen.
+Denne adskillelse skal bevares, og de to ting må ikke flettes ind i hinanden.
+Lax, som bidragede særlig aktivt til denne betænkning.
+Der er risiko for, at formandskaberne bliver toptunge overbygninger.
+Vi kan ikke sætte pigtrådshegn op.
+Forbrugerblade læses af mange, og de indeholder nyttige tip.
+Denne forordning rejser to hovedspørgsmål og en række bispørgsmål.
+Ingen levende organismer, fra mikrober til oddere, er blevet skånet.
+Pakningen skal indeholde korrekte oplysninger om thrombin, og mærkningen skal være tydelig.
+Det er efter min mening et ueuropæisk forslag.
+Der er kun nuller og ettaller.
+Denne århundreder gamle nation må da have andre fremtidsudsigter end sådan en trist diaspora.
+Det er i det mindste et mere interessant og righoldigt ideal.
+Flautre sagde, det, vi kan gøre, er en hjælp, men behovene er kolossale.
+Balfe samme dag gav tilladelse til medlemmernes medarbejdere til at gøre dette.
+Det foretrækker klikket fra en riffel frem for klikket fra et kamera.
+Nærkysttrafik skal derfor gøres enklere, billigere og mere transporteffektiv.
+Den bolsjevitiske ideologi benyttede metoder, der ikke på nogen måde kan berettiges.
+Jeg vil foreslå, at det ikke skal være mere end en gennemsnitlig årsløn.
+Orban, disse testprocedurer godt.
+Ønsker vi blot at jagte haren, eller vil vi gerne fange den?
+Jeg er imidlertid ikke enig i, at uldvarer skal gøres til genstand for overvågning.
+Coillte er et halvoffentligt selskab, som har til opgave at udvikle skovbruget.
+Hvor er de store mængder ubearbejdet mel, der er potentielt forurenet?
+Måske er denne reform også den sidste slurk af flasken.
+Kvinder bliver degraderet til råstofleverandører af ægceller.
+Men prøv ikke at ville tækkes alle.
+Vi venter stadig på, at det elektroniske system skal loade.
+Men økonomisk politik er ikke kun en enkelt, mekanisk sekvens af procedurer.
+Disse mennesker søger midlertidigt ly.
+Der anes også en vis mistillid til selve programmernes effektivitet.
+Men for at ødelægge et hvepsebo skal man ikke brænde hele huset.
+Denne betænkning er spækket med henstillinger, men jeg har en enkelt kommentar.
+Desværre sker der det, når et diktatur ophører, at låget lettes for disse spændinger.
+Domstolens afgørelse er endnu et søm i ligkisten med britiske friheder.
+Jeg bor på en halvø, så jeg forstår godt øboere.
+I øjeblikket rasler medlemsstaterne til en vis grad stadig med sablerne.
+Pasko har gjort det, som de institutioner, jeg nævnte, hele tiden taler om.
+Israel pulveriserer nu også disse stakkels mennesker med eksperimentelle våben.
+Det var nærmest en karbonkopitale.
+Det er denne usentimentale holdning, jeg har anlagt med hensyn til budgettet.
+Man vil måske kun indynde sig og blande sig lidt i folks hverdag.
+De må eje deres egen jord, deres hjem og deres gård.
+Hvad med dialogen mellem teistiske, ikketeistiske og ateistiske overbevisninger?
+Antwerpen fik ikke en chance trods mange forsøg på at finde en køber.
+Er der indsigelser mod forslaget om at gøre det en bloc?
+Sætningen er grammatisk forkert.
+Hendes snæversynede racistiske bemærkninger vedrørende adoption vil være svære at hamle op med.
+Algarve, der i år beskæres med ca.
+Det betyder, at amalgamfyldningerne står for den allerstørste del af udslippet til kloakkerne.
+Pigerne chatter, indgår i fællesskaber og sender tekstbeskeder, mens drengene spiller computerspil.
+Den arabiske verden har på ny hentet det økonomiske boycotvåben frem.
+Alkalisk hydrolyse er en af disse metoder.
+Spencer for at have fremført noget, der er soleklart for alle.
+Dette er ikke nogen kvasijuridisk kommentar.
+Den nuværende kontraktlige ordning fastlægger kun en rudimentær bilateral dialog.
+Gå ikke med til nogen uldne kompromiser i dette spørgsmål.
+De kan bare sende ekstraregningen videre til deres trælbundne kunder.
+Dette direktiv handler om tapning, testning, behandling, opbevaring og distribution af humant blod.
+Buschauffører, bagere og mange andre erhverv organiserer deres egne uafhængige fagforeninger.
+Når dejen er klar, skal den formes for at blive til et godt brød.
+Man kan ikke få både i pose og sæk.
+Det betyder derfor, at disse områder hægtes af.
+Det er også en måde at forynge vores økonomier på.
+Lebedev, kan vi ikke have et godt og normalt partnerskab.
+Jeg stod og ventede et stykke tid og blev iskold.
+Det kan betyde, at ampicillin går tabt for altid som terapeutikum.
+Den bedste affaldsforebyggelse, kære kolleger, findes i disse produkters økodesign, som ændres.
+Scholz, har gjort for at nå frem til en aftale om dette forslag.
+Så går jeg over til at behandle gasolie og lette brændstoffer.
+Baldarelli, om for lidt siden.
+Det er de italienske myndigheders opgave at finde den opimale løsning på problemet.
+Sneen dalede ned i store fnug.
+Man kan ikke finde rundt i virvaret af overstregede budgetposter og fupoverskrifter.
+Man anerkender også modkandidatens sejr, når vurderingen af selve valgene er positiv.
+Man kan kalde denne tilgang for neoimperialistisk og revanchistisk.
+Linzer, for deres store indsats.
+For det andet spurgte jeg direkte om dialogen mellem kristne, muhamedanere og jøder.
+Vi ved, at relætolkningen nogle gange kan være et problem.
+Jeg er homoseksuel og opvokset hos en almindelig mand og kvinde.
+Han ville lytte til fuglenes og cikadernes koncert.
+Bonn har i sidste øjeblik givet det politiske signal, som var nødvendigt.
+Vi er meget optaget af geotermisk energi såvel som af andre vedvarende energikilder.
+Jeg håer, vi kan fortsætte på den måde.
+Hverken flertalsafgørelser eller kompensationer i huj og hast gør en uretfærdig behandling retfærdig.
+Vi endte rent faktisk med en niårig periode.
+De har ikke de samme nautiske kvaliteter.
+Man har set seniormedlemmer give sig af med dette, og ligefrem en tidligere formand.
+Det forekommer som om, at man nu taler om piratvirksomhed med en overdreven lethed.
+Det er da dårekistepolitik.
+Jesus siger, at sandheden gør os frie.
+Det er klart, at en diktator ikke kan kues af aggressive holdninger alene.
+Disse utaknemmelige opgaver overlader man så gerne til andre.
+Ondartede kræftknuder er den næststørste dødsårsag hos børn.
+Men disse love krænkes uafladeligt.
+Forbrugerne famler fortsat i mørke.
+Vi skal ikke hoppe på limpinden.
+Vi taler således ikke kun om lytning og pleje, men også om egentlig praksis.
+D for demokrati og dialog.
+Forud for høringerne inden det seneste valg var ordet gennemsigtighed på alles læber.
+Wuermeling vedkommende, fordi han har forklaret dette komplicerede forslag i vores gruppe.
+De centrale aspekter i vores forslag er trefoldige.
+Albanerne var tilbagestående landmænd og hyrder, som ingen ville tage hensyn til.
+Det er unavngivne civile, der tilbageholdes af russerne.
+Ordføreren har slet ikke forsøgt at analysere og løse disse målkonflikter.
+Til gengæld vil jeg gerne skose de holdninger, der gennemsyrer dem.
+Jeg kommer nu tilbage til mine kuverter.
+Tillad mig som østriger at komme med et surt opstød.
+Fyr den næste, der lyver, i stedet for at fyre whistleblowere.
+Kinesisk ginsengrod eller indisk tetræsolie, mange borgere sværger til naturprodukter.
+Meddelelsen er også en guide til nye støttemåder, særlig budgetstøtte.
+Mange af disse mennesker ender desværre i hænderne på beduinske menneskehandlere.
+Bylden kunne være blevet tømt med det samme.
+Grundvandet er en vigtig naturressource, der bruges som drikkevand, i industrien og i ndbruget.
+Ikke desto mindre udelukkes de af uforklarlige åsager fra processen.
+Hvis jeg sammenligner denne forskningsrapport med den foregående, kan man ane en svag udvikling.
+Hov, jeg kan se, at jeg allerede har talt i fem minutter.
+Der planlægges en udvejsstrategi, så vi ikke længere behøver døje med genopretningsstrategien.
+Køretøjerne har kameraovervågning og klimaanlæg, og dyrene læsses med lift.
+Symbolets form er naturligvis statuerne, som også tjener som afguder.
+Cercas, for hans udmærkede betænkning.
+Men helten i den fortælling, som var en rigtig gnier, undergik en forvandling.
+Bristen lå i tilgangen til de mindre hårde safarigitre.
+Indien støttede kaftigt denne holdning.
+Desuden har vi en poloniumsag.
+Det anvendelsesområde, som vi havde foreslået, bliver desuden reduceret med cooperations.
+Det har intet, overhovedet intet, med staying loyal to principles at gøre!
+Carswell, andrageren i denne sag.
+Romtraktaten indeholdt allerede beføjelser hertil.
+Jeg repræsenterer et randområde, der ofte kaldes en ødemark.
+Det er en udfordring at sikre, at en europæisk bystrategi tages alvorligt.
+Det er føget med komplimenter her.
+Disse lige betingelser angår arbejdstider, hviletid, betalt ferie, lønramme, status og sikkerhed.
+Disse ændringsforslag omfattede imidlertid ikke tilføjelsen af egespån.
+Det er også vigtigt at understrege integritetsaspektet, som brugen af dna kræver.
+Krarup sagde, mangler disse forslag under alle omstændigheder proportionalitet.
+Baissespekulation bør også forbydes.
+Jeg tænker her på vores babyer, vores sutteflasker osv.
+Budgettet er det nav, hvorpå alle det europæiske hjuls eger samles.
+Folk bliver lokket med pertentlig mikroforvaltning, og ingen tør delegere beslutningstagningen nedad.
+Tbilisi er ansvarlig for den uforståelige beslutning om at involvere sig militært.
+Spørgsmålet er, hvem der bærer skylden for, at hunden åd pølsen.
+Det behøver ikke at være en tyk bog.
+Wien er dog ikke altid gået ram forbi.
+De giver mulighed for fortolkninger, der går længere end enabling clause.
+Da passageren ikke adlød, blev han koldblodigt henrettet i passagerområdet.
+Ispa er det, vi kan stille til rådighed af finansielle midler.
+Til afstemningen skal udpeges fire stemmetællere ved lodtrækning.
+Jeg mener ikke, at vi bør nøle med dette transitspørgsmål.
+Meciar mistede folkets tillid, men hans parti er stadigvæk det største.
+Men den mælk, som dette yver indeholder, er, om jeg så må sige, forgiftet.
+Belsat er en fremragende start, men godt tv har sin pris.
+Det er faktisk mit kontor, som har offentliggjort læservenlige udgaver på adressen www.euabc.com.
+Den omfatter odderen, ulven, bæveren og lossen.
+Jeg tror, at vi alle sammen følte et behageligt sus under formiddagens møde.
+Det er desuden ikke noget onesize direktiv.
+Og jeg tror ikke, at vikingeskibene producerede drivhusgasser.
+De har slugt den toldfrie industris argumenter råt.
+Muchas gracias, muito obrigado!
+Clarke, at der ikke kun er nejer til forfatningen, men derimod mange jaer.
+De usikre elementer skal holdes nede på et minimum i denne økonomiske malstrøm.
+Alitalia er godt eksempel på dette.
+Vi bør alle synge efter samme nodeblad i denne sag.
+Liberaliseringen er et paradeeksempel på job creator.
+I morgen vil genetiske sygdomme som cystisk fibrose eller fenylketonuri være udryddet.
+Sund kost er et essentielt apekt af livskvaliteten.
+Det er fortåeligt, da vores tilpasningsevne jo ikke er uuendelig.
+For det første anerkender det ikke typologier.
+Shell har, så vidt jeg ved, trukket sig tilbage.
+Vores vaner og bosteder er blevet stive.
+Jeg peger på anomalien i lufttrafikkens fritagelse for afgift på kerosen.
+Det er at lade ræven vogte gæs.
+Og så til det sidste punkt, nemlig spørgsmålet om iderigdom.
+Den seneste bølge af pøbelvold fandt sted i december.
+Pelinkas tilfælde, er langtfra resultatet af et sammentræf eller en tilfældighed.
+Cecilia, og andre af dem har også været her i lang tid, f.eks.
+Han bebrejdede verden, at den tav ligesom første gang.
+Parlamentet har valgt kompromiset og har ikke givet efter for sortseernes sirenerøster.
+Nulfejlstolerance er dog noget, vi snart skal til at tage fat på.
+Elkabler og offshorevindenergi fortjener naturligvis de ekstra penge.
+Octa forarbejdes hovedsageligt i kontorudstyr af plastik og i dele af husholdningsapparater.
+På den anden side har vi komparative fordele med hensyn til tunopdræt.
+Jeg vil derfor kommentere den mulige opdukken af en ny økonomi i euroområdet.
+Guellec gjort på en udmærket måde.
+Dette ville betyde en ende på udsendelser på ungarsk, ruthensk og ukrainsk.
+Mit sexliv er blevet bedømt.
+Man skal ikke lade hø mugne, for så bliver det rent ud sagt farligt.
+Den komplicerede og tidrøvende håndtering koster ikke blot meget tid, men også mange penge.
+Vi har derfor brug for disse fora for internationale koproduktioner.
+Vi er ikke kun den ydende part.
+Zaire er, som vi ved, indbegrebet af udnyttelse og plyndring.
+Lad os nu sammen arbejde på et ærbart kompromis, som gavner alle.
+Når de når hjem til sig selv, forvandler denne vægelsindethed sig til sand modvilje.
+Det er rigtigt, at vi foretog en simulationsøvelse for kopper i sidste uge.
+Fidesz fik et mandat på to tredjedeles flertal til at gøre dette.
+Simcyp går forrest i udviklingen af alternativer.
+En boboer på et plejehjem hører i dag ind under det sociale område.
+Dels på grund af krig og ufred og dels på grund af naturkatastrofer.
+Vi kan ikke konfrontere de nye medlemsstater med en ufærdig asylpolitik.
+Nu ledes vi af kommunister, kollaboratører og quislinger.
+De bidrager også til skabelsen af ozon og smog om sommeren.
+Ønsketænkning blokerer for en bare nogenlunde ædruelig realisme.
+Populistisk hugst, som om man går til en botanisk have med en økse.
+Det er mennesker, der lever her, ikke robocops!
+Reach er altså det rene humbug.
+Resten er eucalyptus til papirfremstilling, og så det usædvanlige træ korkegen.
+Klimaspørgsmålene er varme emner, og det er yderst sexet at stemme grønt.
+Hvert tilfælde af et kriseramt bydistrikt har naturligvis sine egne karakteristika.
+Albertini så udmærket siger det i sin betænkning, innovative foranstaltninger og instrumenter.
+Azzoloni for hans arbejde og for den imødekommenhed, som han har udvist.
+Poignant for hans samarbejde ved udarbejdelsen af min betænkning.
+Vi har brug gennemsigtighed og etstedsbetjening.
+Vi skal også undgå at duplikere lovgivningen.
+Vil parlamentsbetjentene venligst eskortere dem, der forlader forhandlingen, ud af salen.
+Det drejer sig om korrekturer af destillationsbestemmelserne, af nyplantningsrettighederne.
+Jonckheer mindede os om, er krisen i den europæiske bilindustri ikke noget nyt.
+Se blot på pneumokokfremkaldt sygdom.
+Men til rumfart og fusion og slige mærkværdigheder bruges der masser af penge!
+Snørklet og hemmelighedsfuld er bogen i sin søgen efter læsere.
+Chokoladeelskere, nyd nu endelig religiøst jeres forestående påskeæg!
+Derfor har jeg også fundet nogle få regeringer med fingrene i denne møgbunke.
+Det er udelukkende af neokoloniale grunde, og det accepterer vi ikke!
+Nu vil jeg gå videre til spørgsmålet om sælmassakren.
+Kairo indrømmede, at de havde modtaget ham ved hjælp af ekstraordinære procedurer.
+Kommissisonen afventer i øjeblikket svar fra de gabonesiske myndigheder på dette tilbud.
+Jeg tror ikke, han er logget på og lytter.
+Jeg vil til sidst pege på en solooptræden, som er betænkelig.
+For det første skal de betale mere for hotelværelser end turister, der rejser parvis.
+Var det korrekt at informere butikkerne om, at de ikke skulle trække risene tilbage?
+I påkommende tilfælde, hvornår skete det så?
+Jeg støtter helt sikkert alle dele af belutningsforslaget fra alle de berørte grupper.
+En stat er selvstændig, når den overholder princippet om uti possidetis, grænsernes ukrænkelighed.
+Jeg har stadig visse forbehold med hensyn til udnævnelsen af en europæisk netforvalter.
+Johannesburg var som ventet en ny skuffelse.
+Måske skulle vi gøre os klar til at tænde bavnene!
+Desværre kan vi ikke afgifte betænkningen om proteinunderskud fra angrebet på nultolerance for gmo.
+Vi bør være bekymrede for de søgående fartøjers sødygtighed.
+Endelig har man i den seneste tid talt meget om fast track, om hasteproceduren.
+Menneskeheden er gået fra træalder til kulalder og derefter til oliealder.
+Kommissionen er faldet tilbage i en førdemokratisk tænkemåde.
+Andre iranske sagførere har også været udsat for undertrykkelse.
+Hvis vi ikke snart begynder at arbejde på dette, kan euroen ende som matadorpenge.
+De respektive forfattere er ansvarlige for inholdet af disse dokumenter.
+Wathelet skal i en ansvarsprocedure have mulighed for at forsvare sig.
+Den synes i stigende grad at fungere som skohorn for globaliseringen.
+Einstein sagde, at iderigdom er vigtigere end viden.
+De bedes virkelig undersøge, hvem der har underskrevet seddelen!
+Vi observerer desværre, at meget landbrugsjord ikke er opdyrket og derfor forringes.
+Faktisk gled den mere og mere i baggrunden.
+Og det har også været et slag med en kødhammer i samvittighederne.
+De taler om hallucinationer.
+Hvad kan vi håbe på at få ud af den uelastiske konservatisme i stabilitetspagten?
+Men selv de smukkeste roser er usynlige, hvis de bliver overgroet af ukrudt.
+Retinalmønstre er et meget effektivt middel til entydigt at identificere bilejere.
+Idag bør vi fejre vores evne til at forene.
+Befolkningerne blæser i trompeterne rundt omkring bymurene.
+Delphi er i denne forbindelse et dybt sår i mit land.
+Det var en tid, hvor man virkelig var åndrig i denne type debat.
+De ser tegn herpå nærmest overalt, som spåkvinden, der ser lykken i kaffegrumsen.
+Vi kan ikke bare fortsætte den ubegrænsede vækst i lufttrafikken og opofre alt andet.
+Det beviste vi fremragende i forbindelse med leghole traps, fælderne i forbindelse med dyrepelsene.
+Hvis de får lov, må vi acceptere, at verden enten er ond eller gal.
+Csibi allerede har sagt, baner direktivet vej for et frivilligt initiativ fra erhvervslivets side.
+Det er en livgivende naturgas!
+Noget tilsvarende skal finde sted med hensyn til bly og tin.
+Vi skal bruge vores kulreserver bedre.
+Anvendelsen af bindsler til søer og gylte vil blive definitivt forbudt.
+Eller betragt søpindsvinets pigge under mikroskop.
+Den kom og frifandt phatalaterne.
+Fujimori regerede sågar uden hensyntagen til det parlamentariske demokrati og vælgernes ønsker.
+Byrne ikke større kompetence end enhver anden fagmand, som ikke har kendskab til prioner.
+Kommissionen har på forskellig vis forsøgt at torpedere denne aftale.
+Cyprioterne er ikke en slags andenklasses borgere i en osmannisk eller en anden koloni.
+Bloom til at komme med en undskyldning.
+Helpline skal sættes i gang så hurtigt som muligt.
+Som det senere fremgik af afstemningen, var det endelige resultat marginalt i kandidatens favør.
+Vi danner en ny hær af nyfattige!
+Folk sælger fødevarer i pund og ounces.
+Giegold, er yderligere bevis herpå.
+Farvel koruna, velkommen euro.
+Freitas tillykke med hans fremragende betænkning.
+De er forblevet under skæppen.
+Dette er ikke den fortabte søns hjemkomst.
+Den europæiske tunindustri er ikke truet.
+Busquins stærke støtte til garantifonden for blot at nævne nogle få.
+Set fra forbrugerens synspunkt viste oprindelseslandsprincippet sig at være et pingpongspil.
+Og dette pokerspil er nu gået galt.
+Hoedt løslades uden tiltale.
+Elkøretøjer omfatter tog, sporvogne, busser, biler og cykler.
+Rådet og medlemsstaterne er lysår væk fra denne holdning.
+Aftalen indeholder heldigvis også stærke incitamenter vedrørende elektriske biler eller hybridbiler.
+Gaubert tydeligt understreget i sin betænkning.
+Har landet ikke baseret sit fremskridt på negrenes pinsler og slaveri?
+Hun kom hjem igen i weeekenden.
+Efter sultestrejken blev han anklaget for at gennemføre en uautoriseret protest.
+Men deres protester er blevet affejet med en håndbevægelse som forhastet teknokratisk argumentation.
+Under pres tyede ordføreren til et groft proceduremæssigt trick.
+Vi fosøger at anvende et klassisk, parlamentarisk instrument til at kontrollere den udøvende magt.
+Kisterne blev gravet op, og kirkegården blev uden nogen form for ærbødighed vanhelliget.
+Denne angivelige statssuverænitet er helt usuveræn og helt inhuman.
+Hvem skal betale for vådterrænerne, biodiversiteten osv.?
+Før i tiden kunne elektrolyse, tandlægevidenskaben og juvelerer ikke klare sig uden.
+Kommissionen vier en stor del af meddelelsen til de fremtidige demografiske forandringer.
+Vi bliver i virkeligheden bedt om så at sige at købe koen i sækken.
+Men man kan ikke behandle kræft med aspirin.
+Dehaene, deltog i konferencen.
+Man finder allerede det blå flag på alle pengesedler og bilnummerplader.
+Sågar algoritmer i computerprogrammer skal ikke længere stå til fri rådighed.
+Det er en reminiscens af en zars besøg i en undergivet provins.
+For det tredje fordi det fastsætter en uacceptabel undtagelse for uemballeret cement.
+Chountis for at henlede opmærksomheden på dette emne, der vil blive afklaret meget snart.
+Selv dværgene burde kunne rejse sig i deres fulde højde.
+Malmø bys initiativer inden for energibesparelser og brug af miljøvenlig transport er lovende.
+Jeg støtter i stedet demilitarisering og nuloprustning.
+Jeg har forståelse for de frustrationer og yderligere omkostninger, som påløber i dette område.
+Det bygger på sand og er en kolos på lerfødder.
+Jeg tænker konkret på den portugisiske regerings holdning over for de andalusiske fiskere.
+Ja, de overvejer det, ja, de har modtaget adskillige årberetninger om beskyttelse af persondata.
+Varme somre er på vej, og vi bør redde byboernes liv.
+Det betyder, at der er behov for reformer over hele linien.
+Dette er en moderne form for feudalisme.
+De giver alt væk, rub og stub, deres formue og deres håb.
+Vi skal fortsætte med den frivillige etos.
+Med projekttilgangen skydes der for tilfældigt fra hoften.
+En foranstaltning som denne kan måske finansiere et fartøjs turomkostninger og faste omkostninger.
+Den samme hulhed gælder for de erklæringer, der offentliggøres efter vores egne europæiske topmøder.
+Alt dette sker i koherens med de tidligere udnyttelsesprocenter.
+Det kapitulerer over for sukkerindustriens interesser og sødladne måde at lobbye på.
+Det ville føre til en ny steppebrand.
+Møderne sluttede alle i de årle morgentimer.
+Det tilsætningsstof, jeg tænker på i denne sag, er ethylhydroxyethylcellulose.
+Direktivet om byspildevand er et eksempel på denne dårlige gennemførelse.
+Hans eneste fejl er, at han har fordømt regimets slingrende kurs.
+Det er det, der gør dreamlineren til det mest støttede fly i verden.
+Denne remailing er dybest set illoyal konkurrence og skal stoppes.
+Det ligner sommetider en kombination af en argentinsk tango og en brasiliansk samba.
+De mange lækager og forskellige oplysninger såede tvivl om de offentliggjorte valgresultater.
+I al sin nøgenhed ser vi, hvilken høst kommunismens dragefrø resulterer i.
+De er det roterende formandskab.
+Det er i syddelen, vi finder dem, der afviser den.
+Vi mener desuden, at rammedirektiver skal have en slags sunset clause, en frist.
+For det andet er den i betænkningen foreslåede biregionale solidaritetsfond ikke ønskværdig.
+Lomas, at jeg som formand havde udtrykt mig helt klart.
+Hvad ville han imidlertid have været uden et bigband?
+Det er med rette, at vi klør på.
+I dette tilfælde blev bagmændene fanget.
+Vi er ikke nogen cd, som man sætter i gang igen og igen.
+Det har ikke en birolle i processen.
+Det skal ske med pull and push foranstaltninger.
+Har vi den mindste brøkdel af denne algeriske løjtnants mod?
+Disse billeder udgør en indtrængen på en persons private enemærker.
+Såvel de nye medlemmer som eksisterende medlemsstater drog fordel af dem.
+Sollys, vind og havstrømme er eksempler på den type energi.
+Men jeg advarer mod at bringe bykulturen ud på landet med disse programmer.
+Råhuset står færdigt, lad os gøre det beboeligt.
+Vi ville simpelthen ende med kun at have sport, amerikanske film og talkshows.
+Da jeg sagde, at jeg ikke bærer nag, tænkte jeg på visse kolleger.
+På et vist tidspunkt vil det så tippe over til en anden tilstand.
+Colajannis ensidige beslutningsforslag opfylder ikke dette udgangspunkt.
+På denne måde øves der produktivt pres.
+Flere gange har man også talt om et sionistisk komplot.
+Titfords forsøg på at ødelægge vores gode humør sådan en dag.
+Det vigtigste stridspunkt er imidlertid spørgsmålet om, hvilke typer havari der skal omfattes.
+For det første, hvorfor har vi brug for en risreform?
+Et sejlskib, som udvides, men ikke gøres dybere, kæntrer let.
+Vi skal være særligt opmærksomme på vejprojekter for at undgå dårligt håndværk.
+En væsentlig manko er ganske givet den præcision, der stadig mangler mange steder.
+Dette hverv har jeg altid uøvet med meget stor glæde.
+Dette er særligt relevant i min østirske valgkreds.
+Vi har imidlertid først og fremmest brug for class budgeting eller budgettering efter samfundsgruppe.
+Notfiskeriet truer ikke den biologiske overlevelse af de udnyttede bestande.
+Så jeg købte endnu en god ovn.
+Tabajdi for hans fremragende betænkning.
+Jeg foreslår derfor, at man i stedet taler om optælling af sædprøver.
+Moldova er et land, hvor fællesskabet, hvor samfundet har abdiceret på en række områder.
+Kakao, chokolade, kaffe og cikorie
+Der bliver ikke krøbet uden om.
+Mettenbetænkningen siger ja.
+Det kan vælge mellem at være en urostifter eller en konstruktiv partner.
+Jeg har kun sagt goddag til de to store matadorer i denne debat.
+Der er ikke gjort noget seriøst for at få has på problemet.
+Det er derfor øknomisk fornuftigt at ramme en balance nu.
+Dette er kapitalismens grimme fjæs.
+Juncker, mine damer og herrer!
+De frygter, at de igen kommer til at befinde sig mellem hammer og ambolt.
+At udbrede sådanne handlinger er et angreb på familien, og det fører til abnormiteter.
+Ferber taknemmelig for hans venlige bemærkninger om min præcise ankomst.
+I praksis er hæren i dag et bolværk mod den islamiske religion.
+Ved en fjerdedel af træerne blev der konstateret alvorlige tab af nåle eller løv.
+Alså ikke nogen dramatisk forskel.
+En sidste bemærkning til det prekære tema double use eller kun civil anvendelse.
+Kaput er kaput på alle sprog!
+De nævner de særlige omstændigheder, især ved finansieringen af open broadcasting network.
+Spørgsmålet om sikkerhed ved nethandel bør ikke blandes med de juridiske krav ved merværdiafgifterne.
+Undskyld mig, men det er både præhistorisk tænkning og bondefangeri.
+Padania er det sidste eksempel herpå!
+Kun i to lande findes der et endnu større løngab.
+Ja, vi må tage spørgsmålet om szeklerfolkets territoriale selvstyre op.
+Killilea på ny ønsker ordet.
+Ønsker vi at skyde fra boven?
+Der er ikke brug for didaktik, men berettiget kritik.
+Vi har allerede haft nogle homeriske diskussioner om mærkning af alkoholholdige drikkevarer.
+De risikerer at dø en særdeles pinefuld død af enten dehydrering eller iltmangel.
+Bowes bemærkning om behovet for at reducere, genbruge og genanvende affald.
+Man må vænne sig til referencer af nærmest klerikal art.
+Kerr om at huske tilbage til afstemningsdagen.
+Den ligger igen primært inden for lånyderens ansvar.
+Hvorfor er vi nødt til at finansiere skiundervisning i skolerne denne uge?
+Hvis vi skal kunne gribe ind, har vi brug for et kort med geohenvisninger.
+Men vi kan ikke skabe fred ved at bibeholde disse bantustans eller denne apartheid.
+I forbindelse med rumopvarmning har vi således været uafhængige af prisudsving på verdensmarkedet.
+De skal opvarmes af en brand, for at de kan gro.
+Kozloduy illustrerer et vigtigt aspekt af dette problem.
+Det kræver ikke nye magiske remedier.
+Hvad så, er tiøren nu faldet?
+Drabet af den apostolske nuntius er et af de seneste eksempler på meningsløs vold.
+Ordføreren kan påregne den grønne gruppes støtte i forbindelse med denne sag.
+Castro bliver ved med at være umedgørlig.
+Hvirveldyr og primater nyder særlig beskyttelse.
+Er fastsættelsen af forpligtelser i strid med den nuværende økonomiske og teknologiske situation?s
+Vondra tilføje noget om, hvordan denne pakke bliver forberedt til junitopmødet.
+Oprindeligt bidrog det kun til at udarbejde den europæiske fælles akt.
+Lige så vigtigt ville det være at diskutere natmøderne bedre.
+Barton forsøger at torpedere enhver strengere regulering.
+En uskreven aftale er ikke nok og garanterer ikke dataenes sammenlignelighed og fuldstændighed.
+Fordi så længe aftalen ikke er på plads, er der unødvendig omkørselstrafik.
+Jeg er blevet valgt på et mandat for at kæmpe mod politisk pilfingerering.
+Ah, det var da slet ikke så slemt!
+De vil få lov til at smage et sødt løg.
+Wuori, understreger, men det går fremad.
+Der anvendes rug af meget høj kvalitet til produktion af funktionel mad.
+Det drejer sig om de brandfarlige drivgasser butan, isobutan og propan.
+Haagerkonferencens høringsrunde, som begyndte for syv år siden, nærmer sig en afslutning.
+Bypartnerskaber er et godt middel til at bidrage til dette.
+Bibliotekernes kundskaber vil udgøre en særlig vigtig del som arrangør af netdata.
+Det er absolut nødvendigt for at udgå afartede forhold og beskytte den menneskelige værdighed.
+De fleste af de lande, som vi kommer fra, har et tokammersystem.
+Desuden forbrændes der allerede meget biomasse i kulcentraler.
+Situationen kan derfor risikere atter at gå i hårknude.
+Hyde, for jeg er helt enig med dr.
+Åger gør ciselering rusten, gør kunst og kunstneren rusten.
+Giusto, du har lavet en dum fejl.
+For øjeblikket er vi ved at udforme flunkende nye måder at lave energi på.
+Det betyder, at en zinkkiste er påkrævet, hvilket er meget dyrt.
+Burundi har brug for vores hjælp.
+Sakellariou, der er ingen, der har foreslået, at man stemmer imod denne betænkning.
+Vi mener sågar, at dette er et ret stort vrængbillede.
+De skrev aldrig hjem om, at den rhodesiske befolkning måtte sulte.
+Ingen medlemsstat må få lov til at sno sig ud af sine forpligtelser.
+Maritim transport er hjørnestenen i den irske industri, som er en øbaseret økonomi.
+Denne ene procent er alt, hvad vi har at rutte med.
+Han insisterer også på, at alle selvstændige chauffører skal have et takometer.
+Dette tilsagn bør ikke omfatte kosmetisk ommærkning af midler til infrastrukturen.
+De kvæulerer om den fuldstændige rædsel?
+Dette had opstod under zardømmet og fortsatte under stalinismen og er endnu ikke udryddet.
+Det måske vigtigste fremskridt er, at den usigelige kørekortturisme stoppes.
+Efter den første toenhalvtimesdebat havde hver minister tre minutters taletid.
+Tomczak var inde på det generelle med hensyn til finanskrisen.
+Der er fortsat nulafgift på visse produkter.
+Erlæggelsen af visse sundhedsydelser er ringe i de fleste af de nye medlemsstater.
+Den engelske tekst skal helt rigtigt oversættes med without delay.
+Der er tale om et rusmiddel, der skal behandles som sådant.
+Beslutningsforslagets tekst, dok.
+Wijkman, som ikke er til stede.
+De stopper uden grund på etager, bliver overfyldt og går i stå.
+Med hensyn til ost fremstillet af råmælk, har vi også stadig knap et år.
+Selvom benzinmotorer er den primære benzenkilde, er metallurgiske koksværker også berørt.
+Det handler om dagblade, ugeaviser og andre pakkeforsendelser.
+Problemet er de høje blyværdier i den maling, der anvendes til det pågældende legetøj.
+Mladenov har præsenteret med hjælp fra sine kolleger.
+Jeans er en måde at undgå voldtægt på.
+Der er også mindre bærende ting i bogordningen.
+Men det bliver vi også nødt til at henføre til detaildebatterne, til fagdebatterne.
+Veraldis betænkning omhandler alle disse punkter, og af den grund stemte jeg for betænkningen.
+Danskerne regner ikke med nogen omkostninger, de har øjensynligt ingen blyrør.
+Det var angiveligt et rovmord begået af unge.
+Alt i alt er det altså ikke en tabula rasa , vi vil.
+Det skal gælde for alle , som er lovligt bosiddende hos os.
+Vi kan heller ikke lægge bekæmpelsen af ulovlig indvandring over på fiskerfartøjernes skippere.
+Det er ikke, hvad vi forstår ved taking into account.
+Vin er et fermenteret produkt, ikke et blandet produkt.
+Få uger før ikræfttrædelsen af det tredje trin skal dette vigtige spørgsmål løses endeligt.
+Det forsøger at lokke ayatollaherne ud af deres nukleare ambitioner.
+Dette er sandsynligvis ikke tilfældet for de andre rumbaser.
+Khanbhai undskylder meget for ikke at være til stede for at fremlægge sin betænkning.
+Den næste lejlighed bliver udenrigsministrenes troika i november.
+Man kan ikke være beslutsom i ord, men vankelmodig i handling.
+Sulfit er et af de stoffer, der er medvirkende årsag hertil.
+Til gengæld bliver spørgsmålet om lande, som eventuelt bliver uden for emuen, uløst.
+Wittgenstein har sagt, at det at vælge et sprog er at vælge en livsform.
+Hongkong planlægger også et forbud.
+Kuckelkorn, for deres betænkninger og det arbejde, de har gjort.
+Gualtieri med dagens betænkning.
+Det tilsigtede modal shift kommer herved ud på et skråplan.
+Men det er også centrum for pædofile, bondefangere og de mest usofistikerede udenlandske agenter.
+Et meget vigtigt initiativ på dette område blev søsat tidligere på året.
+Det var nærmest bogværker, som af og til blev for meget for mig.
+Kun personer, der har en uplettet straffeattest har tilladelse til at arbejde med børn.
+Forskningsmidler til mindskelse af affaldsmængden og en øgning af anlæggenes sikkerhed er påkrævet.
+Vanskeligt kontrollerbare sygdomme såsom ebola har spredt sig til mennesker.
+Vi kan holde alle de skåltaler, vi vil, om dette kombinerede transportprojekt.
+Den fungerer som bustjeneste.
+Men desværre betyder denne udelukkelse ikke, at solteknologier støttes.
+Udvalgets tredje prioritet er integration af indvandrere og bekæmpelse af rascisme og fremmedhad.
+Wiersma og flere andre meget klart.
+Forhandlingens vaghed sikrer ikke nationernes frihed, sådan som man gerne vil give udtryk for.
+Her handler det om en asset inflation i verdensformat.
+Således trak den en enorm mængde rubler ud af landets offentlige pengeomløb.
+Nicaragua er et advarende eksempel på, at den slags herskere ikke ændrer sig.
+Senere fandt man spor af sarin i atmosfæren.
+Fondsmodellen er blevet foreslået, men anpartsmodellen kan være et andet alternativ.
+Etymologerne provokerer os.
+Jeg insinuerer ikke, at nederlænderne er æreløse, heller ikke svenskerne.
+Udnyttelsen af rummet er ganske umærkeligt blevet en del af dagligdagen.
+Det catalanske, occitanske og bretonske sprog er rodspirerne til det franske kulturelle træ.
+Bolognaprocessen er den mest radikale reform af de videregående uddannelser i de senere år.
+Togo er på vej ud af en vanskelig politisk og økonomisk situation.
+Grækenland fortjener anerkendelse og støtte, ikke at få på puklen.
+Europas stemme skal lyde som et enstemmigt kor, ikke disharmonisk og ude af takt.
+Myndigheden i det eksporterende tredjeland skal udtrykkeligt give tilladelse til reeksporten.
+Denne meget realistiske betænkning vidner unægteligt om en åbnhed.
+I virkeligheden rider dette direktiv med på modebølgen og den nemme dydighed.
+Det vil romantiske amatørers dagdrømme ikke ændre på.
+Men på dette tdispunkt kan forhandlingen dårligt fortsættes.
+Desuden minder ofringen af menneskeligt liv for at kunne bedre andres liv om kannibalisme.
+Lad mig straks sige, at religiøs forfølgelse er uislamisk.
+Efter min mening er det lykkedes helt for os at skille avnerne fra kernerne.
+Åbenheden i gasbranchen skal øges, og forsyningsruter og leverandører skal diversificeres.
+Bendtsen, for hans nøjagtige betænkning.
+Saddams biologiske våben omfatter anthrax eller miltbrand.
+Indiens geostrategiske og geoøkonomiske betydning er åbenlys.
+Jeg har endnu aldrig set en ko stå ved grøftekanten og spejde efter fisk.
+Cushnahan, talte om kløften mellem retorik og virkelighed.
+Kommissionen burde sætte en stopper for den systematiske og forsætlige lækning til pressen.
+Jeg blev for nylig opereret for at få fjernet min galdeblære.
+Det er aldrig før blvet tilladt i denne forbindelse.
+Vi skal alle sammen være en del af den sydvestlige region.
+De er vidner til, at demonstranter arresteres, og at journalister chikaneres og tæves.
+Godmorgen, mine damer og herrer!
+Det er forældet at ensrette menneskers liv til efter ensartet ugeplan.
+Man kan tilmed hyre institutioner til at gøre arbejdet.
+Ortuondo ordet, hvis han mener, at dette vedrører ham.
+Pegase burde fornuftigvis sættes i kraft i morgen.
+Marianne, du har gjort et meget efficient, professionelt og effektivt arbejde.
+Ecuen havde således en vis stabilitet.
+Vi må ikke flå dette hjertestykke ud, og vi bør udrydde misforståelserne i offentligheden.
+Anna er imidlertid ikke det eneste offer.
+Han opførte klinikker, hvor han opererede kvinder, der led af fistler efter vanskelige fødsler.
+Derfor er jeg bestemt ikke tilhænger af, at rismarkederne åbnes for alle verdens markeder.
+Først og fremmest foreslås et tilsætningsstof kaldet natriumalginat til brug i revne gulerødder.
+Spyware giver en tredjepart adgang til samme data som brugeren.
+Det er almindelig tuns virkelige problem.
+Derfor står dette direktiv på gyngende grund.
+Foie gras er en national specialitet i mange lande.
+For transport, for byarkitektur og særlige politikker for arbejdsmarkedet og for uddannelse.
+Jeg kan ikke selv se løsningen i denne form for temmelig kortsigtet ideologisk skvalder.
+Vi må gøre en ende på det monopol, som krigens bipolarisering har besiddet.
+Silesien er det område, der er hårdest ramt.
+Haglbygerne og naturkræfterne var så voldsomme, at de ødelagde adskillige afgrøder.
+Vi ynder at fastsætte betingelser i forbindelse med vores støttepakker.
+Lisi, for hans hårde arbejde på denne betænkning, og jeg støtter hans bemærkninger.
+Birdal, som deltog meget aktivt i mødet.
+Fiat nægter at holde møder, debatter eller forhandlinger med fagforeningsrepræsentanterne.
+Jeg ønsker ikke endnu et svar i kancellistil.
+Det er den institutionaliserede bodfærdighed.
+Det er da ikke noget scoop.
+Inglewood med henblik på den bemærkning, han netop havde.
+We want to be players, not only payers.
+Ispir trods rumænske mediers påstande om hans indblanding i korruption.
+Vores gruppe har stillet et ændringsforslag om en jorudtagningssats på nul.
+Hvis man betaler med lire, skal jeg så give tilbage i euro?
+Et ormstukkent æble kan udmærket være sundere end et dejligt rundt, skinnende æble.
+Vi har brug for at gå fremad, ikke baglæns ligesom krabber.
+Tværtimod knokler arbejdstagerne under forfærdelige forhold og får næsten ingenting for det.
+De tyrkiske myndigheder klassificerede affaldet som farligt på grund af dets indhold af krom.
+Beka mistede en del af sit kranium, og der er fortsat granatkardæsk derinde.
+Vi er loyale partnere og ikke lakajer.
+Turchi, for det frugtbare samarbejde.
+Sygdomme som kolera, polio og gulsot er mangedoblet.
+There is no culture without agriculture!
+Mens alt dette finder sted, fortsætter varroamiden sit ødelæggende arbejde, og bierne dør.
+På begge punkter er problemet, at man sjældent når, men snarere kløjs i målene.
+Her handler det ikke blot om gennemskueligheden af talopsætninger, tabeller eller grafer.
+Mercosur har alt det, det behøver.
+Glem ikke den venstre vinge.
+Under recessions kølige vinde har investorerne søgt ly under euroens vinger.
+Der er andet arbejde nok, så vi behøver ikke at udføre et sådant sisyfosarbejde.
+Derfor er mærkningen alt for ofte blevet brugt i flæng og uberettiget.
+Togbilletter til fjerne destinationer er man ofte nødt til at købe uden for afrejselandet.
+Afstraffelsen skyldtes øldrikning.
+Emiren indgav altså lovforslaget i ferieperioden.
+Monnet lagde fundamentet til dette foretagende.
+En proaktiv politik bør indebære, at ukvoterede sorter hurtigst muligt kvoteres.
+Parlamentsmedlemmerne ved, at man ikke kan reregulere et marked.
+Kirilovs betænkning, velkommen.
+Endnu en gang er den megen kokkereren ikke ensbetydende med god mad.
+Jeg vil også gerne kunne se nødudgangsskilte.
+Er det bare et teknisk fif eller en udvikling af gennemsigtigheden i selve beslutningstagningen?
+Vi burde holde os for gode til at kolportere rygter på plenarforsamlingen.
+Ih, hvor dejligt, der kommer hun jo!
+Den, der kender denne egn, ved, at den ligefrem er forudbestemt til akvakultur.
+Kommissionen havde faktisk støttet nogle nye faciliteter til opdræt af pighvar.
+Man skal samtidig udføre grundlæggende arbejde for at højne den tanzaniske befolknings bevidsthed.
+Min definition af liberalisme er ikke en fri ræv i en fri hønsegård.
+Når løven, der brøler i den økonomiske jungle, bliver våd, opdager den solidaritetens fordele.
+Men hvis vi blot ville foreslå en ommøblering, ville det helt klart være utilstrækkeligt.
+Formanden udtog stemmetællerne ved lodtrækning
+Æret være heltenes, martyrernes og ofrenes minde!
+Disse ændringsforslag vil slibe reformen til, således at den bliver god for landmændene.
+Mange generationer før os har higet efter dette.
+Jackson har forstået dette godt og taget hensyn til aspektet i sin betænkning.
+Han har nemlig på engelsk talt om et clear and rational document.
+Det må ikke være sådan, at verdens landmænd er afhængige af nogle multinationale frøproducenter.
+Nogle mennesker har endog en fupstatus som selvstændige.
+Vatikanet har i mellemtiden truffet foranstaltninger og iværksat en undersøgelse.
+Swietokrzyskie er et eksempel herpå.
+Man kan ikke se bort fra menneskerettigheder for nemheds skyld på et bestemt tidspunkt.
+Sædtallene falder, mens antallet af tilfælde af testikelkræft og brystkræft stiger.
+Der er brug for en tydelig specificering og prioritering af byniveau.
+Også små børn skal fremvise en hivtest for at få et russisk langtidsvisum osv.
+Jeg vil altså ikke sige mea culpa.
+Måske kunne en anden trehed være leve, rejse og elske.
+Vi skal hejse et klart signal.
+Hvis epilepsi ikke behandles, lider folk mere, end når der er passende behandling.
+For mælken og yoghurten eller for kartonet eller bægeret?
+Med andre ord forbliver omkostningerne de samme for eloperatørerne.
+Vi ved jo, hvem der oftest bliver ramt af sygdommen tinnitus.
+Næsten alle regeringer murrer over tjenestemændenes eller dommernes lønninger.
+Vi havde vores hyr med definitionen på vodka.
+Kohl til at gøre en indsats til fordel for beskæftigelsen!
+Men vi må lade vores iver løbe af med os.
+Sexarbejdere skal have adgang til retshjælp til en overkommelig pris for at øge domfældelsesraten.
+Caldeira, mine damer og herrer!
+Famagusta var en populær turistdestination.
+Regeringskonferencen er i bakgear.
+De opsvulmede åer og floder rev alt det med, som stillede sig i vejen.
+Vi må forberede os på en lang og sej kamp.
+Teverson for en modig og upartisk betænkning samt for en fordomsfri behandling af emnet.
+Mbekis opgave bliver at skabe betingelser for frie og retfærdige valg.
+Men de skal tale ærligt, ikke tale med to tunger eller med kløvet tunge.
+Mayer sagde om retsgrundlaget.
+Dette har især ramt den samiske befolkning.
+Cepol skal ikke desto mindre gøre en større indsats.
+Så hvad med nødgenbosættelse?
+Hizbollah er en politisk, men også en militær organisation.
+Den er kogt ned til kun at indeholde specifikke politikker.
+Foranstaltningerne er palliative.
+Hvis vi vil gøre noget mod flylarmen, skal de tekniske forbedringer gennemføres hurtigere.
+Dens morderiske angreb har ikke forbedret deres situation en tøddel.
+Lazarus slår virkelig til igen.
+Det ville være et brohoved for indsatsen for at sikre ytringsfrihed.
+Mange tophoveder fra dengang er i dag ikke længere nogen fryd for øjet.
+Laeken stillede de rigtige spørgsmål.
+Lyskurven lyser efter min mening gult her.
+Denne undersøgelseskommission skal i så fald dække hele det store søområde.
+Leksikonets konklusion var, at menneskeheden aldrig ville kunne ødelægge denne art.
+Vi har hørt en meget omfattende opremsning af forskellige muciner.
+Man nævner nemlig hunde, katte, akvariefisk, amfibier, reptiler, fugle og pattedyr.
+Vi ønsker ikke amerikanske tilstande, hvor lovgivning udarbejdes alt efter dagens misopfattelser.
+Dette litra bør efter vores mening helt slettes.
+Fromt håb indadtil, øredøvende tavshed udadtil.
+Der foregår en tektonisk forandring lige for øjnene af os.
+Hvor er solfangeranlæggene i troperne?
+Det er en aftale, der indeholder mange uklare punkter, tvivl og uopklarede områder.
+Halvdelen af isdækket er allerede smeltet.
+Brasilien nægtede at slippe nogen ind, der ikke var vaccineret mod gul feber.
+Hvilke produkter mener man, når der står krebsdyr?
+Man har også taget hensyn til vores særlige forhold, som for eksempel isbryderes betydning.
+Det bliver værre for udviklingslandene, fordi udbredelsen af ørknerne rammer dem i særlig grad.
+For den kan hverken gøre dit eller dat!
+Foretager vi en uhildet vurdering, må vi erkende, at man bifalder dets resultater.
+Vatanen sagde dette med stor overbevisning for et øjeblik siden.
+Det er en uskik, når det gælder databeskyttelse.
+Det er den tvungne skyldighed, den moralske inkvisition og den konstante psykiske bearbejdning.
+Man ved, at denne praksis med fjernelse af hajfinner truer adskillige hajarters overlevelse.
+Det er naturligvis igen den grønne gruppe med dens ævl om miljøet, ikke sandt?
+Csangoerne, som også lever i yderste fattigdom i et enkelt område?
+Samtidig har issmeltningen medført nogle uforudsete ændringer i havstrømmene.
+Vi har såldes en ny traktat.
+Der er heller ikke nogen mening med at plukke kirsebær på nuværende tidspunkt.
+Vi vil ikke underskrive nogen bodserklæring til imperialisterne.
+Men hvem sørger for nyvindinger inden for teknologien?
+Alle ved, at den næste skandale bliver salpeterforurenede grøntsager.
+Den kan undertiden være snoet, og den er altid krævende.
+Min egen bror, engelsk som jeg selv, var teknisk tegner.
+Forarbejdningsindustrien og forhandlerne vil æde det hele op.
+Iskapper forsvinder, havoverfladen stiger, og der er snart ingen vej tilbage.
+Vi skal ikke blandes ind i for mange interne micromanagementbeslutninger.
+De har karakter af grundlæggende rettigheder, men er ikke just frodige i deres formuleringer.
+Det hele er tillige blevet spundet ind i en bestikkelsesskandale i den sydafrikanske regering.
+Wojciechowski sagde for et øjeblik siden, er dette et eksempel på europæisk solidaritet.
+Det lærer man ikke vores kære små poder.
+Denne prøve er dog en forudsætning for optagelse på de fleste angloamerikanske universiteter.
+Koordinering af den økonomiske politik må ikke være et fyord i disse haller.
+Desuden kræves det, at der træffes de nødvendige foranstaltninger til at opfylde elindustriens behov.
+Jeg husker stadig, at mange dengang drillede hende med, at hun så spøgelser.
+Lærer du ham at fiske, er han mæt resten af livet.
+Life is very short and there is no time.
+Kompensationen er til sukkerroeavlere, inulinsirupproducenter og cikorieavlere.
+I vores øjne van denne strategi mangelfuld på to vigtige punkter.
+Stauners ændringsforslag om observatoriet skal vedtages.
+Den krig, der har været spået om, er ved at være en realitet.
+Grech for deres positive måde at lede denne budgetprocedure på.
+Alexander, særlig når det gælder spørgsmålet om den juridiske status af erklæringen.
+Væk er de ubehagelige sprøjter, de ildelugtende piber og den afslørende røglugt.
+Lad os holde op med at lege kispus med landbruget.
+Nicole, som en ven takker jeg dig af hele mit hjerte.
+Investering i mennesker børe være omdrejningspunktet, når det gælder strukturelle reformer.
+Denne bonus bør vi ikke klatte væk, ærede kolleger.
+Der laves piratkopier af musik og film på cd og dvd.
+Men hvad bliver der så tilbage af susidiaritetsprincippet?
+Mange liv anhænger af disse foranstaltninger.
+Emnets aktuelle status er ynkværdig.
+Pasning og bearbejdning af træmasse og tørv kræver arbejde.
+Er det korrekt, at en norsk virksomhed har fået topdomænenavnene?
+Utæmmet konkurrence og kapløbet om rentabilitet er imidlertid uacceptabelt i denne forbindelse.
+Med dette direktiv vil døren være pivåben.
+Monfils, for deres aktive deltagelse i denne procedure.
+Tobak er en gift og en rusgift.
+Hestene står i vand til bugen, men de drikker alligevel ikke.
+Hvis euroen er en svag valuta, så var marken helt bestemt anæmisk.
+Se cierra el turno de votaciones.
+På denne måde banes vejen for flere forbrydelser til søs i lighed med m.fl.
+De gotiske domkirker blev til gennem mange generationer.
+Det, de afviste, var ikke åbningen af verden, men den globaliserede merkantilisme.
+Det langtovervejende flertal af befolkningen fordømmer fabrikslandbrug og buræglægningssystemet.
+I øjeblikket kan medlemsstaterne selv definere begrebet natperiode.
+Denne formulering kan forekomme en smule ukultiveret og behøver en smule forklaring.
+Bardong, vil komme med en kort kommentar.
+Det vil hjælpe med til at mindske nepalesernes sårbarhed over for de maoistiske rebeller.
+Trods de seneste dages feststemning handler disse tanker mere om problemer end om ovationer.
+Aceh var en stor søfarernation og har også haft en religiøs indflydelse på regionen.
+Vi har efter min opfattelse reageret alt for vegt i denne sag indtil nu.
+Javist er der mangler, men de kan korrigeres.
+I de sidste seks år har hun som bekendt forsøgt at blive cand.jur.
+Meget højtydende rapsfrø vokser lige ved siden af en eksisterende petrokemisk industri.
+Hensigten at gå på kompromis med sikkerheden for ikke at tirre den kinesiske regering?
+Feira satte spørgsmålet på regeringskonferencens dagsorden.
+Challenger sprang i luften trods teknologerne.
+Zimmerling netop har sagt.
+Kommissionen har dog været dumdristig nok til at se gennem fingrene med det.
+Jeg tror, at de baltiske lande har fået de allerværste knubs.
+Der foregår storstilet jagt på krondyr, vildsvin og elg i de polske skove.
+Og så spiste jeg nogle glimrende hotdogs!
+Casparys ord om, at der er en lang række menneskerettighedsproblemer og andre problemer.
+Det trænger sig derfor på at gøre status over forbindelserne med vores alpine nabo.
+Accepterer vi, at forskningen identificeres med drømmen om et nyt økonomisk eldorado?
+Blodbadene fra disse robåde er alt for hyppige.
+De skal til omeksamen i juni.
+Petersborg og ikke champagne.
+Bogafbrændinger lever i bedste velgående.
+Som det understreges i betænkningen og meddelelsen, er valghandlinger ikke endagsforestillinger.
+Man er ved at forberede en bistandspakke, der skal søsættes snarest muligt.
+Jeg husker tydeligt de enorme ligbål med brændende dyr.
+Det er en kårde, der rammer lige i hjertet.
+Desuden ville vi udsætte os for at blive bebrejdet, at novel foodforordningen er etiketsvindel.
+De skader, den forårsager, truer mange dambrugeres og fiskeres eksistens.
+Før bogtrykkeriet var der reelt ikke noget, der hed intellektuel ejendomsret.
+Horror vacui , det lærte vi i gymnasiet i de klassiske fag.
+Tjah, men vi løsgængere har kontorer uden toiletter, uden vand!
+Mulighederne herfor stækkes til stadighed.
+Denne aggressive bakterie synes ustoppelig.
+Næste gang går midlerne utvivlsomt til snerydning.
+Elchlepp havde til hensigt at stemme for forslaget.
+Det tredje emne er krydsoverensstemmelse, cross compliance.
+De forventede indtægter varierer naturligvis på grundlag af disse to koefficienter.
+Skilsmisse er en alvorlig sag, der ganske ofte involverer smadrede tallerkener og bodeling.
+Mødre, børn og familier er en treenighed, som fremtiden skal bygges på.
+Glyphosat betragtes som kræftfremkaldende, og det har indflydelse på forplantningen.
+Bajonetter kan, som bekendt, bruges til meget.
+Afrikansk trypanosomiasis, bedre kendt under navnet sovesyge, er et godt eksempel herpå.
+Tavares med deres forhandlinger og deres indsats.
+Den newzealandske delegation består af fem medlemmer af parlamentet.
+Den øger mulighederne for jobformidling og styrker derudover også selvtilliden.
+Det var så alvorligt, at oprydningsholdet var iklædt rumdragter, som næsten begyndte at smelte.
+Borgerinitiativet www.oneseat.eu fortsætter.
+Det drejer sig i grunden om at addere ettaller og nuller.
+Vi har her i salen flere arvtagere til denne tankegang.
+Andesbjergenes isgletsjere er tæt på helt at forsvinde.
+Jeg vil også gerne fremhæve, at enhver henvisning til højtydende rifler er unødvendig.
+De herrer har åbenbart også fået den udenrigspolitiske paella i den gale hals.
+Der svæver således et gigantisk damoklessværd over den europæiske kulturpolitik.
+Jeg vil gerne nævne noget, de sicilianske fiskere sagde.
+De ved nok, at det finske sprog har alt for mange vokaler.
+Også dyrebeskyttelsen og bekæmpelsen af epizootier tildeler vi stor betydning.
+Hvad betyder i denne sammenhæng farven på væggene eller trykket i cisternerne?
+Vold af denne art er foragtelig og umenneskelig og derfor også umandig.
+Det er vigtigt i forbindelse med ulykker og navnlig eneulykker.
+I øjeblikket deponerer syv lande mere end halvdelen af deres dagrenovation.
+Kurserne faldt så meget, at bærrene ikke engang blev plukket.
+Det er allerede blevet nævnt, at mange børn med dysleksi er endog højt begavede.
+Soares ikke i dag lejlighed til at spise os af med pæne ord.
+Euro skal blive den tredje internationale reservevaluta ved siden af dollar og yen.
+Det er meget gode nyheder for døvblinde.
+Dette problem kom ikke som et lyn fra en klar himmel.
+Også en hotelvirksomhed har best available technology for spildevandet.
+Alt var altid meget vagt og uldent.
+Måske bare med en simpel ordassocieringsprøve.
+Der er for meget krigsretorik og tamtam.
+Rådets esktraordinære samling
+Poos vil sige mere om det senere.
+Mine damer og herrer, det er på tide, vi vågner op fra vores rus.
+Formålet med vinreformen er at fremme produktionen af acceptable vine af god kvalitet.
+Narkotikaproblemet kæver en pragmatisk tilgang og et åbent sind.
+Vi er nødt til at skrue bissen på.

--- a/server/data/da/europarl-v7-da.txt
+++ b/server/data/da/europarl-v7-da.txt
@@ -134,7 +134,6 @@ De skal kun opfylde det, vi selv opfylder i dag.
 Yderst effektiv er naturligvis forbrugerafgørelsen.
 De har foreslået en styrkelse af disse kinesiske mure.
 Jeg venter mig endvidere en hel del af forbedrede vilkår for dyrehold.
-Der er ikke hverken planter eller dyr tilbage.
 Det har efterladt mange af os med flere spørgsmål end svar.
 Det er enten sundhed, der er vigtigst, eller også er det markedet.
 Med direktivet indføres der harmonisering af uddannelseskravene til sygeplejersker.
@@ -398,7 +397,6 @@ Hvad angår alternativerne, er de fremlagt i rammeprogrammet.
 Nigeria er desværre et eksempel, som vækker bekymring.
 I denne forbindelse er det postdirektivet, som er lakmusprøven.
 Valget er ikke legitimt, eftersom den siddende præsident kom til magten ved et statskup.
-Dels det symbol, der ligger i temporal enhed.
 Derfor er vi ikke enige i ordførerens meget kritiske vurdering og begrundelse.
 Det havde været tilstrækkeligt at udskyde denne debat til en senere dato.
 De skal beskyttes ordentligt.
@@ -808,7 +806,6 @@ Dette er rigtigt og på sin plads, idet familien og børns trivsel bliver inddra
 Ifølge deres rådgivning bør alle lovforslag opridse formålet med den foreslåede lovgivning.
 Jeg tænker her på nødvendigheden af et mere solidarisk og generøst koncept om migration.
 Nye medlemmer vil naturligvis straks skulle have løn i overensstemmelse med det nye system.
-Busk, for deres udmærkede betænkning.
 Men betænkningen indeholder både korrekte videnskabelige data og fejlagtig polemik.
 Vi skal støtte det libanesiske folk, og vi skal støtte de libanesiske demokrater.
 Ingen forlader sit land, sin kultur og sin familie for sjov.
@@ -824,7 +821,6 @@ Hun foreslår, at differencen skal betales ud af de nuværende kvoteejeres lomme
 Også dets industri, dets landbrug og dets tertiære sektor frembyder gode muligheder for udvikling.
 Fred kan kun baseres på ligeværdig respekt for modpartens territoriale integritet og rettigheder.
 Hovedproblemet i nutidens samfund er netop, at alderspyramiden bliver stadig bredere i toppen.
-Terrorister, mordere og kommunister!
 Jeg ønsker ikke at se disse ting degenerere til overcentralisering, kaos og forvirring.
 Denne særdeles lave pris er kun mulig på grund af masseproduktion på minimale arealer.
 Eksportstøtten udfases også.
@@ -1156,7 +1152,6 @@ I modsat fald ville det naturligvis være fuldstændig absurd at gennemføre den
 Det handler både om ordentlige toldkontroller ved de ydre grænser og kontroller i medlemsstaterne.
 Herefter aflagde udenrigsministre og kommissærer besøg på øen.
 Udbredelse af europæiske film
-Lange har, nemlig at det i allerhøjeste grad ville være nyttigt at inkludere dem.
 Vi må imødegå den vedtagne lov med meget skarpe tiltag.
 Det lød som arrogance i mine øren.
 Der har de en fremragende platform for deres politiske budskab om had.
@@ -1489,7 +1484,6 @@ Men den barbariske behandling af kvinderne knytter sig ikke kun til præstestyre
 Så vil denne aktion tjene til vores nationers æres.
 Måske den offentlige europæiske debat venter på at blive rusket op.
 En gammel trawler er lige så farlig som en gammel olietanker.
-Ifølge mine oplysninger stilles de op få kilometer herfra, hvorfor, ved jeg ikke.
 Vi skal dog afholde en afstemning for at få fastlagt næstformændenes rangfølge.
 Det er billigere end at lægge korn på lager.
 Økonomi, æstetik og teknologi indgår i en symbiose med hinanden.
@@ -1626,7 +1620,6 @@ De skulle jo fodres, så vi havde et alvorligt problem.
 Systemets pålidelighed er vigtig, da det skal fungere hele tiden.
 Kan man handle via kirker og på andre måder?
 Menneskehandlen berører især kvinder, som er ofre for organiserede mafiaer og for prostitution.
-Brok, ville vi faktisk allerede været kommet langt videre.
 Krisens økonomiske omkostninger er endnu ikke endeligt opgjort.
 Det forsøger at købslå sig frem, men er dømt til at mislykkes.
 Derfor kan vi ikke acceptere, at vi bliver miskrediteret på denne måde.
@@ -1706,7 +1699,6 @@ Man kan trygt sige, at flyselskaberne tidligere ynkeligt har negligeret passager
 En indforståethed, der bringer volden med sig, som en tordensky bringer torden.
 Det er særligt uærligt over for det tyrkiske folk.
 Borgernes opvågnen er i alvorlig fare.
-Finlands eget nationale parlament, , fejrer et særligt jubilæum.
 Europæiske intellektuelle ejendomsrettigheder vil opnå øget beskyttelse.
 Det beskytter skibsfartens storkapital mod idømmelse af sanktioner.
 På grund af disse udfordringer må vi ikke være gerrige over for vores borgere.
@@ -1860,7 +1852,6 @@ Alle bevillinger og al administration foretages i dag på edb.
 Uddannelse skal uddanne, ikke skabe billige, lydige arbejdere.
 Bygningens udvendige glasparti er snavset.
 Her må såvel importører som ferierejsende og forbrugere være sig deres ansvar bevidst.
-Syn ved vejsiden af erhvervskøretøjer
 Men denne model vil redde liv i mange tilfælde, før ambulancen når frem.
 Jeg tror, at budgettet kan klare, at alle medlemmer får en papkasse til papirgenbrug.
 Det andet punkt, hvor vi er i dissens, er natarbejde.
@@ -1920,7 +1911,6 @@ Selvfølgelig var der fejl ved deres plan, og deres fantasifulde monetære syste
 Irerne har sagt nej til at få den demokratiske kontrol væk fra borgerne.
 Disse manøvrer er latterlige.
 Særlig kosmetikindustrien er berørt af disse metoder.
-Ved hårdhændede udvisninger er der også tidligere faldet døde og sårede i andre medlemsstater.
 Hvad vil der ske, såfremt den drastiske rentenedsættelse medfører en overophedning af økonomien?
 Jernbanespeditørerne er et sammenbrud nær.
 Vi er muligvis på nippet til at finde de politiske løsninger på vores problemer.
@@ -2025,7 +2015,6 @@ Jeg går selv altid ind for nultolerance, hvad angår mærkning.
 Hidtil har det efter vores skøn ikke været nødvendigt.
 Det betyder helt konkret, at indgreb kun er tilladt i tilfælde af groft misbrug.
 Eftersom jeg er i ekstraordinært godt humør, vil jeg rejse et tredje punkt.
-Derfor fordømmer vi naturligvis blasfemi.
 Vi går ind for, at vi udfylder dette behov for beskyttelse, dette vakuum.
 De nytilkomne har optaget helt nye eller ledige job.
 Den stakkels kommissær ønskede et slankt program, men er endt op med en tyksak!
@@ -2069,7 +2058,6 @@ Vi skal finde balancen mellem at beskytte forbrugeren mod udlåneren og udlåner
 Det virker som en rød klud på en tyr.
 I energisektoren er de lave gaspriser kun et minde.
 Med den grænse åbnes der for et sjuskeri, en ligegyldighed hos leverandører og producenter.
-Tiden er ikke til defaitistisk tale, men til konstruktive og praktiske svar.
 Denne erfaring bør være den væsentligste præmis bag en helt ny reform af traktatsystemet.
 Jeg synes egentlig, det er ærgerligt, at vi taler så lidt om det nu.
 Tyrkiets kulturelle rødder er mere forskelligartede, end de fleste af os er klar over.
@@ -2111,7 +2099,6 @@ Den er også behæftet med temmelig mange fejl.
 For en liter mælk måtte han dengang arbejde ni minutter, i dag kun tre.
 Forskning i multipel sklerose bør også medtages i det syvende rammedirektiv.
 Lyt ikke til de polske politikere.
-Det er det, jeg ville kalde en kartesiansk klarhed.
 Her lader man hånt om alt, hvad man kan lade hånt om.
 Hun bor i det område, som min søn repræsenterer i byrådet.
 Jeg har især arbejdet for en forenklet procedure for professionelle brugere af fyrværkeri.
@@ -2124,7 +2111,6 @@ Det er helt sandt, hvad kollegerne har sagt om hudkræft.
 For trekvart år siden var jeg rådgivende ordfører.
 Jeg takker kommissæren for hendes svar, som uden tvivl er velment.
 Jeg vil komme med en spådom.
-Lemlæstede, brændte børn, hele familier var udryddet, en familie mistede fem medlemmer.
 Men selv ikke højere mål for genanvendelse af miljøfarligt emballage er tilstrækkeligt.
 Denne keramikemballage består af ren, brændt lerjord og indeholder derfor ingen skadelige stoffer.
 Hvad angår vraget, er der nogen forvirring.
@@ -2138,7 +2124,6 @@ Internationalt er der jo i særdeleshed tale om en knivskarp priskonkurrence.
 Det har jeg erfaret på egen krop.
 Det er rigtigt, at antallet af marsvin er meget lavt.
 Jeg var ikke klar over, at han havde så ærefuld en fortid.
-Staes og andre medlemmer med rette har henvist til.
 I så fald ville vi ikke være mennesker, men guddommelige væsener.
 Det er aldrig godt at unddrage sig regler, man har tilsluttet sig frivilligt.
 Efter min mening er vin et af de mest elegante produkter, landbruget kan fremstille.
@@ -2184,7 +2169,6 @@ Jeg gætter på, at nogle af vores kolleger vil tale om det her.
 Liberia har gennemlevet de mest forfærdelige og traumatiske tider.
 De ting, man antyder i dette beslutningsforslag, er meget, meget alvorlige.
 En sådan opførsel gør den sudanesiske regering til medskyldig i disse påståede forbrydelser.
-Denne dekalog fokuserer grundlæggende på tre områder.
 Jeg har endda gjort noget, der måske var juridisk ukorrekt.
 Vi har også bragt et omtåleligt emne på banen.
 Intolerance og ekstremisme skyldes først og fremmest, at historien er blevet glemt.
@@ -2205,7 +2189,6 @@ Nu er det låntagerne, som står tilbage med kursrisikoen.
 I den nuværende situation ville landet ikke engang turde fyre et kanonslag af.
 Vi socialister anråber bønligt om en europæisk pagt for vækst og beskæftigelse.
 Det afhang imidlertid af en udtalelse fra kommissæren i går aftes.
-Af disse grunde lan vi ikke stemme for denne betænkning.
 Entreprenøren har afgivet forskellige erklæringer.
 Det er en konkurrenceforvridning, som vi skal have elimineret.
 Meget ofte bliver de europæiske værdier en hul frase.
@@ -2229,7 +2212,6 @@ De medfører oversvømmelser, jordskred, klimaforandringer og ødelæggelse af f
 Jeg er også bekymret over politikken om outsourcing af alle eksterne finansieringsprogrammer.
 Vi må vogte over den proces som høge.
 Bromat findes navnlig i ozonbehandlet vand.
-Så reagerede den kun halvhjertet, vidste ikke, at importvarerne hobede sig op i havnene.
 Jeg tror, at vi er enige om, at de filippinske søfolk også skal løslades.
 Sikken et forbryderisk spild af tapre unge menneskers liv!
 Flertallet af prostituerede lever et usselt liv med risiko for overfald, voldtægt, kønssygdomme osv.
@@ -2260,7 +2242,6 @@ Marokkos grunde har ikke noget med bevarelse af ressourcerne at gøre.
 Det er absolut forbløffende og bekymrende og en kovending i den britiske regerings politik.
 Det er klart, at vi efterhånden har nået mætningspunktet.
 Hvis vi giver dem kærlighed, bliver tilværelsen her på jorden lidt lysere.
-Det samme gælder for ftalater.
 Reglerne om bemanding gælder for skibets mandskab som helhed.
 De forskellige holdningsskift hos myndighederne viser klart deres rådvildhed.
 Oppositionen og uafhængige medier undertrykkes, og demokrati er en saga blot.
@@ -2355,7 +2336,6 @@ Colombia bliver heller ikke nævnt.
 Det er utænkeligt, at det blot på nogen måde ville blive tolereret.
 Argumentet er kolonien af murmeldyr.
 Vi er ikke alle ustuderede røvere eller analfabeter.
-Man kan slet ikke anvende en aritmetisk opdeling a la halvt om halvt.
 Som erhvervsdrivende i en mellemstor virksomhed har jeg adspurgt mange af mine kolleger.
 Det er gyselig bagvaskelse, som har til formål at forvirre og vildlede.
 Endelig understreger vi, at sedlerne skal bringe borgerne tættere på deres valuta.
@@ -2496,7 +2476,6 @@ Det er naturligvis ikke ensbetydende med, at det pynter på handelsstriden, snar
 I mellemtiden tikker den globale opvarmning roligt videre.
 Måske har disse små øer gjort det, fordi de oplever faren meget tættere på.
 Planlægger den moldoviske regering virkelig at åbne ild mod demonstranter i nødsituationer fremover?
-At vi ikke udfaser dem, mener jeg, er uambitiøst, og mener jeg, er trist.
 Det glæder mig, at isolerede, smalsporede og fredede jernbaner vil være undtaget.
 Når man finansierer forebyggelse, begrænser man ligeledes de betydelige udgifter til genrejsning.
 En urentabel produktion bør ikke holdes kunstigt i live i al evighed.
@@ -2737,7 +2716,6 @@ Vi ønsker med andre ord at skabe et egentligt marked for clearing og afvikling.
 Der er i forbindelse med udvidelsen allerede sagt meget om tidsplaner, datoer og årstal.
 Den pågældende rapport er i det store og hele deskriptiv.
 Det drejer sig ikke om at kickstarte den økonomiske vækst i den sædvanlige retning.
-Chip er farlige, når børn putter dem i munden.
 Antallet af ulykker til havs er uacceptabelt højt.
 Vi bifalder den robuste måde, hvorpå han har forsvaret balancen i dette direktiv.
 Den etiopiske lærerforening chikaneres og forfølges til stadighed.
@@ -2817,7 +2795,6 @@ Det gik lige så godt, så hvorfor spolere det?
 Der kan man se, hvilket niveau vi er sunket ned på.
 Ved reorganisationer bestemmer aktionærer og chefer, og arbejde er den sidste post.
 Jeg vil understrege, at det er den engelske udgave, der er den autentiske tekst.
-Ganske vist står det tilstræbte mål i spagat, som derfor skal kunnes.
 Skal lærere eller læger tage stoffer, der virker opkvikkende?
 De er nødt til at vide, hvordan man forkuller træ, inden det brændes.
 Bilfabrikkerne er rigeligt bevis på, at princippet om kooperativt ejerskab brydes.
@@ -2829,7 +2806,6 @@ Ja, interessen for de tre kaukasiske lande er stor.
 Episoderne i forbindelse med betænkningen var alt andet end flatterende.
 Vi må sørge for, at de bliver mætte.
 Parlamentet har stået i spidsen på dette område mere end en gang.
-Så det er et hegelsk problem.
 Afstemningsanlægget fungerede desværre ikke på daværende tidspunkt.
 Vi har en kolossal overforsyning på vores marked for ufaglært arbejdskraft.
 Der er forsat problemer med at finansiere fælles projekter virkelig ukompliceret.
@@ -2872,11 +2848,9 @@ Og alt dette har vi under vores fødder.
 Det vil være en vanære, der vil vare i flere årtier, hvis det vedtages.
 Udviklingspolitik er ikke kun uselviskhed, det er interessepolitik.
 Enhver delforanstaltning vil skabe utilfredshed og uretfærdighed.
-Derfor har jeg stillet et lille ændringsforslag til stk.
 Det er derfor helt afgørende med et internationalt samarbejde for at kontrollere infektionssygdomme.
 Der findes ikke noget undskyldning for denne obskøne praksis.
 De er gået bankerot på grund af deres egne stupide ledere og politikere.
-Jeg vil endnu en gang takke fr.
 Jeg glæder mig især over, at betænkningen i mange tilfælde irettesætter den irske regering.
 Jeg så gerne, at bestemmelserne går let henover operationelle risici.
 Men det vigtige er, at kimen findes, at muligheden eksisterer.
@@ -2998,7 +2972,6 @@ Man vil have forbedret proceduren for bilæggelse af stridigheder.
 Uden skovbrug er der ingen træindustri.
 Der er røde streger på vejen.
 Det er et gammelt tema, men alligevel højaktuelt.
-Ved at skrabe midler sammen på en usystematisk og uorganiseret måde?
 To eksempler på dette er hårtørrere i en frisørsalon eller udstyr i et motionscenter.
 Eller er det måske politikerne, der har mistet følingen med almindelige mennesker?
 Sukker kan anvendes til andet end slik.
@@ -3018,7 +2991,6 @@ Letland var udsat for risiko for at gå bankerot uden finansiel bistand udefra.
 Dette forbud indbefatter også pædofile blade.
 Der er blevet udsendt et vademecum.
 Så amerikansk politik er israelsk politik, og vi europæere trasker efter vores ledere.
-Chirac ved besvarelsen af spørgsmålene også anvendte denne benævnelse.
 Lovgivningen er særligt vigtig for spædbørns sundhed i forbindelse med amning.
 Det er endnu en gang mellemhandlere og de dominerende fødevarekæder, der skummer fløden.
 Ordføreren og andre talere nævnte spørgsmålet om økomærkning.
@@ -3072,7 +3044,6 @@ Den zimbabwiske befolkning lider i forvejen alt for hårdt.
 På den måde kan vi blive spydspids i reformen af det internationale finansieringssystem.
 Det drejer sig naturligvis om titusindvis.
 Der findes ingen udødelige diktatorer, men frihedens ånd er tidløs.
-At holde fast ved denne udgave ville være en pyrrhussejr.
 Igen kunne et regionalt samarbejde afbøde virkningerne af sådanne naturkatastrofer.
 Dette bevidner vores menneskerettighedsdialog med alle grene af de israelske myndigheder.
 Vores empati er ikke tilstrækkelig.
@@ -3102,7 +3073,6 @@ Kommissionens forslag om reformer af vinsektoren er et skridt i den rigtige retn
 De havde en meget vanskelig rolle, men udviste dygtighed og udholdenhed.
 Også i denne sammenhæng gælder det, at man må krybe, før man kan gå.
 På denne måde vil vi kunne reducere den administrative segmentering.
-Dykke ned i fleksibilitetsinstrumentet?
 Nåletræerne er betydeligt blødere end løvtræerne, hvilket gør deres støv mindre risikabel.
 Her skal der foretages et radikalt snit.
 Vi må i øvrigt sørge for, at oplysningerne er læsbare.
@@ -3143,7 +3113,6 @@ Vi kan ikke være som de frøer, der krævede en konge.
 Den, der fusker, mister kunder.
 Det hører egentlig til den sædvanlige forretning, og beløbet burde ikke slå os omkuld.
 Den aktuelle israelske politik er grotesk og virker mod hensigten.
-Kommissionen anmoder om, at de reducerer deres fiskeri, deres tonnage og deres fangster.
 Vi skal i ro og mag opveje plusserne og minusserne.
 Der er beretninger om, at der finder totur sted.
 Denne atavisme må overvindes hurtigst muligt.
@@ -3159,7 +3128,6 @@ Men de småpenge, de får, kan måske lette deres trængsler.
 Disse dyr lever under skrækkelige forhold, og mange bliver flået levende.
 De franske lastbilchaufførers vejblokade
 I praksis opmuntrer de en hæmningsløs sort økonomi.
-Dette er et sensitivt stadium i børns intellektuelle, fysiske og kognitive samt sproglige udvikling.
 Desværre er det kun amerikanske westernfilm, der ender lykkeligt.
 Tilladelser til dybvandsboringer skal kontrolleres nøje.
 Kommissionen har begået en stor fadæse her.
@@ -3254,7 +3222,6 @@ At medlemmer af et erhverv fastsætter fælles salærer strider principielt mod 
 Når markedets usynlige hånd fungerer, virker dette tilnærmelsesvist.
 De afgivne tilsagn må absolut honoreres på mødet i september.
 I øjeblikket er denne fabrik lagt i mølpose, og de ansatte er på ventepenge.
-Det er det, vi kalder en palimpsest.
 Det er atomlobbyen, der på lumsk vis sniger sig gennem bagdøren.
 Hvad sker der, hvis hjorte, vildsvin og geder smittes?
 Hvad er den langsigtede vision for vores rumpolitik, og hvad er formålet med den?
@@ -3292,12 +3259,10 @@ I det nye gasdirektiv tillægges gasmyndighederne og agenturet stor betydning.
 Et andet aspekt, som jeg gerne vil have med i debatten, er dyrplageri.
 Den første var rationalisering af informationspolitikken, agenturerne og nomenklaturen.
 Jernet skal smedes, mens det er varmt, sammen med den nye regering.
-Med den blev åbningen af markederne for godstransport en realitet pr.
 Garnene blev indført i handlen, som så senere blev udvidet.
 Nu kommer turen så til ris.
 Tillad mig her at iføre mig min institutionskasket.
 I en uge er der ikke sket nogen lovændringer eller ændringer i valgkommissionens sammensætning.
-Decharge, ledsaget af en række bønfaldelser, er ikke et sådant magtmiddel.
 Disse mennesker bør ikke betale prisen for, at andre har ødelagt moserne.
 Det pågældende anlæg leverede glukosesirup eller melasse til hollandske foderproducenter.
 Vi har udvist lederskab og løst den gordiske knude.
@@ -3313,7 +3278,6 @@ Jeg vil kort omtale direktivet, der er opkaldt efter en tidligere kommissær.
 I dagevis blev klostret hermetisk afskåret fra omverdenen.
 Vi enedes om at arbejde sammen i et partnerskab.
 Ved begyndelsen af strejken angreb politiet arbejdstagerne med tåregas og vandkanoner.
-Men nu hører jeg, at man vil lægge forfatningen, de finansielle overslag på køl.
 Lavspændingsdirektivet og maskindirektivet dækker allerede mange spørgsmål i denne henseende.
 Brugen af antibiotika er bestemt en torn i øjet på både dyr og mennesker.
 Den lille røde bog fik tilsyneladende kolossal betydning, enorm betydning.
@@ -3331,7 +3295,6 @@ Tidligere har den ikke gjort sig den ulejlighed at søge denne støtte.
 Papirøkonomi er bobleøkonomi.
 Efter det smittede benmel vil man en dag se flyene falde ned.
 Præstation og ansvar er fremmedord for dem, slendrian hører til dagens orden.
-Burtone, for hans indsats.
 Det er jo en imponerende clairvoyance, som lover godt for projekterne.
 Hurtig kunstig opdrætning af kyllinger og kalkuner skal ophøre.
 Sådanne konflikter kan ikke løses med militære metoder eller med kugler og krudt.
@@ -3471,7 +3434,6 @@ De indiske raketforsøg er et uanvendeligt pressionsmiddel og en kontraproduktiv
 Med andre ord drejede det sig om en lille uvarslet demonstration.
 Ud fra det lækkede dokument vil jeg gerne stille ham tre spørgsmål.
 Hos de mangeårige medlemmer dæmrer det formodentligt.
-Rådet bryster sig, fordi det er så god til at håndtere høvlen.
 Der hersker åbenbart et vist virvar de to herrer imellem.
 Vi skal oplyse dem om, at arrogance er malplaceret her.
 Skrøbelig på grund af dens store modløshed.
@@ -3562,7 +3524,6 @@ Japan hamstrer i stor stil.
 At forhale direktivet ved at kives om urealistiske mål hjælper ikke nogen.
 Vi så ikke bålene i fjernsynet, men på den anden side af hækken.
 Orlando, en stor tak for kvaliteten af deres betænkninger.
-Jura skal ikke besvares large, men med jura.
 Der erhverves viden, opøves færdigheder og indøves social adfærd og vilje til integration.
 Når det gælder et så vigtigt emne, burde usle kneb ikke forekomme.
 Den første er til de specialiserede producenter af oksekød med besætninger af ammekøer.
@@ -3581,7 +3542,6 @@ Jeg skal sørge for, at spørgeren får denne brochure.
 Dette er ikke bare alvorligt, kære venner, det er uhæderligt og meget trist.
 Jeg har i høj grad nydt at arbejde sammen med hende.
 Stalinismens tvillingebror var nazismen.
-Vi skal være retfærdige, men ikke salomoniske.
 I denne sal bør den italienske præsident altid kun omtales med respekt og ærbødighed.
 Det vedrører oftest en skade på bulkskibenes skrog, som skyldes forkert lastning eller losning.
 Det er et højpolitisk projekt, højpolitisk!
@@ -3667,13 +3627,11 @@ At påpege dette er ikke at føre stereotyper til torvs.
 Det andet er at hindre udbredelsen af atomvåben og naturligvis også af spaltbare stoffer.
 Forslaget til betænkning om grønbogen er et vigtigt bidrag til spørgsmålet om byudvikling.
 Det er grunden til, at ordningen kun gælder for nyansatte.
-Såvidt min funktion som ordfører.
 Så er det det rene bluff for forbrugerne.
 Det var dog mere en dyr og mondæn hobby end en økonomisk aktivitet.
 Den er dog ikke alene om dette comeback.
 Dette fjerner en evindelig kilde til konflikt.
 Jeg tror, at der er store potentielle muligheder i bioplast.
-Kofoed vil jeg sige, at vi fuldt ud tilslutter os hans udtalelser om kvoteringen.
 Selv en lille fødevarevirksomhed ved, hvilke ingredienser brød eller snacks indeholder.
 Det skal være en enstemmig beslutning i henhold til wienerkonventionen om traktatret mellem stater.
 Alle sprang for livet, og det var børnene, der blev hårdest ramt.
@@ -3682,7 +3640,6 @@ Skal vi sætte en etiket på hvert enkelt riskorn?
 Størstedelen af markedet er sikkerhedsudstyr til køretøjer som airbags og sikkerhedsseler.
 Han valgte et æsel som partisymbol.
 Som trofast europæer må jeg derfor stemme imod denne betænkning.
-Derved sættes der måske spørgsmålstegn ved det, som dr.
 To af mine sønner taler polsk.
 Også det tærer på de videnskabelige ressourcer.
 Det betyder altså, at irerne og belgierne har begået en brøler i denne sag.
@@ -3785,7 +3742,6 @@ Vi har brug for en håndværker, en altmuligmand, ikke en statsmand.
 Der var lidt uenighed hist og pist, men hvor er der ikke det?
 Det er rart at se ham rødme.
 Her fremmer jobrotation udviklingen af kvalifikationer.
-Amerikanske arbejdstagere skifter i gennemsnit profession tre gage i løbet af deres levetid.
 Men det estiske samfund er blevet opdelt i vindere og tabere.
 Men jeg noterer mig det og vil ved først givne lejlighed indhente det forsømte.
 Der vil blive gjort forsøg på at pådutte alle investeringstraktater den fulde grønne dagsorden.
@@ -3840,7 +3796,6 @@ Jeg mindes, at der i de græske krukker ikke var olie, men olivenolie.
 Konflikten brød ud i lys lue i marts sidste år.
 Men de er notorisk ineffektive i dag.
 En fed hamburger bliver jo ikke sund, fordi der tilsættes nogle vitaminer.
-Dette er et gammelt opråb, for problem har eksisteret i lang tid.
 I modsat fald skal man straks holde op med dette pjat.
 Det gælder ikke mindst reglerne for metylbromid.
 Fru formand, det er ved at blive ensformigt at tale om de tyrkiske grovheder.
@@ -3858,7 +3813,6 @@ For arbejderne er der imidlertid sulteløn og evig nøjsomhed.
 Den må ikke være hullet som en si.
 Nogle kommentatorer har omtalt disse bestræbelser som politisk nekrofili.
 Rusland har også en stor betydning som brobygger mellem de europæiske og asiatiske lande.
-Tobak af høj kvalitet etcetera, og mindst mulig støtte til den.
 Det er en anmassende, hovmodig og arrogant holdning fra den tyske forbundskanslers side!
 Straffen bør udmåles i form af strafferetlige sanktioner, ikke civilretligt ansvar.
 Det indre markeds undertiden meget snærende regler finder anvendelse på skovprodukterne.
@@ -3941,7 +3895,6 @@ De steder, hvor situationen er vanskelig, kan man benytte definitionen af byluft
 Det er et kompliceret svar, og derfor er det også vanskeligt at kapere.
 Vi gider ikke høre på den slags historier!
 Dette ligner en nykolonial tankegang.
-Det er en farisæisme, som hurtigst muligt må bringes til ophør.
 Gerningsmændene efterlod deres offer liggende på jorden smurt ind i blod.
 Vi hverken fremstiller eller sælger infanteriminer.
 Vi kan ikke høre tolkningen tydeligt på grund af det stærke ekko i salen.
@@ -3975,7 +3928,6 @@ De to andre nye features er tilføjelser til proceduren.
 Man har indtryk af, at ploven er spændt for okserne.
 Jeg er derfor en arg modstander af kernekraft, når den praktiseres på denne måde.
 Vi siger, åh, infrastrukturen er ødelagt.
-Med en sådan opførelse vil der kun blive handlet med hajprodukter fra bæredygtige bestande.
 Ha, så meget for den gennemsigtighed, man hele tiden prædiker!
 Bliver kritik kvalt under en kåbe af tavshed eller ganske enkelt fjernet?
 Jeg henleder opmærksomheden på, at vores konkurrenter ikke læner sig tilbage og triller tommelfingre.
@@ -3984,12 +3936,10 @@ Efter min mening er denne omrokering og forhøjelse af budgetressourcerne ikke s
 De har glemt de rødhårede!
 Trods visse oratoriske forholdsregler er denne tekst faktisk ikke afbalanceret og retfærdig.
 Disse problemer skyldes en hedonistisk og utilitaristisk holdning til det enkelte menneske.
-Den importerer bauxit til produktion af aluminium.
 Selv afgrøderne skal affugtes.
 I fægtekunsten er undvigemanøvrer effektive.
 Det er stadigvæk ost, og dette er stadigvæk tang.
 Gidseltagerne har været skruppelløse og har allerede pryglet eller skudt nogle mennesker.
-For det andet suggererer disse forslag indirekte, at der findes en menneskerettighed til abort.
 Selv solen blev fjernet fra vores åsyn.
 Med andre ord kræver det dunkelhed og hemmelighed.
 Akin, vi beder dig blive rask igen!
@@ -4006,7 +3956,6 @@ Under alle omstændigheder stemte jeg imod denne betænkning igen med fynd og kl
 Hvor er åbenheden henne til at vedstå, at reformer gør ondt af og til?
 Perry, at han ønsker, at disse foranstaltninger skal være absolut faste og grumme.
 Disse symbolske gebærder kan få gamle sår mellem mennesker til at bryde op igen.
-Der skal skabes ligevægt med femogtyve.
 Syrerne saver på den måde muligvis den gren over, de selv sidder på.
 Vi må udbasunere de gode nyhedshistorier, når vi hjælper borgerne.
 Lokalerne er ikke nødvendigvis uhumske, underjordiske fangehuller med fugtigt halm.
@@ -4261,7 +4210,6 @@ Derved kan menneskene blive ufølsomme over for humane antibiotika.
 Sådan skaber man ikke fred, kun hadske fjender.
 Niveauet af kommerciel erfaring her i salen er jammerligt.
 Imiteret ost, kød med klister og vaniljeyoghurt uden vanilje er blot et par eksempler.
-Det er ikke et udtryk for vrangvillighed, men er situationen.
 Det skal skabes, det kan ikke beordres.
 Forsimplet oppiskning af stemningen, ja tak.
 Hvad er meningen med beslutningsforslagene i morgen, hvis det ikke er politisk rænkespil?
@@ -4281,7 +4229,6 @@ Derfor er en udifferentieret løsning uanvendelig.
 Demonstranterne brugte i den forbindelse enorme lydanlæg, nærmere bestemt højttalere.
 Piloterne, teknikerne og de øvrige fagmænd besidder uundværlige erfaringer på området.
 Mange irske bataljoner har gjort tjeneste i de europæiske stormagters hærstyrker gennem årene.
-Her bliver det tydeligt, at det er ren makulatur, et tågestrejf.
 De er vigtige for en bys attraktion.
 Dette bringer den nordiske pasfrihed i fare.
 Men da vi var rejst, blev befolkningen alligevel jaget af proindonesiske militser.
@@ -4312,7 +4259,6 @@ Rådets føromtalte fælles holdning giver den britiske regering medhold.
 Computervirusser, spammail, phishing og trojanere er reelle trusler i de virtuelle datas verden.
 Det er vigtigt, at regeringen arbejder på at opbygge en ægte upolitisk statsforvaltning.
 Lad os vogte os for særheder, som er på grænsen til at være fornærmende.
-Corrie og andre, som har nævnt denne misforståelse.
 Den vigtigste kilde til indtægter forventes at blive royalties fra ophavsrettigheder.
 Der er ikke nok brød og marmelade til dem alle.
 Kommissionen må ikke smyge ansvaret af sig.
@@ -4398,7 +4344,6 @@ Det drejer sig om løsarbejde med usikre ansættelsesvilkår.
 Det virker adlende at befinde sig blandt de bedste.
 Bæredygtigt skovbrug vil gøre det muligt at producere energi på grundlag af træaffald.
 Vi ved alle, at der findes forestillinger, hvor der anvendes falke og andre rovfugle.
-I dag holdes barnet så at sige over dåben.
 Hvis det er tilfældet, er det på høje tid, at der iværksættes en rigsretssag.
 De fleste store årgange er bedre uddannede end de foregående generationer.
 Krigsherrerne er de nye lensherrer.
@@ -4406,7 +4351,6 @@ Nu da prisen på en tønde olie er steget, bør der være betydelige ressourcer.
 Det er ikke så mærkeligt, at menneskesmuglerne ler hele vejen til banken.
 Hvilke lyksaligheder er der for øvrigt tale om?
 Tadsjikistan har stadigvæk træk, der ikke hører hjemme i en demokratisk retsstat.
-Ståstedet, det er midlerne.
 Hendes evaluering giver indtryk af, at situationen er noget broget.
 De døde lå på gårdspladserne, og til slut blev de i deres hytter.
 Uddelingen af foldere er vel ikke for meget forlangt.
@@ -4486,7 +4430,6 @@ Den har først og fremmest ramt roeproducenterne og de ansatte på sukkerfabrikk
 Nye arbejdskoncepter blev introduceret abrupt, koncernen blev overcentraliseret.
 De to største grupper foretrækker langt et topartisystem.
 Alt for mange instanser er involveret, og nogen skal tage teten.
-Khartoum har protesteret mod denne overførsel og råbt op om et vestligt komplot.
 Kompromissystemet vil ikke gøre det muligt at spore det enkelte fårs bevægelser.
 Det var mere en meget generel udveksling af synspunkter, en slags brainstorming.
 Landbrugsgeneraldirektoratet trænger ganske givet til en ordentlig udluftning.
@@ -4637,8 +4580,6 @@ Hendes snæversynede racistiske bemærkninger vedrørende adoption vil være sv�
 Det betyder, at amalgamfyldningerne står for den allerstørste del af udslippet til kloakkerne.
 Pigerne chatter, indgår i fællesskaber og sender tekstbeskeder, mens drengene spiller computerspil.
 Alkalisk hydrolyse er en af disse metoder.
-Spencer for at have fremført noget, der er soleklart for alle.
-Dette er ikke nogen kvasijuridisk kommentar.
 Den nuværende kontraktlige ordning fastlægger kun en rudimentær bilateral dialog.
 Gå ikke med til nogen uldne kompromiser i dette spørgsmål.
 De kan bare sende ekstraregningen videre til deres trælbundne kunder.
@@ -4654,7 +4595,6 @@ Så går jeg over til at behandle gasolie og lette brændstoffer.
 Sneen dalede ned i store fnug.
 Man kan ikke finde rundt i virvaret af overstregede budgetposter og fupoverskrifter.
 Man anerkender også modkandidatens sejr, når vurderingen af selve valgene er positiv.
-Man kan kalde denne tilgang for neoimperialistisk og revanchistisk.
 For det andet spurgte jeg direkte om dialogen mellem kristne, muhamedanere og jøder.
 Jeg er homoseksuel og opvokset hos en almindelig mand og kvinde.
 Han ville lytte til fuglenes og cikadernes koncert.
@@ -4690,7 +4630,6 @@ Hov, jeg kan se, at jeg allerede har talt i fem minutter.
 Køretøjerne har kameraovervågning og klimaanlæg, og dyrene læsses med lift.
 Symbolets form er naturligvis statuerne, som også tjener som afguder.
 Men helten i den fortælling, som var en rigtig gnier, undergik en forvandling.
-Bristen lå i tilgangen til de mindre hårde safarigitre.
 Romtraktaten indeholdt allerede beføjelser hertil.
 Jeg repræsenterer et randområde, der ofte kaldes en ødemark.
 Det er en udfordring at sikre, at en europæisk bystrategi tages alvorligt.
@@ -4772,7 +4711,6 @@ Hvis de får lov, må vi acceptere, at verden enten er ond eller gal.
 Det er en livgivende naturgas!
 Noget tilsvarende skal finde sted med hensyn til bly og tin.
 Vi skal bruge vores kulreserver bedre.
-Anvendelsen af bindsler til søer og gylte vil blive definitivt forbudt.
 Eller betragt søpindsvinets pigge under mikroskop.
 Kommissionen har på forskellig vis forsøgt at torpedere denne aftale.
 Cyprioterne er ikke en slags andenklasses borgere i en osmannisk eller en anden koloni.
@@ -4786,7 +4724,6 @@ Og dette pokerspil er nu gået galt.
 Elkøretøjer omfatter tog, sporvogne, busser, biler og cykler.
 Rådet og medlemsstaterne er lysår væk fra denne holdning.
 Aftalen indeholder heldigvis også stærke incitamenter vedrørende elektriske biler eller hybridbiler.
-Har landet ikke baseret sit fremskridt på negrenes pinsler og slaveri?
 Efter sultestrejken blev han anklaget for at gennemføre en uautoriseret protest.
 Men deres protester er blevet affejet med en håndbevægelse som forhastet teknokratisk argumentation.
 Under pres tyede ordføreren til et groft proceduremæssigt trick.
@@ -4866,7 +4803,6 @@ Kun i to lande findes der et endnu større løngab.
 Der er ikke brug for didaktik, men berettiget kritik.
 Vi har allerede haft nogle homeriske diskussioner om mærkning af alkoholholdige drikkevarer.
 De risikerer at dø en særdeles pinefuld død af enten dehydrering eller iltmangel.
-Man må vænne sig til referencer af nærmest klerikal art.
 Hvorfor er vi nødt til at finansiere skiundervisning i skolerne denne uge?
 I forbindelse med rumopvarmning har vi således været uafhængige af prisudsving på verdensmarkedet.
 De skal opvarmes af en brand, for at de kan gro.
@@ -4950,7 +4886,6 @@ Jeg blev for nylig opereret for at få fjernet min galdeblære.
 Vi skal alle sammen være en del af den sydvestlige region.
 De er vidner til, at demonstranter arresteres, og at journalister chikaneres og tæves.
 Godmorgen, mine damer og herrer!
-Det er forældet at ensrette menneskers liv til efter ensartet ugeplan.
 Man kan tilmed hyre institutioner til at gøre arbejdet.
 Ecuen havde således en vis stabilitet.
 Vi må ikke flå dette hjertestykke ud, og vi bør udrydde misforståelserne i offentligheden.
@@ -4965,7 +4900,6 @@ Jeg kan ikke selv se løsningen i denne form for temmelig kortsigtet ideologisk 
 Vi må gøre en ende på det monopol, som krigens bipolarisering har besiddet.
 Haglbygerne og naturkræfterne var så voldsomme, at de ødelagde adskillige afgrøder.
 Vi ynder at fastsætte betingelser i forbindelse med vores støttepakker.
-Lisi, for hans hårde arbejde på denne betænkning, og jeg støtter hans bemærkninger.
 Jeg ønsker ikke endnu et svar i kancellistil.
 Det er da ikke noget scoop.
 Hvis man betaler med lire, skal jeg så give tilbage i euro?
@@ -5039,7 +4973,6 @@ Man har også taget hensyn til vores særlige forhold, som for eksempel isbryder
 Det bliver værre for udviklingslandene, fordi udbredelsen af ørknerne rammer dem i særlig grad.
 For den kan hverken gøre dit eller dat!
 Foretager vi en uhildet vurdering, må vi erkende, at man bifalder dets resultater.
-Vatanen sagde dette med stor overbevisning for et øjeblik siden.
 Det er en uskik, når det gælder databeskyttelse.
 Det er den tvungne skyldighed, den moralske inkvisition og den konstante psykiske bearbejdning.
 Man ved, at denne praksis med fjernelse af hajfinner truer adskillige hajarters overlevelse.
@@ -5059,9 +4992,7 @@ Denne prøve er dog en forudsætning for optagelse på de fleste angloamerikansk
 Koordinering af den økonomiske politik må ikke være et fyord i disse haller.
 Jeg husker stadig, at mange dengang drillede hende med, at hun så spøgelser.
 Lærer du ham at fiske, er han mæt resten af livet.
-I vores øjne van denne strategi mangelfuld på to vigtige punkter.
 Den krig, der har været spået om, er ved at være en realitet.
-Alexander, særlig når det gælder spørgsmålet om den juridiske status af erklæringen.
 Væk er de ubehagelige sprøjter, de ildelugtende piber og den afslørende røglugt.
 Lad os holde op med at lege kispus med landbruget.
 Nicole, som en ven takker jeg dig af hele mit hjerte.
@@ -5095,7 +5026,6 @@ Det trænger sig derfor på at gøre status over forbindelserne med vores alpine
 Accepterer vi, at forskningen identificeres med drømmen om et nyt økonomisk eldorado?
 Blodbadene fra disse robåde er alt for hyppige.
 De skal til omeksamen i juni.
-Petersborg og ikke champagne.
 Bogafbrændinger lever i bedste velgående.
 Som det understreges i betænkningen og meddelelsen, er valghandlinger ikke endagsforestillinger.
 Man er ved at forberede en bistandspakke, der skal søsættes snarest muligt.


### PR DESCRIPTION
As requested by @phirework in #2730, I recreated the original PR after manual QA.
@Isomorph70 wasn't sure if you would prefer to create a PR yourself, hopefully this is okay with you :)

Reviewed 2399 of the original 5136 sentences with 3% error rate, at 99% confidence.
After deleting problematic sentences, the new total is 5066.

Manual QA results here https://github.com/Pertel/danish-cv-validation/blob/main/Common%20Voice%20-%20Sentence%20QA%20-%20Danish.ods 

I deleted the sentences with issues found in review, but am unsure if this was too early in the process.
Let me know and I'll revert the deleted lines.

@nukeador 