### PR TITLE
Lower localization threshold to account for SC

### DIFF
--- a/scripts/import-locales.js
+++ b/scripts/import-locales.js
@@ -3,7 +3,7 @@ const path = require('path');
 const { parse } = require('@fluent/syntax');
 const request = require('request-promise-native');
 
-const TRANSLATED_MIN_PROGRESS = 0.9;
+const TRANSLATED_MIN_PROGRESS = 0.75;
 const CONTRIBUTABLE_MIN_SENTENCES = 5000;
 
 const dataPath = path.join(__dirname, '..', 'locales');


### PR DESCRIPTION
Since we added Sentence Collector sentences to the same localization file, we're lowering the threshold for how complete the localization needs to be for it to show up in `translated.json` to avoid putting undue burden on new/smaller communities joining in the future. 