### PR TITLE
Re-add fluent syntax dependency to fix import-locales script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "repository": "mozilla/voice-web",
   "private": true,
   "dependencies": {
+    "fluent-syntax": "^0.14.0",
     "http-status-codes": "^1.4.0",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4449,6 +4449,11 @@ fluent-intl-polyfill@^0.1.0:
   dependencies:
     intl-pluralrules projectfluent/IntlPluralRules#module
 
+fluent-syntax@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/fluent-syntax/-/fluent-syntax-0.14.0.tgz#d332a67eb3c0a3cdd3d07ee097c89e1c0b95bb84"
+  integrity sha512-+k8uXWfRpSrE33764RbpjIKMzIX6R9EnSjFBgaA1s0Mboc3KnW9sYe0c6vjIoZQY1C4Gst1VFvAOP6YGJjTJuA==
+
 flush-write-stream@^1.0.2:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.1.1.tgz#8dd7d873a1babc207d94ead0c2e0e44276ebf2e8"


### PR DESCRIPTION
The recent dependency upgrade PR removed the `fluent-syntax` package, which broke the `yarn import-locales` script. This re-adds the dependency from the old name, as the package under `@fluent/syntax` requires Node >= 12.