### PR TITLE
fix(param): query param incorrectly parsed

### DIFF
--- a/server/src/lib/api.ts
+++ b/server/src/lib/api.ts
@@ -536,7 +536,7 @@ export default class API {
     const countNumberResult = parseInt(count, 10);
 
     // handle if we don't have a number sent
-    if (!Number.isNaN(countNumberResult)) {
+    if (Number.isNaN(countNumberResult)) {
       return null;
     }
 

--- a/server/src/lib/clip.ts
+++ b/server/src/lib/clip.ts
@@ -404,7 +404,7 @@ export default class Clip {
     const number = parseInt(count, 10);
 
     // if invalid number return nothing
-    if (!Number.isNaN(number)) {
+    if (Number.isNaN(number)) {
       return null;
     }
 


### PR DESCRIPTION
This bug was returning null because of incorrect check of valid numbers.