### PR TITLE
Add Sentence Collector EN strings export section

### DIFF
--- a/web/locales/en/messages.ftl
+++ b/web/locales/en/messages.ftl
@@ -1008,3 +1008,8 @@ contribution-just-unsure-description = If you come across something that these g
 
 see-more = <chevron></chevron>See more
 see-less = <chevron></chevron>See less
+
+# Don't rename the following section, its contents are auto-inserted based on the name. These strings are
+# automatically exported from Sentence Collector.
+# [SentenceCollector]
+# [/SentenceCollector]


### PR DESCRIPTION
This adds a section for the Sentence Collector source strings. Sentence Collector will export automatically to this section on every automatic export. Commits are only done when there indeed are changed/deleted/new strings.

PR for Sentence Collector: https://github.com/common-voice/sentence-collector/pull/536