### PR TITLE
Use @fluent/syntax instead of fluent-syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "mozilla/voice-web",
   "private": true,
   "dependencies": {
-    "fluent-syntax": "^0.14.0",
+    "@fluent/syntax": "^0.18.0",
     "http-status-codes": "^1.4.0",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.8"

--- a/scripts/import-locales.js
+++ b/scripts/import-locales.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { parse } = require('fluent-syntax');
+const { parse } = require('@fluent/syntax');
 const request = require('request-promise-native');
 
 const TRANSLATED_MIN_PROGRESS = 0.9;
@@ -90,7 +90,10 @@ async function importPontoonLocales() {
   const languages = await fetchPontoonLanguages();
   await Promise.all([
     saveToMessages(languages),
-    saveDataJSON('all', languages.map(l => l.code)),
+    saveDataJSON(
+      'all',
+      languages.map(l => l.code)
+    ),
     saveDataJSON(
       'rtl',
       languages

--- a/yarn.lock
+++ b/yarn.lock
@@ -829,6 +829,11 @@
   resolved "https://registry.yarnpkg.com/@fluent/sequence/-/sequence-0.5.0.tgz#6349b614711df2d8ed256598fa31a757fe032539"
   integrity sha512-70LhnbPO/sO2rI2vHws66QwKq9a7PKiEN0hrc65xY3LzWq3AlATZnt+EmFG1ihmPI+5mqGPnJMAdpp3qze3X2Q==
 
+"@fluent/syntax@^0.18.0":
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/@fluent/syntax/-/syntax-0.18.0.tgz#5204b4bb65e9446f257b33a90e16016fa077c963"
+  integrity sha512-9UTl7hpZMoCxlJht5C1ZU6SsisPwXmu00c9EzHbWhNOKQGMALpNYe79PGFMFV6eg3Eu/dtTOnAoAuIYEUIVWug==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz#10602de5570baea82f8afbfa2630b24e7a8cfe5b"
@@ -4470,11 +4475,6 @@ fluent-intl-polyfill@^0.1.0:
   integrity sha1-ETOUSrJHeINHOZVZaIPg05z4hc8=
   dependencies:
     intl-pluralrules projectfluent/IntlPluralRules#module
-
-fluent-syntax@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/fluent-syntax/-/fluent-syntax-0.14.0.tgz#d332a67eb3c0a3cdd3d07ee097c89e1c0b95bb84"
-  integrity sha512-+k8uXWfRpSrE33764RbpjIKMzIX6R9EnSjFBgaA1s0Mboc3KnW9sYe0c6vjIoZQY1C4Gst1VFvAOP6YGJjTJuA==
 
 flush-write-stream@^1.0.2:
   version "1.1.1"


### PR DESCRIPTION
As Node 10 is now not supported anymore, we can upgrade to `@fluent/syntax` instead of using the old `fluent-syntax` package.