### PR TITLE
Dupe encoding

### DIFF
--- a/server/src/lib/bucket.ts
+++ b/server/src/lib/bucket.ts
@@ -66,6 +66,21 @@ export default class Bucket {
     }
   }
 
+
+  /**
+   * Check if given file exists
+   */
+  async fileExists(path: string) {
+    const file = await this.s3
+      .headObject({
+        Bucket: getConfig().CLIP_BUCKET_NAME,
+        Key: path,
+      })
+      .promise();
+
+    return file.ContentLength > 0;
+  }
+
   /**
    * Grab metadata to play clip on the front end.
    */

--- a/web/src/components/pages/contribution/speak/speak.tsx
+++ b/web/src/components/pages/contribution/speak/speak.tsx
@@ -505,7 +505,7 @@ class SpeakPage extends React.Component<Props, State> {
             retries = 0;
           } catch (error) {
             let msg;
-            if (error.message === 'save_clip_error') {
+            if (error.message.includes('save_clip_error')) {
               msg =
                 'Upload of this clip keeps failing at server, reload the page or try after sometime';
             } else {

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -81,7 +81,7 @@ export default class API {
       return;
     }
     if (response.status >= 400) {
-      if (response.statusText === 'save_clip_error') {
+      if (response.statusText.includes('save_clip_error')) {
         throw new Error(response.statusText);
       }
       throw new Error(await response.text());


### PR DESCRIPTION
Sometimes (maybe when the server is under load and not responsive)
the client sends multiple copies of a file to the server, and diff
pods all try to encode the file at the same time, which both
is an inefficient use of resources. The errors from these also makes
it difficult to diagnose real FFmpeg issues from weird collision ones.
This PR checks if a file exists on S3 before beginning the encoding
process, and if yes, skips it. It incidentally also:

* Fixes issues where throw errors inside a request don't terminate
  the rest of the function
* Ensures tasks for after S3 upload actually happens after the entire
  stream is encoded
*  Send encoding errors to Sentry instead of just logging 