### PR TITLE
fix(stats): moving between languages stored filters

### DIFF
--- a/web/src/components/pages/dashboard/stats/stats-card.tsx
+++ b/web/src/components/pages/dashboard/stats/stats-card.tsx
@@ -31,13 +31,16 @@ export default function StatsCard({
   scrollable?: boolean;
   currentLocale?: string;
 }) {
-  const [locale, setLocale] = useLocalStorageState(DEFAULT_LOCALE_OPTION, id);
+  const [locale, setLocale] = useLocalStorageState(
+    DEFAULT_LOCALE_OPTION,
+    `${id}${currentLocale}`
+  );
   const [selectedTab, setSelectedTab] = useState(Object.keys(tabs)[0]);
   const isDefaultOptionSelected = locale === DEFAULT_LOCALE_OPTION;
 
-  // handle site wide locale change
+  // handle when changing language tab towards top of page
   useEffect(() => {
-    if (isDefaultOptionSelected && currentLocale) {
+    if (currentLocale) {
       setLocale(currentLocale);
     }
   }, [currentLocale]);


### PR DESCRIPTION
I noticed when moving between the languages on the stats page we would incorrectly store the stats filters.

![image](https://user-images.githubusercontent.com/93216813/153222893-f75b7aa4-eacf-4b1b-a941-9952df93b891.png)

This PR fixes this issue.