### PR TITLE
feat(accessibility): add component to hide things visually

### DIFF
--- a/web/src/components/visually-hidden/visually-hidden.css
+++ b/web/src/components/visually-hidden/visually-hidden.css
@@ -1,5 +1,5 @@
 /*
-  stolen from GOV.UK
+  based on code from GOV.UK
   https://github.com/alphagov/govuk-frontend/blob/main/src/govuk/helpers/_visually-hidden.scss
 */
 .visually-hidden {

--- a/web/src/components/visually-hidden/visually-hidden.css
+++ b/web/src/components/visually-hidden/visually-hidden.css
@@ -1,0 +1,17 @@
+/*
+  stolen from GOV.UK
+  https://github.com/alphagov/govuk-frontend/blob/main/src/govuk/helpers/_visually-hidden.scss
+*/
+.visually-hidden {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    overflow: hidden !important;
+    clip: rect(0 0 0 0) !important;
+    -webkit-clip-path: inset(50%) !important;
+    clip-path: inset(50%) !important;
+    border: 0 !important;
+    white-space: nowrap !important;
+}

--- a/web/src/components/visually-hidden/visually-hidden.tsx
+++ b/web/src/components/visually-hidden/visually-hidden.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+import './visually-hidden.css';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+const VisuallyHidden = ({ children }: Props) => {
+  return <div className="visually-hidden">{children}</div>;
+};
+
+export default VisuallyHidden;


### PR DESCRIPTION
Add `VisuallyHidden` component. This hides content visually but allows assitive technology to access it still.
```js
<VisuallyHidden>This is hidden weee!</VisuallyHidden>
```

Sometimes we want something to not show visually but availablefor assistive technologies such as screenreaders.

These styles are from GOV.UK's work, known for their accessibility work.