### PR TITLE
chore(profile): test and refactor language form elements

### DIFF
--- a/web/src/components/index.css
+++ b/web/src/components/index.css
@@ -345,17 +345,6 @@ a.small,
 }
 
 .tippy-popper {
-    & .tippy-tooltip.grey-tooltip-theme {
-        color: var(--black);
-        letter-spacing: initial;
-        background: var(--darker-grey);
-        font-style: normal;
-
-        & .arrow-regular {
-            border-top-color: var(--darker-grey) !important;
-        }
-    }
-
     & .tippy-tooltip {
         border-radius: 20px;
         padding: 9px 25px;

--- a/web/src/components/pages/contribution/speak/recording-pill.tsx
+++ b/web/src/components/pages/contribution/speak/recording-pill.tsx
@@ -75,7 +75,7 @@ function RecordingPill({
           <Tooltip
             arrow
             open={isPlaying || showSentenceTooltip}
-            theme="grey-tooltip"
+            theme="dark"
             title={clip.sentence.text}>
             <button
               className="play"

--- a/web/src/components/pages/profile/info/info.css
+++ b/web/src/components/pages/profile/info/info.css
@@ -53,54 +53,6 @@
         flex-wrap: wrap;
         width: 99%;
 
-        &.multilingual {
-            .accent-wrap {
-                border-bottom: 2px solid rgba(230, 229, 227, 0.6);
-                margin-bottom: 2rem;
-                &:last-child {
-                    border-bottom: 0;
-                }
-            }
-        }
-
-        .accent-wrap {
-            display: block;
-            width: 100%;
-            position: relative;
-            padding-bottom: 0.5rem;
-
-            label {
-                width: 100%;
-            }
-
-            > label:last-child {
-                margin-bottom: 15px;
-            }
-
-            ul {
-                margin: -30px 0 30px;
-                position: absolute;
-                padding: 0;
-                background: white;
-                z-index: var(--override-z-index);
-                width: 100%;
-
-                li {
-                    cursor: pointer;
-                    list-style: none;
-                    padding: 15px;
-                    border-bottom: 1px solid var(--dark-grey);
-                }
-            }
-
-            .downshift-open {
-                border: 1px solid var(--light-grey);
-                box-sizing: border-box;
-                box-shadow: 0 2px 5px 0 var(--light-grey);
-                overflow: hidden;
-            }
-        }
-
         label {
             box-sizing: border-box;
             margin-bottom: 30px;
@@ -118,29 +70,6 @@
                     margin-inline-start: var(--profile-column-margin);
                 }
             }
-        }
-    }
-
-    .add-language-section {
-        .profile-toggle {
-            margin-top: 0;
-        }
-    }
-
-    .add-language {
-        display: inline-block;
-        justify-content: center;
-        direction: ltr;
-        margin-inline-end: 1rem;
-
-        & :first-child {
-            margin-right: 25px;
-        }
-
-        & :nth-child(2) {
-            font-family: initial;
-            font-size: var(--font-size-lg);
-            color: var(--black);
         }
     }
 
@@ -208,33 +137,5 @@
         margin: 0 auto;
         min-height: 57px;
         background: var(--black);
-    }
-}
-
-.selected-accent {
-    background: var(--light-grey);
-    border-radius: 15rem;
-    padding: 0.8rem 1.5rem;
-    margin-bottom: 1.5rem;
-    margin-inline-end: 1rem;
-    display: inline-block;
-    img {
-        cursor: pointer;
-        padding-inline-end: 1rem;
-    }
-}
-
-#accent-selection-menu {
-    max-height: 200px;
-    overflow-y: scroll;
-
-    .add-new-accent {
-        color: var(--blue);
-        font-weight: 600;
-
-        &:focus,
-        &:hover {
-            background: var(--light-grey);
-        }
     }
 }

--- a/web/src/components/pages/profile/info/info.tsx
+++ b/web/src/components/pages/profile/info/info.tsx
@@ -7,6 +7,7 @@ import * as React from 'react';
 import Downshift from 'downshift';
 import { useCallback, useEffect, useState } from 'react';
 import { Redirect, RouteComponentProps, withRouter } from 'react-router';
+import { Tooltip } from 'react-tippy';
 import { useAction, useAPI } from '../../../../hooks/store-hooks';
 import { NATIVE_NAMES } from '../../../../services/localization';
 import { trackProfile } from '../../../../services/tracker';
@@ -31,8 +32,9 @@ import { Accent, UserAccentLocale } from 'common';
 
 import './info.css';
 
+// TODO: remove pick
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const pick = require('lodash.pick');
-const { Tooltip } = require('react-tippy');
 
 // Types for Downshift haven't caught up yet. Can be removed in the future
 const Input = LabeledInput as any;
@@ -92,14 +94,8 @@ function ProfilePage({
     sendEmails: false,
     privacyAgreed: false,
   });
-  const {
-    username,
-    visible,
-    age,
-    gender,
-    sendEmails,
-    privacyAgreed,
-  } = userFields;
+  const { username, visible, age, gender, sendEmails, privacyAgreed } =
+    userFields;
   const [userAccentLocales, setUserAccentLocales] = useState<UserAccentLocales>(
     []
   );
@@ -158,14 +154,14 @@ function ProfilePage({
     setUserAccentLocales(account ? account.locales : userAccentLocales);
   }, [user]);
 
-  const handleChangeFor = (field: string) => ({
-    target,
-  }: React.ChangeEvent<any>) => {
-    setUserFields({
-      ...userFields,
-      [field]: target.type == 'checkbox' ? target.checked : target.value,
-    });
-  };
+  const handleChangeFor =
+    (field: string) =>
+    ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+      setUserFields({
+        ...userFields,
+        [field]: target.type == 'checkbox' ? target.checked : target.value,
+      });
+    };
 
   const getAutocompleteAccents = (locale: string) => {
     return accentsAll[locale]
@@ -296,6 +292,8 @@ function ProfilePage({
       )}
       {!user.account && (
         <Localized id="thanks-for-account">
+          {/* Localized injects content into child tag */}
+          {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
           <h2 />
         </Localized>
       )}
@@ -357,6 +355,7 @@ function ProfilePage({
             <Options>{GENDERS}</Options>
           </LabeledSelect>
         </Localized>
+
         {userAccentLocales.map(({ locale, accents }, i) => (
           <div className="accent-wrap" key={i}>
             <Localized id="profile-form-language" attrs={{ label: true }}>
@@ -446,8 +445,8 @@ function ProfilePage({
                         className={isOpen ? 'downshift-open' : ''}>
                         {options.map((item, index) => (
                           <li
+                            key={item.name}
                             {...getItemProps({
-                              key: item.name,
                               index,
                               item,
                               style: {
@@ -493,6 +492,7 @@ function ProfilePage({
           </div>
         ))}
       </div>
+
       <div className="add-language-section">
         {userAccentLocales.length > 0 ? (
           <div
@@ -544,8 +544,8 @@ function ProfilePage({
           <div className="signup-section">
             <Tooltip
               arrow
-              html={getString('change-email-setings')}
-              theme="grey-tooltip">
+              html={<>{getString('change-email-setings')}</>}
+              theme="dark">
               <Localized id="email-input" attrs={{ label: true }}>
                 <LabeledInput value={user.userClients[0].email} disabled />
               </Localized>

--- a/web/src/components/pages/profile/info/info.tsx
+++ b/web/src/components/pages/profile/info/info.tsx
@@ -4,12 +4,10 @@ import {
   WithLocalizationProps,
 } from '@fluent/react';
 import * as React from 'react';
-import Downshift from 'downshift';
 import { useCallback, useEffect, useState } from 'react';
 import { Redirect, RouteComponentProps, withRouter } from 'react-router';
 import { Tooltip } from 'react-tippy';
 import { useAction, useAPI } from '../../../../hooks/store-hooks';
-import { NATIVE_NAMES } from '../../../../services/localization';
 import { trackProfile } from '../../../../services/tracker';
 import { AGES, GENDERS } from '../../../../stores/demographics';
 import { Notifications } from '../../../../stores/notifications';
@@ -19,7 +17,7 @@ import { User } from '../../../../stores/user';
 import URLS from '../../../../urls';
 import { LocaleLink, useLocale } from '../../../locale-helpers';
 import TermsModal from '../../../terms-modal';
-import { DownIcon, CloseIcon } from '../../../ui/icons';
+import { DownIcon } from '../../../ui/icons';
 import {
   Button,
   Hr,
@@ -28,16 +26,15 @@ import {
   LabeledSelect,
 } from '../../../ui/ui';
 import { isEnrolled } from '../../dashboard/challenge/constants';
-import { Accent, UserAccentLocale } from 'common';
+import { UserAccentLocale } from 'common';
+
+import ProfileInfoLanguages from './languages/languages';
 
 import './info.css';
 
 // TODO: remove pick
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const pick = require('lodash.pick');
-
-// Types for Downshift haven't caught up yet. Can be removed in the future
-const Input = LabeledInput as any;
 
 const Options = withLocalization(
   ({
@@ -58,15 +55,7 @@ const Options = withLocalization(
 
 type UserAccentLocales = UserAccentLocale[];
 
-type AccentsAll = {
-  [locale: string]: {
-    default: Accent;
-    userGenerated: { [id: string]: Accent };
-    preset: { [id: string]: Accent };
-  };
-};
-
-function ProfilePage({
+function ProfileInfo({
   getString,
   history,
 }: WithLocalizationProps & RouteComponentProps<any, any, any>) {
@@ -96,15 +85,11 @@ function ProfilePage({
   });
   const { username, visible, age, gender, sendEmails, privacyAgreed } =
     userFields;
-  const [userAccentLocales, setUserAccentLocales] = useState<UserAccentLocales>(
-    []
-  );
-  const [accentsAll, setAccentsAll] = useState<AccentsAll>({});
-  const [isInitialized, setIsInitialized] = useState(false);
+  const [areLanguagesLoading, setAreLanguagesLoading] = useState(true);
+  const [userLanguages, setUserLanguages] = useState<UserAccentLocales>([]);
   const [isSaving, setIsSaving] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [showDemographicInfo, setShowDemographicInfo] = useState(false);
-  const [showAccentInfo, setShowAccentInfo] = useState(false);
   const [termsStatus, setTermsStatus] = useState<null | 'show' | 'agreed'>(
     null
   );
@@ -112,14 +97,9 @@ function ProfilePage({
     user?.userClients[0]?.enrollment || isEnrolled(account);
 
   useEffect(() => {
-    if (user.isFetchingAccount || isInitialized) {
+    if (user.isFetchingAccount || areLanguagesLoading) {
       return;
     }
-
-    api.getAccents().then(accents => {
-      setAccentsAll(accents);
-      setIsInitialized(true);
-    });
 
     if (!account && userClients.length == 0) {
       history.push('/');
@@ -151,8 +131,8 @@ function ProfilePage({
       );
     }
 
-    setUserAccentLocales(account ? account.locales : userAccentLocales);
-  }, [user]);
+    setUserLanguages(account ? account.locales : userAccentLocales);
+  }, [user, areLanguagesLoading]);
 
   const handleChangeFor =
     (field: string) =>
@@ -162,63 +142,6 @@ function ProfilePage({
         [field]: target.type == 'checkbox' ? target.checked : target.value,
       });
     };
-
-  const getAutocompleteAccents = (locale: string) => {
-    return accentsAll[locale]
-      ? Object.entries({
-          ...accentsAll[locale].userGenerated,
-          ...accentsAll[locale].preset,
-        }).reduce((acc, [_, accent]) => {
-          return acc.concat(accent);
-        }, [])
-      : [];
-  };
-
-  const updateCustomAccent = (accent: any, locale: string, index: number) => {
-    const accentName = typeof accent === 'string' ? accent : accent.name;
-    const accentId = typeof accent === 'string' ? null : accent.id;
-
-    const newLocales = userAccentLocales.slice();
-
-    const accentExists =
-      newLocales[index].accents.filter(accentObj => {
-        return accentObj.name === accentName;
-      }).length > 0;
-
-    if (accentExists) return;
-
-    // if this is new custom accent, input value will be string
-    // otherwise it will be Accent
-    newLocales[index] = {
-      locale,
-      accents: (newLocales[index].accents || []).concat({
-        name: accentName,
-        id: accentId,
-      }),
-    };
-
-    setUserAccentLocales(newLocales);
-  };
-
-  const removeAccent = (languageIndex: number, accentIndex: number) => {
-    const newAccents = userAccentLocales.slice();
-    newAccents[languageIndex].accents.splice(accentIndex, 1);
-    setUserAccentLocales(newAccents);
-  };
-
-  function stateReducer(state: any, changes: any) {
-    // this clears out the Downshift input upon selecting an accent
-    switch (changes.type) {
-      case Downshift.stateChangeTypes.keyDownEnter:
-      case Downshift.stateChangeTypes.clickItem:
-        return {
-          ...changes,
-          inputValue: '',
-        };
-      default:
-        return changes;
-    }
-  }
 
   const submit = useCallback(() => {
     if (!user.account) {
@@ -236,7 +159,7 @@ function ProfilePage({
 
     const data = {
       ...pick(userFields, 'username', 'age', 'gender'),
-      locales: userAccentLocales.filter(l => l.locale),
+      locales: userLanguages.filter(l => l.locale),
       visible: JSON.parse(visible.toString()),
       client_id: user.userId,
       enrollment: user.userClients[0].enrollment || {
@@ -257,19 +180,7 @@ function ProfilePage({
         setIsSaving(false);
       },
     ]);
-  }, [
-    api,
-    getString,
-    locale,
-    userAccentLocales,
-    termsStatus,
-    user,
-    userFields,
-  ]);
-
-  if (!isInitialized) {
-    return null;
-  }
+  }, [api, getString, locale, userLanguages, termsStatus, user, userFields]);
 
   if (!isSaving && isSubmitted && isEnrolledInChallenge) {
     return (
@@ -287,16 +198,18 @@ function ProfilePage({
 
   return (
     <div className="profile-info">
-      {termsStatus == 'show' && (
+      <h1>Profile</h1>
+
+      {termsStatus === 'show' && (
         <TermsModal onAgree={submit} onDisagree={() => setTermsStatus(null)} />
       )}
+
       {!user.account && (
         <Localized id="thanks-for-account">
-          {/* Localized injects content into child tag */}
-          {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
-          <h2 />
+          <p />
         </Localized>
       )}
+
       <Localized id="why-profile-text">
         <p />
       </Localized>
@@ -317,10 +230,7 @@ function ProfilePage({
         </Localized>
       </div>
 
-      <div
-        className={`form-fields ${
-          userAccentLocales.length > 1 ? 'multilingual' : ''
-        }`}>
+      <div className="form-fields">
         <Localized id="profile-form-username" attrs={{ label: true }}>
           <LabeledInput
             value={username}
@@ -355,188 +265,14 @@ function ProfilePage({
             <Options>{GENDERS}</Options>
           </LabeledSelect>
         </Localized>
-
-        {userAccentLocales.map(({ locale, accents }, i) => (
-          <div className="accent-wrap" key={i}>
-            <Localized id="profile-form-language" attrs={{ label: true }}>
-              <LabeledSelect
-                value={locale}
-                onChange={({
-                  target: { value },
-                }: React.ChangeEvent<HTMLSelectElement>) => {
-                  const newLocales = userAccentLocales.slice();
-                  newLocales[i] = {
-                    locale: value,
-                    accents: accentsAll[value]
-                      ? [accentsAll[value]?.default]
-                      : [],
-                  };
-                  if (!value) {
-                    newLocales.splice(i, 1);
-                  }
-                  setUserAccentLocales(
-                    newLocales.filter(
-                      ({ locale }, i2) => i2 === i || locale !== value
-                    )
-                  );
-                }}>
-                <option value="" />
-                {Object.entries(NATIVE_NAMES).map(([locale, name]) => (
-                  <option key={locale} value={locale}>
-                    {name}
-                  </option>
-                ))}
-              </LabeledSelect>
-            </Localized>
-            <Localized id="profile-form-accent" attrs={{ label: true }} />
-            <Downshift
-              id="accent-selection"
-              onChange={selection => {
-                updateCustomAccent(selection, locale, i);
-              }}
-              stateReducer={stateReducer}
-              itemToString={item => (item ? item.name : '')}>
-              {({
-                getInputProps,
-                getItemProps,
-                openMenu,
-                getMenuProps,
-                isOpen,
-                inputValue,
-                highlightedIndex,
-                selectItem,
-              }) => {
-                const clean = (text: string) => {
-                  return text ? text.trim().toLowerCase() : '';
-                };
-
-                const options = getAutocompleteAccents(locale).filter(item =>
-                  clean(item.name).includes(clean(inputValue))
-                );
-
-                return (
-                  <div>
-                    <Localized
-                      id="profile-form-custom-accent-help-text"
-                      attrs={{ label: true }}>
-                      <Input
-                        disabled={locale.length === 0}
-                        {...getInputProps({
-                          onFocus: openMenu,
-                          type: 'text',
-                          value: inputValue || '',
-                          onKeyDown: (e: any) => {
-                            if (e.key === 'Enter') {
-                              selectItem(e.target.value, {
-                                type: Downshift.stateChangeTypes.keyDownEnter,
-                              });
-                            }
-                          },
-                        })}
-                        placeholder={getString(
-                          'profile-form-custom-accent-placeholder-2'
-                        )}
-                      />
-                    </Localized>
-
-                    {isOpen ? (
-                      <ul
-                        {...getMenuProps()}
-                        className={isOpen ? 'downshift-open' : ''}>
-                        {options.map((item, index) => (
-                          <li
-                            key={item.name}
-                            {...getItemProps({
-                              index,
-                              item,
-                              style: {
-                                backgroundColor:
-                                  highlightedIndex === index
-                                    ? 'var(--light-grey)'
-                                    : 'initial',
-                              },
-                            })}>
-                            {item.name}
-                          </li>
-                        ))}
-                        {inputValue?.length > 0 && options.length == 0 && (
-                          <li
-                            {...getItemProps({ item: inputValue })}
-                            className="add-new-accent">
-                            <Localized
-                              id="profile-form-add-accent"
-                              vars={{ inputValue }}
-                            />
-                          </li>
-                        )}
-                      </ul>
-                    ) : null}
-                  </div>
-                );
-              }}
-            </Downshift>
-            {locale && locale.length > 0 ? (
-              <>
-                {accents.map((accent, idx) => {
-                  return (
-                    accent.name?.length > 0 && (
-                      <span key={`accent-${idx}`} className="selected-accent">
-                        <CloseIcon black onClick={() => removeAccent(i, idx)} />
-                        {accent.name}
-                      </span>
-                    )
-                  );
-                })}
-              </>
-            ) : null}
-          </div>
-        ))}
       </div>
 
-      <div className="add-language-section">
-        {userAccentLocales.length > 0 ? (
-          <div
-            className={'profile-toggle ' + (showAccentInfo ? 'expanded' : '')}>
-            <button
-              type="button"
-              onClick={() => setShowAccentInfo(!showAccentInfo)}>
-              <Localized id="help-accent">
-                <span />
-              </Localized>
+      <ProfileInfoLanguages
+        userLanguages={userLanguages}
+        setUserLanguages={setUserLanguages}
+        setAreLanguagesLoading={setAreLanguagesLoading}
+      />
 
-              <DownIcon />
-            </button>
-            <Localized id="help-accent-explanation">
-              <div className="explanation" />
-            </Localized>
-          </div>
-        ) : null}
-
-        <Button
-          className="add-language"
-          outline
-          onClick={() => {
-            if (
-              userAccentLocales.length &&
-              !userAccentLocales[userAccentLocales.length - 1].locale
-            ) {
-              return;
-            }
-            setUserAccentLocales(
-              userAccentLocales.concat({ locale: '', accents: [] })
-            );
-          }}>
-          <Localized id="add-language">
-            <span />
-          </Localized>
-          <span>+</span>
-        </Button>
-        {userAccentLocales.length == 0 ? (
-          <Localized id="profile-select-language">
-            <span className="no-languages" />
-          </Localized>
-        ) : null}
-      </div>
       <Hr />
 
       {!user.account?.basket_token && (
@@ -605,7 +341,7 @@ function ProfilePage({
         <Button
           className="save"
           rounded
-          disabled={isSaving || !privacyAgreed}
+          disabled={isSaving || !privacyAgreed || areLanguagesLoading}
           onClick={submit}
         />
       </Localized>
@@ -613,4 +349,4 @@ function ProfilePage({
   );
 }
 
-export default withLocalization(withRouter(ProfilePage));
+export default withLocalization(withRouter(ProfileInfo));

--- a/web/src/components/pages/profile/info/languages/input-language-accents/input-language-accents-input.test.tsx
+++ b/web/src/components/pages/profile/info/languages/input-language-accents/input-language-accents-input.test.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { RenderResult } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { renderWithLocalization } from '../../../../../../test/mock-localization';
+import { AccentsAll } from '../languages';
+import { UserAccentLocale } from 'common';
+
+import InputLanguageAccentsInput from './input-language-accents-input';
+
+expect.extend(toHaveNoViolations);
+
+const MOCK_USER_LANGUAGES = [
+  {
+    locale: 'en',
+    accents: [],
+  },
+] as UserAccentLocale[];
+
+const MOCK_ACCENTS_ALL = {
+  en: {
+    userGenerated: {},
+    preset: {
+      '1': {
+        id: 1,
+        token: 'england',
+        name: 'England English',
+      },
+      '2': {
+        id: 2,
+        token: 'singapore',
+        name: 'Singaporean English',
+      },
+      '3': {
+        id: 3,
+        token: 'filipino',
+        name: 'Filipino',
+      },
+    },
+    default: {
+      id: 18,
+      token: 'unspecified',
+      name: '',
+    },
+  },
+  'zh-TW': {
+    userGenerated: {},
+    preset: {},
+    default: {
+      id: 176,
+      token: 'unspecified',
+      name: '',
+    },
+  },
+} as AccentsAll;
+
+describe('InputLanguageAccentsInput', () => {
+  // TODO: while this tests this is todo as there's accessibility work to fix this component
+  it.skip('should render with no accessibility violations', async () => {
+    const renderResult: RenderResult = await renderWithLocalization(
+      <InputLanguageAccentsInput
+        locale={'en'}
+        accentsAll={MOCK_ACCENTS_ALL}
+        userLanguages={MOCK_USER_LANGUAGES}
+        setUserLanguages={() => null}
+      />
+    );
+    const results = await axe(renderResult.container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('should be able to search and add a accent', async () => {
+    const mockSetUserLanguage = jest.fn();
+
+    const { getByLabelText, getByRole, getByTestId } =
+      await renderWithLocalization(
+        <InputLanguageAccentsInput
+          locale={'en'}
+          accentsAll={MOCK_ACCENTS_ALL}
+          userLanguages={MOCK_USER_LANGUAGES}
+          setUserLanguages={mockSetUserLanguage}
+        />
+      );
+
+    const input = getByLabelText('How would you describe your accent?');
+    userEvent.type(input, 'Filip'); // type some of the text
+
+    // TODO: this should not be found via test ID, it should be via a label
+    const list = getByTestId('input-language-accents-input-list');
+    userEvent.selectOptions(list, getByRole('option', { name: 'Filipino' }));
+
+    expect(mockSetUserLanguage).toHaveBeenCalledWith([
+      { accents: [{ id: 3, name: 'Filipino' }], locale: 'en' },
+    ]);
+    expect(mockSetUserLanguage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/components/pages/profile/info/languages/input-language-accents/input-language-accents-input.tsx
+++ b/web/src/components/pages/profile/info/languages/input-language-accents/input-language-accents-input.tsx
@@ -1,0 +1,191 @@
+import * as React from 'react';
+import {
+  Localized,
+  withLocalization,
+  WithLocalizationProps,
+} from '@fluent/react';
+import Downshift from 'downshift';
+
+import { LabeledInput } from '../../../../../ui/ui';
+import { AccentsAll } from '../languages';
+import { UserAccentLocale } from 'common';
+
+import './input-language-accents.css';
+
+// TODO: Types for Downshift haven't caught up yet. Can be removed in the future
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const Input = LabeledInput as any;
+
+const clean = (text: string) => {
+  return text ? text.trim().toLowerCase() : '';
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function stateReducer(state: any, changes: any) {
+  // this clears out the Downshift input upon selecting an accent
+  switch (changes.type) {
+    case Downshift.stateChangeTypes.keyDownEnter:
+    case Downshift.stateChangeTypes.clickItem:
+      return {
+        ...changes,
+        inputValue: '',
+      };
+    default:
+      return changes;
+  }
+}
+
+interface Props {
+  locale: string;
+  accentsAll: AccentsAll;
+  userLanguages: UserAccentLocale[];
+  setUserLanguages: (userLanguages: UserAccentLocale[]) => void;
+}
+
+const InputLanguageAccentsInput = ({
+  locale,
+  accentsAll,
+  userLanguages,
+  setUserLanguages,
+  getString,
+}: Props & WithLocalizationProps) => {
+  const getAutocompleteAccents = (locale: string) => {
+    if (!accentsAll[locale]) {
+      return [];
+    }
+
+    return Object.values({
+      ...accentsAll[locale].userGenerated,
+      ...accentsAll[locale].preset,
+    });
+  };
+
+  const updateCustomAccent = (
+    accent: { id: number; name: string } | string,
+    locale: string
+  ) => {
+    const accentName = typeof accent === 'string' ? accent : accent.name;
+    const accentId = typeof accent === 'string' ? null : accent.id;
+
+    const newLanguages = userLanguages.slice();
+    const languageIndex = newLanguages.findIndex(language => {
+      return language.locale === locale;
+    });
+
+    const accentExists = newLanguages[languageIndex].accents.some(accentObj => {
+      return accentObj.name === accentName;
+    });
+
+    if (accentExists) {
+      return;
+    }
+
+    // if this is new custom accent, input value will be string
+    // otherwise it will be Accent
+    newLanguages[languageIndex] = {
+      locale,
+      accents: (newLanguages[languageIndex].accents || []).concat({
+        name: accentName,
+        id: accentId,
+      }),
+    };
+
+    setUserLanguages(newLanguages);
+  };
+
+  return (
+    <>
+      <Downshift
+        onChange={selection => {
+          updateCustomAccent(selection, locale);
+        }}
+        stateReducer={stateReducer}
+        itemToString={item => (item ? item.name : '')}>
+        {({
+          getInputProps,
+          getItemProps,
+          openMenu,
+          getMenuProps,
+          isOpen,
+          inputValue,
+          highlightedIndex,
+          selectItem,
+        }) => {
+          const options = getAutocompleteAccents(locale).filter(item =>
+            clean(item.name).includes(clean(inputValue))
+          );
+
+          const handleKeyDown = (
+            event: React.KeyboardEvent<HTMLInputElement>
+          ) => {
+            if (event.key === 'Enter') {
+              const { value } = event.target as HTMLInputElement;
+              selectItem(value, {
+                type: Downshift.stateChangeTypes.keyDownEnter,
+              });
+            }
+          };
+
+          return (
+            <div>
+              <Localized
+                id="profile-form-custom-accent-help-text"
+                attrs={{ label: true }}>
+                <Input
+                  disabled={locale.length === 0}
+                  {...getInputProps({
+                    onFocus: openMenu,
+                    type: 'text',
+                    value: inputValue || '',
+                    onKeyDown: handleKeyDown,
+                    'aria-labelledby': null,
+                  })}
+                  id=""
+                  placeholder={getString(
+                    'profile-form-custom-accent-placeholder-2'
+                  )}
+                />
+              </Localized>
+
+              {isOpen ? (
+                <ul
+                  {...getMenuProps()}
+                  data-testid="input-language-accents-input-list"
+                  className={isOpen ? 'downshift-open' : ''}>
+                  {options.map((item, index) => (
+                    <li
+                      key={item.name}
+                      {...getItemProps({
+                        index,
+                        item,
+                        style: {
+                          backgroundColor:
+                            highlightedIndex === index
+                              ? 'var(--light-grey)'
+                              : 'initial',
+                        },
+                      })}>
+                      {item.name}
+                    </li>
+                  ))}
+                  {inputValue?.length > 0 && options.length == 0 && (
+                    <li
+                      {...getItemProps({ item: inputValue })}
+                      className="add-new-accent">
+                      <Localized
+                        id="profile-form-add-accent"
+                        vars={{ inputValue }}
+                      />
+                    </li>
+                  )}
+                </ul>
+              ) : null}
+            </div>
+          );
+        }}
+      </Downshift>
+    </>
+  );
+};
+
+export default withLocalization(InputLanguageAccentsInput);

--- a/web/src/components/pages/profile/info/languages/input-language-accents/input-language-accents-list.test.tsx
+++ b/web/src/components/pages/profile/info/languages/input-language-accents/input-language-accents-list.test.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { fireEvent, RenderResult } from '@testing-library/react';
+
+import { renderWithLocalization } from '../../../../../../test/mock-localization';
+
+import InputLanguageAccentsList from './input-language-accents-list';
+import { UserAccentLocale } from 'common';
+
+expect.extend(toHaveNoViolations);
+
+const MOCK_ACCENTS = [
+  {
+    id: 1,
+    token: 'england',
+    name: 'England English',
+  },
+  {
+    id: 13,
+    token: 'singapore',
+    name: 'Singaporean English',
+  },
+];
+
+const MOCK_USER_LANGUAGES = [] as UserAccentLocale[];
+
+describe('InputLanguageAccentsList', () => {
+  it('should render with no accessibility violations', async () => {
+    const renderResult: RenderResult = await renderWithLocalization(
+      <InputLanguageAccentsList
+        locale={'en'}
+        accents={MOCK_ACCENTS}
+        userLanguages={MOCK_USER_LANGUAGES}
+        setUserLanguages={() => null}
+      />
+    );
+    const results = await axe(renderResult.container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('renders accents in a list', async () => {
+    const mockUserLanguages = [
+      {
+        locale: 'en',
+        accents: [{ name: 'England English' }, { name: 'Singaporean English' }],
+      },
+    ] as UserAccentLocale[];
+    const { getByText } = await renderWithLocalization(
+      <InputLanguageAccentsList
+        locale={'en'}
+        accents={MOCK_ACCENTS}
+        userLanguages={mockUserLanguages}
+        setUserLanguages={() => null}
+      />
+    );
+
+    expect(getByText('England English')).toBeTruthy();
+    expect(getByText('Singaporean English')).toBeTruthy();
+  });
+
+  it('should remove an accent', async () => {
+    const mockUserLanguages = [
+      {
+        locale: 'en',
+        accents: [{ name: 'England English' }, { name: 'Singaporean English' }],
+      },
+    ] as UserAccentLocale[];
+    const mockSetUserLanguage = jest.fn();
+    const { getByText } = await renderWithLocalization(
+      <InputLanguageAccentsList
+        locale={'en'}
+        accents={MOCK_ACCENTS}
+        userLanguages={mockUserLanguages}
+        setUserLanguages={mockSetUserLanguage}
+      />
+    );
+
+    fireEvent.click(getByText(/Remove England English accent/));
+
+    expect(mockSetUserLanguage).toBeCalledWith([
+      { accents: [{ name: 'Singaporean English' }], locale: 'en' },
+    ]);
+    expect(mockSetUserLanguage).toBeCalledTimes(1);
+  });
+});

--- a/web/src/components/pages/profile/info/languages/input-language-accents/input-language-accents-list.tsx
+++ b/web/src/components/pages/profile/info/languages/input-language-accents/input-language-accents-list.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+
+import { UserAccentLocale } from 'common';
+import { CloseIcon } from '../../../../../ui/icons';
+import VisuallyHidden from '../../../../../visually-hidden/visually-hidden';
+
+interface Props {
+  locale?: string;
+  accents: Array<{ id: number; name: string }>;
+  userLanguages: UserAccentLocale[];
+  setUserLanguages: (userLanguages: UserAccentLocale[]) => void;
+}
+
+const InputLanguageAccents = ({
+  locale,
+  accents,
+  setUserLanguages,
+  userLanguages,
+}: Props) => {
+  if (!locale || locale.length === 0) {
+    return null;
+  }
+
+  const removeAccent = (locale: string, accentIndex: number) => {
+    const newLanguages = userLanguages.slice();
+    const languageIndex = newLanguages.findIndex(language => {
+      return language.locale === locale;
+    });
+    newLanguages[languageIndex].accents.splice(accentIndex, 1);
+    setUserLanguages(newLanguages);
+  };
+
+  return (
+    <>
+      {accents.map((accent, index) => {
+        if (accent.name?.length === 0) {
+          return null;
+        }
+
+        return (
+          <span key={`accent-${index}`} className="selected-accent">
+            <button
+              className="selected-accent--button"
+              onClick={() => removeAccent(locale, index)}>
+              <VisuallyHidden>Remove {accent.name} accent</VisuallyHidden>
+              <CloseIcon black />
+            </button>
+            {accent.name}
+          </span>
+        );
+      })}
+    </>
+  );
+};
+
+export default InputLanguageAccents;

--- a/web/src/components/pages/profile/info/languages/input-language-accents/input-language-accents.css
+++ b/web/src/components/pages/profile/info/languages/input-language-accents/input-language-accents.css
@@ -1,0 +1,29 @@
+.selected-accent {
+    display: inline-block;
+    padding-right: 1.5rem;
+    margin-bottom: 1.5rem;
+    margin-inline-end: 1rem;
+    background: var(--light-grey);
+    border-radius: 15rem;
+}
+
+.selected-accent--button {
+    border: none;
+    padding: 0.8rem 1.5rem;
+    padding-inline-end: 1rem;
+}
+
+#accent-selection-menu {
+    max-height: 200px;
+    overflow-y: scroll;
+
+    .add-new-accent {
+        color: var(--blue);
+        font-weight: 600;
+
+        &:focus,
+        &:hover {
+            background: var(--light-grey);
+        }
+    }
+}

--- a/web/src/components/pages/profile/info/languages/input-language-accents/input-language-accents.tsx
+++ b/web/src/components/pages/profile/info/languages/input-language-accents/input-language-accents.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+
+import { UserAccentLocale } from 'common';
+import { AccentsAll } from '../languages';
+
+import InputLanguageAccentsInput from './input-language-accents-input';
+import InputLanguageAccentsList from './input-language-accents-list';
+
+interface Props {
+  locale: string;
+  accents: Array<{ id: number; name: string }>;
+  accentsAll: AccentsAll;
+  userLanguages: UserAccentLocale[];
+  setUserLanguages: (userLanguages: UserAccentLocale[]) => void;
+}
+
+function InputLanguageAccents({
+  locale,
+  accents,
+  accentsAll,
+  userLanguages,
+  setUserLanguages,
+}: Props) {
+  return (
+    <>
+      <InputLanguageAccentsInput
+        locale={locale}
+        accentsAll={accentsAll}
+        userLanguages={userLanguages}
+        setUserLanguages={setUserLanguages}
+      />
+
+      <InputLanguageAccentsList
+        locale={locale}
+        accents={accents}
+        userLanguages={userLanguages}
+        setUserLanguages={setUserLanguages}
+      />
+    </>
+  );
+}
+
+export default InputLanguageAccents;

--- a/web/src/components/pages/profile/info/languages/input-language-name.test.tsx
+++ b/web/src/components/pages/profile/info/languages/input-language-name.test.tsx
@@ -1,0 +1,173 @@
+import * as React from 'react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { screen, RenderResult } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { renderWithLocalization } from '../../../../../test/mock-localization';
+import { UserAccentLocale } from 'common';
+import { AccentsAll } from './languages';
+
+import InputLanguageName from './input-language-name';
+
+expect.extend(toHaveNoViolations);
+
+const MOCK_ACCENTS_ALL = {
+  en: {
+    userGenerated: {},
+    preset: {
+      '13': {
+        id: 13,
+        token: 'singapore',
+        name: 'Singaporean English',
+      },
+    },
+    default: {
+      id: 18,
+      token: 'unspecified',
+      name: '',
+    },
+  },
+  'zh-TW': {
+    userGenerated: {},
+    preset: {},
+    default: {
+      id: 176,
+      token: 'unspecified',
+      name: '',
+    },
+  },
+} as AccentsAll;
+
+describe('InputLanguageName', () => {
+  let mockUserLanguages = [] as UserAccentLocale[];
+  let mockSetUserLanguage = null as (languages: UserAccentLocale[]) => void;
+
+  beforeEach(() => {
+    mockUserLanguages = [{ locale: '', accents: [] }];
+    mockSetUserLanguage = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render with no accessibility violations', async () => {
+    const renderResult: RenderResult = await renderWithLocalization(
+      <InputLanguageName
+        locale={''}
+        accentsAll={MOCK_ACCENTS_ALL}
+        userLanguages={mockUserLanguages}
+        setUserLanguages={mockSetUserLanguage}
+      />
+    );
+    const results = await axe(renderResult.container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('updates the language list when selecting an option', async () => {
+    await renderWithLocalization(
+      <InputLanguageName
+        locale={''}
+        accentsAll={MOCK_ACCENTS_ALL}
+        userLanguages={mockUserLanguages}
+        setUserLanguages={mockSetUserLanguage}
+      />
+    );
+
+    // pick an option in the select box
+    userEvent.selectOptions(
+      screen.getByLabelText('Language'),
+      screen.getByRole('option', { name: '華語（台灣）' })
+    );
+
+    const expectedLanguage = {
+      locale: 'zh-TW',
+      accents: [
+        {
+          id: 176,
+          token: 'unspecified',
+          name: '',
+        },
+      ],
+    } as UserAccentLocale;
+    expect(mockSetUserLanguage).toBeCalledWith([expectedLanguage]);
+    expect(mockSetUserLanguage).toBeCalledTimes(1);
+  });
+
+  it('should handle missing accents', async () => {
+    await renderWithLocalization(
+      <InputLanguageName
+        locale={''}
+        accentsAll={MOCK_ACCENTS_ALL}
+        userLanguages={mockUserLanguages}
+        setUserLanguages={mockSetUserLanguage}
+      />
+    );
+
+    // pick an option in the select box
+    userEvent.selectOptions(
+      screen.getByLabelText('Language'),
+      screen.getByRole('option', { name: 'Tagalog' })
+    );
+
+    const expectedUserLanguage = {
+      locale: 'tl',
+      accents: [],
+    } as UserAccentLocale;
+    expect(mockSetUserLanguage).toBeCalledWith([expectedUserLanguage]);
+  });
+
+  it('should remove item if selecting empty option', async () => {
+    const filledMockUserLanguages = [
+      { locale: 'tl', accents: [] },
+      { locale: 'en', accents: [] },
+      { locale: 'fr', accents: [] },
+    ] as UserAccentLocale[];
+    await renderWithLocalization(
+      <InputLanguageName
+        locale={'en'}
+        accentsAll={MOCK_ACCENTS_ALL}
+        userLanguages={filledMockUserLanguages}
+        setUserLanguages={mockSetUserLanguage}
+      />
+    );
+
+    // pick empty option
+    userEvent.selectOptions(
+      screen.getByLabelText('Language'),
+      screen.getByRole('option', { name: '' })
+    );
+
+    const expectedLanguages = [
+      { locale: 'tl', accents: [] },
+      { locale: 'fr', accents: [] },
+    ] as UserAccentLocale[];
+    expect(mockSetUserLanguage).toBeCalledWith(expectedLanguages);
+  });
+
+  it('should remove duplicates if selecting same language', async () => {
+    const filledMockLanguages = [
+      { locale: 'fr', accents: [] },
+      { locale: 'en', accents: [] },
+    ] as UserAccentLocale[];
+    await renderWithLocalization(
+      <InputLanguageName
+        locale={'en'}
+        accentsAll={MOCK_ACCENTS_ALL}
+        userLanguages={filledMockLanguages}
+        setUserLanguages={mockSetUserLanguage}
+      />
+    );
+
+    // pick empty option
+    userEvent.selectOptions(
+      screen.getByLabelText('Language'),
+      screen.getByRole('option', { name: 'Français' })
+    );
+
+    const expectedLanguages = [
+      { locale: 'fr', accents: [] },
+    ] as UserAccentLocale[];
+    expect(mockSetUserLanguage).toBeCalledWith(expectedLanguages);
+  });
+});

--- a/web/src/components/pages/profile/info/languages/input-language-name.tsx
+++ b/web/src/components/pages/profile/info/languages/input-language-name.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import { Localized } from '@fluent/react';
+
+import { LabeledSelect } from '../../../../ui/ui';
+import { NATIVE_NAMES } from '../../../../../services/localization';
+import { UserAccentLocale } from 'common';
+import { AccentsAll } from './languages';
+
+interface InputLanguageNameProps {
+  locale: string;
+  accentsAll: AccentsAll;
+  userLanguages: UserAccentLocale[];
+  setUserLanguages: (userLanguages: UserAccentLocale[]) => void;
+}
+
+const InputLanguageName = ({
+  locale,
+  accentsAll,
+  userLanguages,
+  setUserLanguages,
+}: InputLanguageNameProps) => {
+  const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const { value } = event.target;
+
+    const newLanguages = userLanguages.slice();
+    const languageIndex = newLanguages.findIndex(language => {
+      return language.locale === locale;
+    });
+
+    newLanguages[languageIndex] = {
+      locale: value,
+      accents: accentsAll[value] ? [accentsAll[value]?.default] : [],
+    };
+
+    if (!value) {
+      newLanguages.splice(languageIndex, 1);
+    }
+
+    const uniqueNewLanguages = newLanguages.filter(({ locale }, index) => {
+      const isCurrentLanguage = index === languageIndex;
+      const anyOtherLanguage = locale !== value;
+      return isCurrentLanguage || anyOtherLanguage;
+    });
+
+    setUserLanguages(uniqueNewLanguages);
+  };
+
+  return (
+    <Localized id="profile-form-language" attrs={{ label: true }}>
+      <LabeledSelect value={locale} onChange={handleChange}>
+        <option value="" />
+        {Object.entries(NATIVE_NAMES).map(([locale, name]) => (
+          <option key={locale} value={locale}>
+            {name}
+          </option>
+        ))}
+      </LabeledSelect>
+    </Localized>
+  );
+};
+
+export default InputLanguageName;

--- a/web/src/components/pages/profile/info/languages/languages.css
+++ b/web/src/components/pages/profile/info/languages/languages.css
@@ -1,0 +1,58 @@
+.add-language {
+    display: inline-block;
+    justify-content: center;
+    direction: ltr;
+    margin-inline-end: 1rem;
+
+    & :first-child {
+        margin-right: 25px;
+    }
+
+    & :nth-child(2) {
+        font-family: initial;
+        font-size: var(--font-size-lg);
+        color: var(--black);
+    }
+}
+
+.profile-info .form-fields .language-wrap {
+    border: 2px solid rgba(230, 229, 227, 0.6);
+    border-radius: 5px;
+    padding: 1rem;
+    margin-bottom: 2rem;
+    display: block;
+    width: 100%;
+    position: relative;
+    padding-bottom: 0.5rem;
+
+    label {
+        width: 100%;
+    }
+
+    > label:last-child {
+        margin-bottom: 15px;
+    }
+
+    ul {
+        margin: -30px 0 30px;
+        position: absolute;
+        padding: 0;
+        background: white;
+        z-index: var(--override-z-index);
+        width: 100%;
+
+        li {
+            cursor: pointer;
+            list-style: none;
+            padding: 15px;
+            border-bottom: 1px solid var(--dark-grey);
+        }
+    }
+
+    .downshift-open {
+        border: 1px solid var(--light-grey);
+        box-sizing: border-box;
+        box-shadow: 0 2px 5px 0 var(--light-grey);
+        overflow: hidden;
+    }
+}

--- a/web/src/components/pages/profile/info/languages/languages.test.tsx
+++ b/web/src/components/pages/profile/info/languages/languages.test.tsx
@@ -1,0 +1,119 @@
+import * as React from 'react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { act, waitFor, fireEvent, RenderResult } from '@testing-library/react';
+
+import { renderWithLocalization } from '../../../../../test/mock-localization';
+import { UserAccentLocale } from 'common';
+
+import ProfileInfoLanguages, { AccentsAll } from './languages';
+
+expect.extend(toHaveNoViolations);
+
+const MOCK_USER_LANGUAGES = [
+  {
+    locale: 'en',
+    accents: [],
+  },
+] as UserAccentLocale[];
+
+const MOCK_ACCENTS_ALL = {
+  en: {
+    userGenerated: {},
+    preset: {
+      '1': {
+        id: 1,
+        token: 'england',
+        name: 'England English',
+      },
+      '2': {
+        id: 2,
+        token: 'singapore',
+        name: 'Singaporean English',
+      },
+      '3': {
+        id: 3,
+        token: 'filipino',
+        name: 'Filipino',
+      },
+    },
+    default: {
+      id: 18,
+      token: 'unspecified',
+      name: '',
+    },
+  },
+  'zh-TW': {
+    userGenerated: {},
+    preset: {},
+    default: {
+      id: 176,
+      token: 'unspecified',
+      name: '',
+    },
+  },
+} as AccentsAll;
+
+// mock components
+jest.mock('./input-language-name', () => ({
+  default: () => {
+    return <div></div>;
+  },
+}));
+jest.mock('./input-language-accents/input-language-accents', () => ({
+  default: () => {
+    return <div></div>;
+  },
+}));
+
+// mock api
+const mockGetAccents = jest.fn(() => Promise.resolve(MOCK_ACCENTS_ALL));
+jest.mock('../../../../../hooks/store-hooks', () => ({
+  useAPI: () => {
+    return {
+      getAccents: mockGetAccents,
+    };
+  },
+}));
+
+describe('ProfileInfoLanguages', () => {
+  it('should render with no accessibility violations', async () => {
+    await act(async () => {
+      const renderResult: RenderResult = await renderWithLocalization(
+        <ProfileInfoLanguages
+          userLanguages={MOCK_USER_LANGUAGES}
+          setUserLanguages={() => null}
+          setAreLanguagesLoading={() => null}
+        />
+      );
+      const results = await axe(renderResult.container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  it('add a new language when lcikcin add new', async () => {
+    await act(async () => {
+      const mockSetLanguage = jest.fn();
+      const { getByText, getByRole }: RenderResult =
+        await renderWithLocalization(
+          <ProfileInfoLanguages
+            userLanguages={MOCK_USER_LANGUAGES}
+            setUserLanguages={mockSetLanguage}
+            setAreLanguagesLoading={() => null}
+          />
+        );
+
+      await waitFor(() => {
+        const languagesHeading = getByText('Languages');
+        return expect(languagesHeading).toBeTruthy();
+      });
+
+      fireEvent.click(getByRole('button', { name: 'Add Language' }));
+
+      expect(mockSetLanguage).toBeCalledWith([
+        ...MOCK_USER_LANGUAGES,
+        { locale: '', accents: [] },
+      ]);
+      expect(mockSetLanguage).toBeCalledTimes(1);
+    });
+  });
+});

--- a/web/src/components/pages/profile/info/languages/languages.tsx
+++ b/web/src/components/pages/profile/info/languages/languages.tsx
@@ -1,0 +1,131 @@
+import * as React from 'react';
+import { useState } from 'react';
+import { Localized } from '@fluent/react';
+
+import { useAPI } from '../../../../../hooks/store-hooks';
+import { DownIcon } from '../../../../ui/icons';
+import { Button } from '../../../../ui/ui';
+import { Accent, UserAccentLocale } from 'common';
+import { useEffect } from 'react';
+
+import InputLanguageName from './input-language-name';
+import InputLanguageAccents from './input-language-accents/input-language-accents';
+
+import './languages.css';
+
+export type AccentsAll = {
+  [locale: string]: {
+    default: Accent;
+    userGenerated: { [id: string]: Accent };
+    preset: { [id: string]: Accent };
+  };
+};
+
+interface Props {
+  userLanguages: UserAccentLocale[];
+  setUserLanguages: (userLanguages: UserAccentLocale[]) => void;
+  setAreLanguagesLoading: (value: boolean) => void;
+}
+
+function ProfileInfoLanguages({
+  userLanguages,
+  setUserLanguages,
+  setAreLanguagesLoading,
+}: Props) {
+  const api = useAPI();
+  const [accentsAll, setAccentsAll] = useState<AccentsAll>({});
+  const [showAccentInfo, setShowAccentInfo] = useState(false);
+  const [hasAccentDataLoaded, setHasAccentDataLoaded] = useState(false);
+  const hasUserLanguages = userLanguages.length > 0;
+  const hasNewEmptyLanguage =
+    hasUserLanguages && !userLanguages[userLanguages.length - 1].locale;
+
+  const handleAddNewLanguageButtonClick = () => {
+    if (hasNewEmptyLanguage) {
+      return;
+    }
+    setUserLanguages(userLanguages.concat({ locale: '', accents: [] }));
+  };
+
+  useEffect(() => {
+    if (hasAccentDataLoaded) {
+      return;
+    }
+
+    api.getAccents().then(accents => {
+      setAccentsAll(accents);
+      setHasAccentDataLoaded(true);
+      setAreLanguagesLoading(false);
+    });
+  }, []);
+
+  if (!hasAccentDataLoaded) {
+    return null;
+  }
+
+  return (
+    <>
+      <h2>Languages</h2>
+
+      <div className="form-fields">
+        {userLanguages.map(({ locale, accents }) => (
+          <div className="language-wrap" key={locale}>
+            <InputLanguageName
+              locale={locale}
+              accentsAll={accentsAll}
+              userLanguages={userLanguages}
+              setUserLanguages={setUserLanguages}
+            />
+
+            <InputLanguageAccents
+              locale={locale}
+              accents={accents}
+              accentsAll={accentsAll}
+              userLanguages={userLanguages}
+              setUserLanguages={setUserLanguages}
+            />
+          </div>
+        ))}
+      </div>
+
+      <div>
+        {hasUserLanguages && (
+          <div
+            className={'profile-toggle ' + (showAccentInfo ? 'expanded' : '')}>
+            <button
+              type="button"
+              onClick={() => setShowAccentInfo(!showAccentInfo)}>
+              <Localized id="help-accent">
+                <span />
+              </Localized>
+
+              <DownIcon />
+            </button>
+            <Localized id="help-accent-explanation">
+              <div className="explanation" />
+            </Localized>
+          </div>
+        )}
+
+        <Button
+          className="add-language"
+          outline
+          disabled={hasNewEmptyLanguage}
+          onClick={handleAddNewLanguageButtonClick}>
+          <Localized id="add-language">
+            <span />
+          </Localized>
+          <span aria-hidden={true}>+</span>
+        </Button>
+
+        {!hasUserLanguages && (
+          <Localized id="profile-select-language">
+            <span className="no-languages" />
+          </Localized>
+        )}
+      </div>
+    </>
+  );
+}
+
+export default ProfileInfoLanguages;

--- a/web/src/components/ui/icons.tsx
+++ b/web/src/components/ui/icons.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 
-const Icon = (path: string, title = '') => ({ children, ...props }: any) => (
-  <img src={path} title={title} {...props} />
-);
+const Icon =
+  (path: string, title = '') =>
+  ({ children, ...props }: any) =>
+    <img src={path} title={title} {...props} />;
 
 let idCounter = 0;
 function uniqueIcon(component: (id: number, props: any) => React.ReactNode) {
@@ -346,7 +347,7 @@ export const HeartIcon = () => (
 
 export const CloseIcon = ({ black, ...props }: any) => {
   const RealIcon = Icon(require(`./icons/close${black ? '-black' : ''}.svg`));
-  return <RealIcon {...props} />;
+  return <RealIcon alt="" {...props} />;
 };
 
 export const CloudIcon = uniqueIcon(id => (


### PR DESCRIPTION
- `setUserAccentLocales` to `setUserLanguages`
  Soon this will be including variants and 'Language' seems to be better than `UserAccentVariantLocale`?
- Various linting
- Move language UI components into separated files
- Added tests for core functionality