### PR TITLE
Tweaks to takeout functions

### DIFF
--- a/common/takeout.ts
+++ b/common/takeout.ts
@@ -2,7 +2,8 @@ export enum TakeoutState {
   PENDING = 0,
   IN_PROGRESS,
   AVAILABLE,
-  EXPIRED
+  EXPIRED,
+  INCOMPLETE
 }
 
 export type TakeoutRequest = {

--- a/server/src/lib/bucket.ts
+++ b/server/src/lib/bucket.ts
@@ -146,8 +146,10 @@ export default class Bucket {
     chunkIndex: number,
     paths: string[]
   ): Promise<S3.HeadObjectOutput> {
-    console.log('start takeout zipping', takeout.id);
     const destination = this.takeoutKey(takeout, chunkIndex);
+
+    console.log('start takeout zipping', destination);
+
     const bucket = getConfig().CLIP_BUCKET_NAME;
     const passThrough = new PassThrough();
 


### PR DESCRIPTION
* Add better logging to mid-stream zipping functions
* Do not cancel a takeout if a second pod tries to re-initiate
* Make sure stuck takeouts ignore expired takeouts
* Do not delete stuck takeouts from db