### PR TITLE
Quick review for the EO wiki extract to remove some errors

### DIFF
--- a/server/data/eo/eo.wiki.rerun-2021-10.txt
+++ b/server/data/eo/eo.wiki.rerun-2021-10.txt
@@ -227,7 +227,6 @@ Arto kiel lingvo helpas rigardi la mondon per alia maniero.
 Atako sur la tuta linio!
 Atestas pri tio sufiĉe plej malnova familia nomo.
 Attila Cosovan apartenis al la hungara minoritato de Rumanio.
-Auzias memmortigis sin du jarojn poste.
 Avino kaj nepino jam ne komprenas unu la alian.
 Aĉetado de najbaraj grundoj kun planoj de eventuala pligrandigo ankaŭ ne eblis.
 Aŭto estas preskaŭ tiel bela kiel neniu aŭto.
@@ -269,7 +268,6 @@ Baldaŭ li revenis al Budapeŝto.
 Baldaŭ li verkis ankaŭ romanojn.
 Baldaŭ okazis tumultoj inter islamanoj kaj la minoritataj ĉinoj.
 Baldaŭ post la malapero de monarkio en Germanujo la socialdemokratoj kolektiĝis surloke.
-Baldaŭ poste Halpaur ekinstruis ĉe la katedrala lernejo.
 Baldaŭ poste Maksimiliano estis arestita.
 Baldaŭ poste li iĝis kapitano de la Trabanta gvardio.
 Baldaŭ sultanlando kaj similaj landoj estis kreitaj en tiu areo.
@@ -657,7 +655,6 @@ En Montenegro li estis ministro pri trafiko.
 En Moskvo estas ekspluatata almenaŭ unu tia buso.
 En Moskvo ŝi ege sukcesis.
 En Naroval la klimato estas humida kaj subtropika.
-En Naujan akademio funkcias.
 En Nederlando ĝi estas ordinara magistro dum du jaroj.
 En Norvegio la rajto je publika aliro estas leĝo tre detale difinita.
 En Novjorko lia medicina diplomo estis akceptita kaj laboris en hospitalo.
@@ -1137,7 +1134,6 @@ Filio estis kreita en Amsterdamo de iama lernanto.
 Filmado ankaŭ okazis dum du semajnoj en Novjorko.
 Filo de la soldato de Polaj Legioj.
 Filologio en si neniam estu la ĉefa celo.
-Financis ilin anoj de Hildburghausen.
 Finante siajn studojn ŝi translokiĝis al Hungario.
 Fine de la jaro la komunumaro havis loĝantojn.
 Fine de la ĉapitro ne ekzistas kadenco de la piano.
@@ -1171,10 +1167,8 @@ Forta influo pri sia arto estas la situacio de Koreio kiel lando dividita.
 Franciskanoj konstruis tie nur kapelon.
 Frank iĝis kortega orgenisto kaj solotrejnisto de la kortega opero munkena.
 Fratino lia iĝis la unua abatino tie.
-Frau von Stein trauert.
 Frazo povas enhavi plurajn ĉefpropoziciojn.
 Freud bonvenigis la proponon.
-Fruaj seismografoj registris la grundmovon sur paperon aŭ sur filmon.
 Fruktoj ne estas kutime parto de la dieto.
 Frunte de la procesio estas voktestro kun kruco.
 Fundamentaj restaĵoj ankaŭ nun estas videblaj ĉe la nuna kirko.
@@ -1186,7 +1180,6 @@ Gandhi organizis tiun movadon por subteni kamparanoj.
 Gapan estas atingebla laŭ flankovojoj.
 Gaspar da Cruz enŝipiĝis al Portugala Hindio cele al la fondo de misio Oriente.
 Gemini ejo povas esti la servilo.
-Genisteino estas varmostabila kaj malforte estrogena laŭ naturo.
 George Lilanga estas internacie konata kiel "la Picasso de Afriko".
 Geranila izobuterato reakcias kun fortaj oksidigagentoj kaj fortaj bazoj.
 Gerardo Diego konis ŝin dum sia restado en Parizo.
@@ -1326,7 +1319,6 @@ Ili estis parolataj en Italio.
 Ili estis pli bonaj en kalkulado ol uzado de lingvo.
 Ili eĉ muntis tie kontraŭleĝe faritan metalan tabulon.
 Ili faras specialan traktadon al la promocio de virinoj en Islamo.
-Ili faris diskon "Kohdusta hautaan" (el utero al tombo).
 Ili frekventis diservojn en la luterana kirko loke aŭ en aliaj vilaĝoj.
 Ili havas fortikajn korpojn kaj grandajn kapojn.
 Ili havas longajn vostojn kiuj kreskas ĝis esti tiom longaj kiom ties korpoj.
@@ -1406,7 +1398,6 @@ Inoj havas du parojn de mamcicoj.
 Inoj naskas ĉiujare unusolan idon.
 Insulo Talikud situas sudokcidente de la ĉefa insulo.
 Insuloj Falklandoj estas Brita transmara teritorio.
-Inter Olkiluoto kaj la kontinento estas mallarĝa markolo Karhukarinrauma.
 Inter ambaŭ mondmilitoj ĝi apartenis al la Dua Pola Respubliko.
 Inter birdoj elstaras pelikanoj.
 Inter brutoj elstaras ŝafoj.
@@ -1671,7 +1662,6 @@ Kiel ekzemploj povas servi eldona agado aŭ turismo (ĝenerala aŭ kleriga).
 Kiel esprimo ĝi iĝis kultura kaj literatura temo.
 Kiel gastscienculo li restadis du jarojn ĉe la Universitato de Amsterdamo.
 Kiel infano li rakontis travivaĵojn al siaj amikoj en la stratoj de Damasko.
-Kiel kantisto Rantasila estis unue konata per kanto "Auringossa".
 Kiel la plej tipa ŝatata elemento eblas konsideri kupolon kaj diversajn specojn de arkoj.
 Kiel la unuopulo estus ankaŭ la socio ideo dia.
 Kiel medikamento ĝi estas uzata kiel antikoagulanto.
@@ -1729,8 +1719,6 @@ Koronadalo situas en la ekvatora klimato.
 Kortesuo estas areo en orienta parto de Kortepohja.
 Kostojn de la apartigo kun informaj tabuloj pagis judoj.
 Kovras ĝin la vino de la trezoro de la respubliko.
-Kraus estis bildiginta la ponton jam antaŭe plurfoje.
-Kraus estris tie ĝismorte.
 Kredo koncerne al la interrilato inter militado kaj biologio eble havas praktikajn efikojn.
 Kritiko venas de pluraj direktoj.
 Krom alia universitato funkcias ankaŭ pluraj altlernejoj.
@@ -1859,7 +1847,6 @@ La agrikulturo estis ĉiam konsiderata grava sektoro.
 La agrikulturo kaj la brutobredado de bovoj estis ĉiam plej grava enspezofonto.
 La agrikulturo produktas precipe rambutanojn.
 La aktiveco estas difinita kiel la plenumo de tasko aŭ agado.
-La aktoro rekomendis lin al la reĝisoro Vladimir Braun.
 La aktuala arkeologia esploro ne okazis.
 La aktuala setlejo estas atribuata al visigotoj.
 La akurata konstrukronologio ne tute klaras tamen.
@@ -1916,7 +1903,6 @@ La asocio baziĝas en Bruselo.
 La atako estis malsukcesa.
 La avantaĝo de elektro(kun)polimerigo estas la alta pureco de la produktoj.
 La aŭtoreco de la propono estas neklara.
-La baptujo estas nun en la Katedralo Sankta Kruco (Nordhausen).
 La baroka sakristio aliĝas al la navofino.
 La bataloj okazis kaj surtere kaj mare.
 La bazo poste estis moderna filipina internacia flughaveno.
@@ -2069,7 +2055,6 @@ La eŭropa dominado estis malrapide disvolvigita.
 La fabrikado de tiu tipo de fromaĝo estas tre facila.
 La fako muziko transprenis krome funkciojn de landa muzikakademio por la tuta federacia lando.
 La fakta bazo por ĉi tio ne estas klara.
-La fama lingvisto Ferdinand de Saussure estis lia pranepo.
 La familio havas pirservanton.
 La familio havis kvin infanojn.
 La familio loĝis en la Flava Kastelo (Vajmaro).
@@ -2305,7 +2290,6 @@ La klimato de Malungon estas klasifikita kiel ekvatora klimato.
 La klimato de Mamburao estas klasifikita kiel tropika klimato.
 La klimato de Metro estas klasifikita kiel ekvatora klimato.
 La klimato de Nabunturan estas klasifikita kiel ekvatora klimato.
-La klimato de Naujan estas klasifikita kiel tropika klimato.
 La klimato de Pajakumbuh estas klasifikita kiel ekvatora klimato.
 La klimato de San Pedro estas klasifikita kiel tropika.
 La klimato de Santa Cruz estas klasifikita kiel tropika.
@@ -2872,7 +2856,6 @@ La proteino kaŭzas morton de tiuj ĉi ĉeloj.
 La protokolo estas desegnita kunlabore kaj ne estas nuntempe normigita kiel interreta normo.
 La protokolo trudas konstantan malpermeson uzi ĉiujn specojn de biologiaj armiloj.
 La provincoj havas jurisdikcion super la Administracio de Justico en sia teritorio.
-La provoj de Kapsreiter tamen ricevi la kastelon fiaskis.
 La publika partopreno pliiĝis draste kaj fariĝis necesa la uzo de pli grandaj instalaĵoj.
 La publikaĵo estas eldonata kvin fojojn semajne.
 La puto kuŝtas sur fundamento el kalkŝtono.
@@ -3227,7 +3210,6 @@ La vizaĝo estas pli hela kaj flaveca ol la cetero de la korpo.
 La vizitebla parto etendiĝas en la lerneja korto.
 La vojkruciĝo situas sur la blazono de Krestci.
 La vojo al ĝi estas reguligita.
-La vorto Sarein en persa signifas "Elirejo de fontoj".
 La vortoj ankaŭ ofte estis menciitaj en religiaj tekstoj tra la mondo.
 La vosto estas griza kaj kaj ruĝaj la kruroj.
 La zono estis loĝata delonge.
@@ -3355,7 +3337,6 @@ Li ankaŭ estis entuziasma peranto de turismo en Altaj Tatroj.
 Li ankaŭ estis konata verkisto de satiro.
 Li ankaŭ estis kuntrovinto de la "stifnata acido".
 Li ankaŭ estis membro de la keŝikoj.
-Li ankaŭ estis mentoro de la liberstudenta rondo Serakreis Jena.
 Li ankaŭ estis pastro en la bohema urbo Psibor.
 Li ankaŭ estis redaktoro de "Katolika sento".
 Li ankaŭ estis tre aktiva kaj entuziasma pri astronomia popularigo.
@@ -3754,10 +3735,6 @@ Li kontribuis nur en la latina kaj la germana.
 Li kontribuis per verkoj al la Pariza Ekspozicio.
 Li kontribuis rumane kaj hungare.
 Li konvertis al kristanismo.
-Li kreis la Nacian Aŭtonoman Universitaton de Nikaragvo kaj la Centran Bankon de Nikaragvo.
-Li kreis la tutlandan bredoregistron.
-Li kreis novan instruan metodon en gimnazioj.
-Li kreis plurajn rolulojn en la serio.
 Li kreskis en Svislando.
 Li kreskis en laborista familio.
 Li kunigis tion kun la arkeologia esplorado de la regiono.
@@ -4152,8 +4129,6 @@ Lia filo estis pastro.
 Lia filo funkciigis plu la presejon.
 Lia filo iĝis muzikisto.
 Lia filo same estis masonisto.
-Lia frato Musa Neidavoud ankaŭ estis muzikisto kaj ili kunlaboris multe.
-Lia frato estis Tivadar Haeffner.
 Lia frua infanaĝo okazis en Londono.
 Lia geedzeco kun Karolino estis malfeliĉa.
 Lia instruisto estis kaj ankaŭ tie li akiris plian diplomon.
@@ -4279,7 +4254,6 @@ Ll servis kiel Helpanta Direktoro de la Luna Sekcio de la Brita Astronomia Asoci
 Loko por estiĝo de la vilaĝo ne estis elektita hazarde.
 Longajn jarojn li vivis kun sia patrino.
 Longe Viva Prezidanto Mao!
-Lubuklinggau situas en interno de la insulo.
 Lugarico Viejo de la Bronzepoko kun tomboj.
 Luktis aŭ la reĝoj inter si aŭ la tutaj grupoj reciproke.
 Lunŝtono estas tradicie uzata en juveloj.
@@ -4401,7 +4375,6 @@ Najbara urboparto de Mannila en sudo estas Lohikoski.
 Najbare al ĝi troviĝas aliaj belaj renesancaj domoj.
 Nature estas bona vojo al la menciita ĉefvojo.
 Nature li havis taskojn en la juda eklezio.
-Naujan kuŝas laŭ la marbordo en la nordorienta parto de la insulo.
 Ne eblas havi pliarangaj titoloj.
 Ne eblis eltrovi la identecon de la skeletoj.
 Ne ekzistas laŭvorta traduko en lingvon alian ol la turka por niaj tekstoj.
@@ -4651,7 +4624,6 @@ Pensiuliĝinte li ankaŭ interesiĝis pri genealogio.
 Per areo temas pri unu el la plej grandaj hanakaj municipoj.
 Per arto ŝi celas atingi socian ŝanĝon en sia propra lando.
 Per koncerna rakonto li fariĝis gajninto de la unua premio.
-Per posteno de ĉefinstruisto ĉe sinjoro von Ritzenstein eblis plibonigi ĝenerale la financan staton.
 Per tio fonditis la benediktana Klostro Sanktaj Petro kaj Paŭlo.
 Per tio ili elinfluigis el influo de la urbo.
 Per tio la municipo fakte pereis.
@@ -5169,11 +5141,9 @@ Santa Maria estas kandidato pri komponenta urbo.
 Santa Maria situas en la ekvatora klimato kun efiko de musono.
 Santa Rosa estas atingebla per aŭtovojo.
 Santiago estas komerca centro de la regiono.
-Sarein estas konata pro siaj varmaj fontoj.
 Sciencaj fakuloj helpis en la verkado por garantii la pedagogian valoron de la serio.
 Sciencfikciaj filmoj ofte estis uzitaj por esplori filozofiajn temojn kiel la homa kondiĉo.
 Sed (sklaveco) estas io kio estas tute finita.
-Sed Kraus postvivis vundojn siajn nur je kelkaj semajnoj.
 Sed ambaŭ municipoj ĝis nun konserviĝis memstarecon.
 Sed baldaŭ ĝi evidentiĝis tro nespacohava.
 Sed baldaŭ ĝi resaniĝis el la krizo.
@@ -5281,17 +5251,12 @@ Spuroj hodiaŭaj ne plu estas.
 Srulik pasigas iom da tempo kun la bando en la geto.
 Statistika mekaniko povas esti uzata por studi sistemojn kiuj estas for de la ekvilibro.
 Statuso de la haveno estas "nacia".
-Steenhuizen havas rilaton kaj filon kaj filinon.
-Stein pasigis nombrajn jarojn loĝante en Parizo kun sia fratino.
-Steiner fondis ĉe la Berlina Akademio premion pri matematiko kiu portas lian nomon.
-Steiner okupiĝis ankaŭ pri la evoluigo de malbruligeblaj tegmentoj.
 Stivisto devas esti fizike forta kaj devas plenumi ordonojn precize.
 Stokregistro enhavis ĉiujn numerojn.
 Stone fidis plie en la kombino de la historio kun la antropologio.
 Stromatolitoj estas strikte protektataj kaj Monda heredaĵo de Unesko.
 Studento volis organizi ekspozicion pri la malriĉo ĉirkaŭ la mondo.
 Studentoj ankaŭ povas uzi ĝin kiel platformo por reciproka lingva interŝanĝo.
-Studo de lia vivo estis verkita de Modris Eksteins.
 Studoj en Finnlando kaj Usono trovis la saman rezulton.
 Sub la kastelo estas keloj.
 Sub la pseŭdonimo "Retsigor" li kontribuis al la satira revuo La Pirato.
@@ -5888,7 +5853,6 @@ Unufoje ŝi ricevis filmajn rolojn en serio.
 Unufoje ŝi tradukis komedion el la germana lingvo.
 Unuopaj domoj estis detruitaj.
 Urbo Bariadi estas la ĉefurbo.
-Urbo Geita estas la ĉefurbo.
 Uskela estis en antaŭaj jarcentoj multe pli vasta.
 Usona Samoo estas dependa teritorio de Usono.
 Usonaj Malgrandaj Insuloj estas dependa teritorio de Usono.
@@ -5900,7 +5864,6 @@ Uzeblaj estas en variaj konstituoj.
 Vaganta vivo komenciĝis por Borrhaus.
 Valencia situas en la ekvatora klimato.
 Valoro de la mapo estas pro sia unika ekzisto antaŭ dominado de turkoj.
-Van Langenhove neis la akuzojn.
 Variado en la ordo indikas diversajn nuancojn de senco kaj emfazo.
 Variaj akademiaj studoj montris alternativajn rezultojn.
 Vasari skribis ke Giovanni estis pentristo je li propra merito.
@@ -6400,7 +6363,6 @@ Zsigmond Teleki devenis el juda familio.
 Ĝi instruas en la azera kaj en la rusa lingvoj.
 Ĝi interne malproksime tanĝas la orbiton de Marso.
 Ĝi iĝis grava pilgrimloko en la regiono.
-Ĝi iĝis la plej bone vendita libro de Stein.
 Ĝi iĝis rara pro habitatoperdo.
 Ĝi komencas en merkredo kaj finas en sekva dimanĉo.
 Ĝi konatas ankaŭ ekstere de la landa ĉefurbo.
@@ -6497,7 +6459,6 @@ Zsigmond Teleki devenis el juda familio.
 Ĝi troviĝas en Ekvadoro kaj Peruo.
 Ĝi troviĝas en la insuloj Salomonoj.
 Ĝi troviĝas en severe protektata zono de la parko.
-Ĝi troviĝas hodiaŭ en Leiden.
 Ĝi troviĝas laŭlonge de la sudaj kaj okcidentaj marbordoj de Aŭstralio.
 Ĝi troviĝas norde de Rataje.
 Ĝi troviĝas oriente de Liberec.
@@ -6559,7 +6520,6 @@ Zsigmond Teleki devenis el juda familio.
 Ĝibraltaro estas Brita transmara teritorio.
 Ĝin apudas flankaj ejoj.
 Ĝin donas la prezidanto de respubliko.
-Ĝin kreis Ernst Paul el Dresdeno.
 Ĝin organizis la belorusa registaro kun la financa subteno de Rusio kaj Ukrainio.
 Ĝin ornamis blazonoj de la konstrukomisiintoj.
 Ĝin vizitas somere multaj eksteraj kaj landaj turistoj.


### PR DESCRIPTION
As discussed in #3298 this pull request deletes some wrong or hard to pronounce sentences from the re-run of the wiki extraction. This was a quick search where I mainly focussed on structural criteria, e.g. sentences that are very similar and not useful for CV. Here are a few examples:

Hard to pronounce names and words:

`Inter Olkiluoto kaj la kontinento estas mallarĝa markolo Karhukarinrauma.`

Structurally similar blocks of sentences:

- The administrative center is called X (mostly names of small  towns)
`Administra centro de la komunumo estas la loĝloko Jegunovce.`
- Sentences about Names of peoples, like "His family name is X" "His wifes name was" and so on
`Lia edzino nomiĝis Terrenzia Cossi.`
- Botanic sentences about plants with long latin names:
` Ĝi enhavas ununuran genron (barbeŭio) kaj ununuran specion (madagaskara barbeŭio).`