### PR TITLE
feat(localization): remove english from share metadata

### DIFF
--- a/web/index_template.html
+++ b/web/index_template.html
@@ -16,11 +16,7 @@
       content="Common Voice is a project to help make voice recognition open to everyone. Now you can donate your voice to help us build an open-source voice database that anyone can use to make innovative apps for devices and the web."
     />
     <meta property="og:type" content="product" />
-    <meta property="og:title" content="Common Voice by Mozilla" />
-    <meta
-      property="og:description"
-      content="Common Voice is a project to help make voice recognition open to everyone. Now you can donate your voice to help us build an open-source voice database that anyone can use to make innovative apps for devices and the web."
-    />
+    <meta property="og:title" content="Mozilla Common Voice" />
     <meta property="og:url" content="https://commonvoice.mozilla.org/" />
     <meta
       property="og:image"


### PR DESCRIPTION
References #2861

We can't localise the share metadata easily because we currently don't serverside render our HTML, the website is all JavaScript.

+ Removes English descriptions
+ Renames 'Common Voice by Mozilla' to 'Mozilla Common Voice'

