### PR TITLE
Fixes and QoL improvements for personal data takeout function

### DIFF
--- a/common/takeout.ts
+++ b/common/takeout.ts
@@ -2,6 +2,7 @@ export enum TakeoutState {
   PENDING = 0,
   IN_PROGRESS,
   AVAILABLE,
+  EXPIRED
 }
 
 export type TakeoutRequest = {

--- a/server/src/lib/api.ts
+++ b/server/src/lib/api.ts
@@ -127,6 +127,7 @@ export default class API {
 
     router.get('/feature/:locale/:feature', this.getFeatureFlag);
     router.get('/bucket/:bucket_type/:path/:cdn', this.getPublicUrl);
+    router.get('/server_date', this.getServerDate);
 
     router.use('*', (request: Request, response: Response) => {
       response.sendStatus(404);
@@ -501,4 +502,9 @@ export default class API {
     );
     response.json({ url });
   };
+
+  getServerDate = (request: Request, response: Response) => {
+    // prevents contributors manipulating dates in client
+    response.json(new Date());
+  }
 }

--- a/web/locales/en/messages.ftl
+++ b/web/locales/en/messages.ftl
@@ -877,6 +877,7 @@ download-recordings-title = Recordings
 download-recordings-info = Includes mp3s and related sentences, may take some time to prepare
 download-recordings-size = Typically megabytes
 download-recordings-unavailable = You cannot request your recordings while another request is already in progress.
+download-recently-requested = You can request a new takeout of your recordings every { $days } days.
 download-size = Size
 download-selected = Selected
 download-start = Download profile data

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -470,4 +470,8 @@ export default class API {
       method: 'GET',
     });
   }
+
+  async getServerDate(): Promise<string> {
+    return await this.fetch(`${API_PATH}/server_date`);
+  }
 }


### PR DESCRIPTION
* Ensure clips are wrapped in subdirectory so that unzipping doesn't
  pollute the current directory
* Ensure cleanup tasks removes files
* Keep records of old expired takeouts in case cleanups fail and
  we need to discover where those files are
* Add frequency limit to # of takeouts users can request
* Increase # of clips per takeout chunk to 2k
* Add language code to metadata file