### PR TITLE
fix incomplete closing tag ctaLink in about-playbook-what-is-language-content-3

### DIFF
--- a/web/locales/cy/messages.ftl
+++ b/web/locales/cy/messages.ftl
@@ -552,7 +552,7 @@ about-nav-playbook = Dyma sut mae cymryd rhan
 about-playbook-what-is-language = Beth yw iaith ar Common Voice?
 about-playbook-what-is-language-content-1 = Mae yna lawer o ffyrdd i feddwl am iaith. At ddibenion modelau adnabod lleferydd, mae Common Voice yn awgrymu canolbwyntio ar ‘gyd-ddealltwriaeth’, neu ‘a all siaradwyr yr iaith hon ddeall ei gilydd os ydynt yn ceisio gwneud hynny?’
 about-playbook-what-is-language-content-2 = Rydym am i fodelau lleferydd fod yn well am ddeall ystod amrywiol o siaradwyr. Er mwyn i hyn ddigwydd, rhaid i set ddata llais gynrychioli llawer o wahanol bobl.
-about-playbook-what-is-language-content-3 = Mae rhai ieithoedd yn amrywio'n fawr o ran gramadeg, geirfa ac ynganiad. Am y rheswm hwn, rydym yn <ctaLink>yn cyflwyno ‘Amrywiadau’</ctaLink yn 2022. Mae hyn yn rhoi ffordd i gymunedau wahaniaethu eu hieithoedd o fewn y set ddata fwy.
+about-playbook-what-is-language-content-3 = Mae rhai ieithoedd yn amrywio'n fawr o ran gramadeg, geirfa ac ynganiad. Am y rheswm hwn, rydym yn <ctaLink>yn cyflwyno ‘Amrywiadau’</ctaLink> yn 2022. Mae hyn yn rhoi ffordd i gymunedau wahaniaethu eu hieithoedd o fewn y set ddata fwy.
 
 ## How do I add a language
 

--- a/web/locales/de/messages.ftl
+++ b/web/locales/de/messages.ftl
@@ -535,7 +535,7 @@ about-nav-playbook = Erfahren Sie, wie Sie mitmachen können
 about-playbook-what-is-language = Was ist eine Sprache bei Common Voice?
 about-playbook-what-is-language-content-1 = Es gibt viele Möglichkeiten, sich Sprache vorzustellen. Für die Zwecke von Spracherkennungsmodellen schlägt Common Voice vor, sich auf „gegenseitige Verständlichkeit“ zu konzentrieren oder „können Sprecher dieser Sprache einander meistens verstehen, wenn sie es versuchen?“.
 about-playbook-what-is-language-content-2 = Wir wollen, dass Sprachmodelle besser in der Lage sind, eine Vielzahl von Sprechern zu verstehen. Damit dies geschieht, muss ein Sprachdatensatz viele verschiedene Personen repräsentieren.
-about-playbook-what-is-language-content-3 = Einige Sprachen haben enorme Unterschiede in Grammatik, Vokabular und Aussprache. Aus diesem Grund führen wir 2022 <ctaLink>„Varianten“</ctaLink ein. Dies gibt Gemeinschaften eine Möglichkeit, ihre Sprachen innerhalb des größeren Datensatzes zu unterscheiden.
+about-playbook-what-is-language-content-3 = Einige Sprachen haben enorme Unterschiede in Grammatik, Vokabular und Aussprache. Aus diesem Grund führen wir 2022 <ctaLink>„Varianten“</ctaLink> ein. Dies gibt Gemeinschaften eine Möglichkeit, ihre Sprachen innerhalb des größeren Datensatzes zu unterscheiden.
 
 ## How do I add a language
 

--- a/web/locales/en/messages.ftl
+++ b/web/locales/en/messages.ftl
@@ -559,7 +559,7 @@ about-nav-playbook = Learn how to take part
 about-playbook-what-is-language = What is a language on Common Voice?
 about-playbook-what-is-language-content-1 = There are lots of ways to think about language. For the purposes of speech recognition models, Common Voice suggests focussing on ‘mutual intelligibility’, or ‘can speakers of this language mostly understand one another if they try to?’
 about-playbook-what-is-language-content-2 = We want speech models to be better at understanding a diverse range of speakers. For this to happen, a voice dataset must represent lots of different people.
-about-playbook-what-is-language-content-3 = Some languages have enormous variation in grammar, vocabulary and pronunciation. For this reason, we are <ctaLink>introducing ‘Variants’</ctaLink in 2022. This gives communities a way to distinguish their languages within the larger dataset.
+about-playbook-what-is-language-content-3 = Some languages have enormous variation in grammar, vocabulary and pronunciation. For this reason, we are <ctaLink>introducing ‘Variants’</ctaLink> in 2022. This gives communities a way to distinguish their languages within the larger dataset.
 
 ## How do I add a language
 about-playbook-how-add-language = How do I add a language?

--- a/web/locales/hsb/messages.ftl
+++ b/web/locales/hsb/messages.ftl
@@ -534,7 +534,7 @@ about-nav-playbook = Zhońće, ka móžeće so wobdźělić
 
 about-playbook-what-is-language = Što je rěč na Common Voice?
 about-playbook-what-is-language-content-2 = Chcemy, zo rěčne modele lěpje móža, wjele rozdźělnych rěčnikow rozumić. Zo by to je móžne, dyrbi datowa sadźba wjele rozdźělnych ludźi reprezentować.
-about-playbook-what-is-language-content-3 = Někotre rěče maja enormne rozdźělne w gramatice, wokabularje a wurěkowanju. Tohodla budźemy w lěće 2022 <ctaLink>„warianty“ zawjedować</ctaLink. To zhromadźenstwam móžnosć dawa, swoje rěče we wjetšej datowej sadźbje rozeznawać.
+about-playbook-what-is-language-content-3 = Někotre rěče maja enormne rozdźělne w gramatice, wokabularje a wurěkowanju. Tohodla budźemy w lěće 2022 <ctaLink>„warianty“ zawjedować</ctaLink>. To zhromadźenstwam móžnosć dawa, swoje rěče we wjetšej datowej sadźbje rozeznawać.
 
 ## How do I add a language
 

--- a/web/locales/sv-SE/messages.ftl
+++ b/web/locales/sv-SE/messages.ftl
@@ -540,7 +540,7 @@ about-nav-playbook = Lär dig hur du deltar
 about-playbook-what-is-language = Vad är ett språk på Common Voice?
 about-playbook-what-is-language-content-1 = Det finns många sätt att tänka på språk. För taligenkänningsmodeller föreslår Common Voice att man fokuserar på "ömsesidig förståelse", eller "kan talare av detta språk mestadels förstå varandra om de försöker?"
 about-playbook-what-is-language-content-2 = Vi vill att talmodeller ska bli bättre på att förstå en mängd olika talare. För att detta ska hända måste en röstdatamängd representera många olika personer.
-about-playbook-what-is-language-content-3 = Vissa språk har enorm variation i grammatik, ordförråd och uttal. Av denna anledning <ctaLink>introducerar vi "Varianter"</ctaLink 2022. Detta ger gemenskaper ett sätt att särskilja sina språk inom den större datamängden.
+about-playbook-what-is-language-content-3 = Vissa språk har enorm variation i grammatik, ordförråd och uttal. Av denna anledning <ctaLink>introducerar vi "Varianter"</ctaLink> 2022. Detta ger gemenskaper ett sätt att särskilja sina språk inom den större datamängden.
 
 ## How do I add a language
 


### PR DESCRIPTION
## Pull Request Form

<!-- Thanks for making a contribution to Common Voice, to help us review the request please fill out this form -->

### Type of Pull Request

- [x] Other

<!--- Please describe the pull request-->

In the latest batch of exported string there is one string `about-playbook-what-is-language-content-3` has a incomplete closing HTML tag `</ctaLink` instead of `</ctaLink>`. This commit fixes en locale, as well as those locales already translated but did not have the tag corrected in translation. 

### Acknowledging contributors

<!-- Please list who collaborated with you to make this contribution. Or Community discussion that helped make this idea possible -->

* me myself.

