### PR TITLE
Update Terms and Privacy content on Locale change

### DIFF
--- a/web/src/components/pages/document-page.tsx
+++ b/web/src/components/pages/document-page.tsx
@@ -3,43 +3,47 @@ import { connect } from 'react-redux';
 import API from '../../services/api';
 import StateTree from '../../stores/tree';
 import { Spinner } from '../ui/ui';
-import { useEffect, useState } from "react";
 
 interface PropsFromState {
   api: API;
   locale: string;
 }
 
-type Props = {
-  name: 'privacy' | 'terms' | 'challenge-terms'
-} & PropsFromState
-
 /**
  * Renders an HTML document determined by the <c>name</c> prop.
  * @param {{name:string} & PropsFromState} props Props passed to the component.
  */
-function DocumentPage(props: Props) {
-  const {api, name, locale} = props;
-  const [html, setHtml] = useState('')
+class DocumentPage extends React.Component<
+  { name: 'privacy' | 'terms' | 'challenge-terms' } & PropsFromState,
+  { html: string }
+> {
+  state = {
+    html: '',
+  };
 
   // Whenever locale changes (and on first draw) fetch the document to be displayed.
-  useEffect(() => {
-    fetchDocument().then();
-  }, [locale])
+  async componentDidUpdate() {
+    await this.fetchDocument();
+  }
 
   /**
    * Retrieves the document to be displayed and updates state.
    */
-  async function fetchDocument() {
-    const nextHtml = await api.fetchDocument(name);
-    setHtml(nextHtml);
+  private async fetchDocument() {
+    const { api, name } = this.props;
+    this.setState({
+      html: await api.fetchDocument(name),
+    });
   }
 
-  return html ? (
-    <div dangerouslySetInnerHTML={{__html: html}}/>
-  ) : (
-    <Spinner/>
-  );
+  render() {
+    const { html } = this.state;
+    return html ? (
+      <div dangerouslySetInnerHTML={{ __html: html }} />
+    ) : (
+      <Spinner />
+    );
+  }
 }
 
 /**

--- a/web/src/components/pages/document-page.tsx
+++ b/web/src/components/pages/document-page.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import API from '../../services/api';
 import StateTree from '../../stores/tree';
 import { Spinner } from '../ui/ui';
-import { useEffect, useState } from "react";
+import { useEffect, useState } from 'react';
 
 interface PropsFromState {
   api: API;
@@ -11,21 +11,21 @@ interface PropsFromState {
 }
 
 type Props = {
-  name: 'privacy' | 'terms' | 'challenge-terms'
-} & PropsFromState
+  name: 'privacy' | 'terms' | 'challenge-terms';
+} & PropsFromState;
 
 /**
  * Renders an HTML document determined by the <c>name</c> prop.
  * @param {{name:string} & PropsFromState} props Props passed to the component.
  */
 function DocumentPage(props: Props) {
-  const {api, name, locale} = props;
-  const [html, setHtml] = useState('')
+  const { api, name, locale } = props;
+  const [html, setHtml] = useState('');
 
   // Whenever locale changes (and on first draw) fetch the document to be displayed.
   useEffect(() => {
     fetchDocument().then();
-  }, [locale])
+  }, [locale]);
 
   /**
    * Retrieves the document to be displayed and updates state.
@@ -36,9 +36,9 @@ function DocumentPage(props: Props) {
   }
 
   return html ? (
-    <div dangerouslySetInnerHTML={{__html: html}}/>
+    <div dangerouslySetInnerHTML={{ __html: html }} />
   ) : (
-    <Spinner/>
+    <Spinner />
   );
 }
 
@@ -47,7 +47,7 @@ function DocumentPage(props: Props) {
  * @param API api Provides methods for fetching HTML for the page.
  * @param {string} locale Triggers a redraw if the locale is changed in state.
  */
-const mapStateToProps = ({api, locale}: StateTree) => ({
+const mapStateToProps = ({ api, locale }: StateTree) => ({
   api,
   locale,
 });

--- a/web/src/components/pages/document-page.tsx
+++ b/web/src/components/pages/document-page.tsx
@@ -3,47 +3,43 @@ import { connect } from 'react-redux';
 import API from '../../services/api';
 import StateTree from '../../stores/tree';
 import { Spinner } from '../ui/ui';
+import { useEffect, useState } from "react";
 
 interface PropsFromState {
   api: API;
   locale: string;
 }
 
+type Props = {
+  name: 'privacy' | 'terms' | 'challenge-terms'
+} & PropsFromState
+
 /**
  * Renders an HTML document determined by the <c>name</c> prop.
  * @param {{name:string} & PropsFromState} props Props passed to the component.
  */
-class DocumentPage extends React.Component<
-  { name: 'privacy' | 'terms' | 'challenge-terms' } & PropsFromState,
-  { html: string }
-> {
-  state = {
-    html: '',
-  };
+function DocumentPage(props: Props) {
+  const {api, name, locale} = props;
+  const [html, setHtml] = useState('')
 
   // Whenever locale changes (and on first draw) fetch the document to be displayed.
-  async componentDidUpdate() {
-    await this.fetchDocument();
-  }
+  useEffect(() => {
+    fetchDocument().then();
+  }, [locale])
 
   /**
    * Retrieves the document to be displayed and updates state.
    */
-  private async fetchDocument() {
-    const { api, name } = this.props;
-    this.setState({
-      html: await api.fetchDocument(name),
-    });
+  async function fetchDocument() {
+    const nextHtml = await api.fetchDocument(name);
+    setHtml(nextHtml);
   }
 
-  render() {
-    const { html } = this.state;
-    return html ? (
-      <div dangerouslySetInnerHTML={{ __html: html }} />
-    ) : (
-      <Spinner />
-    );
-  }
+  return html ? (
+    <div dangerouslySetInnerHTML={{__html: html}}/>
+  ) : (
+    <Spinner/>
+  );
 }
 
 /**

--- a/web/src/components/pages/document-page.tsx
+++ b/web/src/components/pages/document-page.tsx
@@ -3,42 +3,53 @@ import { connect } from 'react-redux';
 import API from '../../services/api';
 import StateTree from '../../stores/tree';
 import { Spinner } from '../ui/ui';
+import { useEffect, useState } from "react";
 
 interface PropsFromState {
   api: API;
+  locale: string;
 }
 
-class DocumentPage extends React.Component<
-  { name: 'privacy' | 'terms' | 'challenge-terms' } & PropsFromState,
-  { html: string }
-> {
-  state = {
-    html: '',
-  };
+type Props = {
+  name: 'privacy' | 'terms' | 'challenge-terms'
+} & PropsFromState
 
-  async componentDidMount() {
-    await this.fetchDocument();
+/**
+ * Renders an HTML document determined by the <c>name</c> prop.
+ * @param {{name:string} & PropsFromState} props Props passed to the component.
+ */
+function DocumentPage(props: Props) {
+  const {api, name, locale} = props;
+  const [html, setHtml] = useState('')
+
+  // Whenever locale changes (and on first draw) fetch the document to be displayed.
+  useEffect(() => {
+    fetchDocument().then();
+  }, [locale])
+
+  /**
+   * Retrieves the document to be displayed and updates state.
+   */
+  async function fetchDocument() {
+    const nextHtml = await api.fetchDocument(name);
+    setHtml(nextHtml);
   }
 
-  private async fetchDocument() {
-    const { api, name } = this.props;
-    this.setState({
-      html: await api.fetchDocument(name),
-    });
-  }
-
-  render() {
-    const { html } = this.state;
-    return html ? (
-      <div dangerouslySetInnerHTML={{ __html: html }} />
-    ) : (
-      <Spinner />
-    );
-  }
+  return html ? (
+    <div dangerouslySetInnerHTML={{__html: html}}/>
+  ) : (
+    <Spinner/>
+  );
 }
 
-const mapStateToProps = ({ api }: StateTree) => ({
+/**
+ * Maps Redux state to local props for the component
+ * @param API api Provides methods for fetching HTML for the page.
+ * @param {string} locale Triggers a redraw if the locale is changed in state.
+ */
+const mapStateToProps = ({api, locale}: StateTree) => ({
   api,
+  locale,
 });
 
 export default connect<PropsFromState>(mapStateToProps)(DocumentPage);


### PR DESCRIPTION
Resolves #3287 

There are two commits in this PR:
* The latest is a state-only change that switches to `ComponentDidUpdate` so that Redux changes trigger a redraw of the inner HTML.
* The prior commit accomplishes the same thing but refactors the component to a functional one.

I wasn't sure which would be preferred, so I included both--deferring to minimizing unnecessary change. If the functional version is preferred I can re-push with just that. If the class-based version is preferred and the extra commit needs to be pruned, I'm happy to do that as well.

For my part, I like the simplicity of functional components and their integration with the Hooks API. Unfortunately the spacing (between parens and braces) isn't right on that commit. I'll fix it if we choose that one.