### PR TITLE
Fix animation of cards to go to the left side in LTR

### DIFF
--- a/web/src/components/pages/contribution/contribution.tsx
+++ b/web/src/components/pages/contribution/contribution.tsx
@@ -455,7 +455,7 @@ class ContributionPage extends React.Component<Props, State> {
                           transform: [
                             `scale(${isActive ? 1 : 0.9})`,
                             `translateX(${
-                              (document.dir == 'rtl' ? -1 : 1) *
+                              (document.dir == 'rtl' ? 1 : -1) *
                               (i - activeSentenceIndex) *
                               -130
                             }%)`,


### PR DESCRIPTION
Currently, the animation when reviewing or speaking a sentence is that the card leaves to the right side of the screen (LTR direction). This is counterintuitive from the animation point, as the slider on mobile looks like it should leave on the left side.

Therefore I changed the direction in the animation,
Fixes #3297

Please let me know if there's anything missing or wrong with this PR.