### PR TITLE
fix(profile): don't allow empty accents values

### DIFF
--- a/web/src/components/pages/profile/info/languages/input-language-accents/input-language-accents-input.test.tsx
+++ b/web/src/components/pages/profile/info/languages/input-language-accents/input-language-accents-input.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { axe, toHaveNoViolations } from 'jest-axe';
-import { RenderResult } from '@testing-library/react';
+import { fireEvent, RenderResult } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { renderWithLocalization } from '../../../../../../test/mock-localization';
@@ -49,5 +49,54 @@ describe('InputLanguageAccentsInput', () => {
       { accents: [{ id: 3, name: 'Filipino' }], locale: 'en' },
     ]);
     expect(mockSetUserLanguage).toHaveBeenCalledTimes(1);
+  });
+
+  it('should let you add a custom accent', async () => {
+    const mockSetUserLanguage = jest.fn();
+
+    const { getByLabelText, getByRole, getByTestId } =
+      await renderWithLocalization(
+        <InputLanguageAccentsInput
+          locale={'en'}
+          accentsAll={MOCK_ACCENTS_ALL}
+          userLanguages={MOCK_USER_LANGUAGES}
+          setUserLanguages={mockSetUserLanguage}
+        />
+      );
+
+    const input = getByLabelText('How would you describe your accent?');
+    userEvent.type(input, 'Brummy'); // type some of the text
+
+    // TODO: this should not be found via test ID, it should be via a label
+    const list = getByTestId('input-language-accents-input-list');
+    userEvent.selectOptions(
+      list,
+      getByRole('option', { name: 'Add new custom accent "Brummy"' })
+    );
+
+    expect(mockSetUserLanguage).toHaveBeenCalledWith([
+      { accents: [{ id: null, name: 'Brummy' }], locale: 'en' },
+    ]);
+    expect(mockSetUserLanguage).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not let you add a empty custom accent', async () => {
+    const mockSetUserLanguage = jest.fn();
+
+    const { getByLabelText, getByRole, getByTestId } =
+      await renderWithLocalization(
+        <InputLanguageAccentsInput
+          locale={'en'}
+          accentsAll={MOCK_ACCENTS_ALL}
+          userLanguages={MOCK_USER_LANGUAGES}
+          setUserLanguages={mockSetUserLanguage}
+        />
+      );
+
+    const input = getByLabelText('How would you describe your accent?');
+    userEvent.type(input, '     '); // type some empty text
+    fireEvent.keyDown(input, { key: 'Enter', code: 13 }); // press enter to submit text
+
+    expect(mockSetUserLanguage).toHaveBeenCalledTimes(0);
   });
 });

--- a/web/src/components/pages/profile/info/languages/input-language-accents/input-language-accents-input.tsx
+++ b/web/src/components/pages/profile/info/languages/input-language-accents/input-language-accents-input.tsx
@@ -120,6 +120,12 @@ const InputLanguageAccentsInput = ({
           ) => {
             if (event.key === 'Enter') {
               const { value } = event.target as HTMLInputElement;
+
+              // don't submit blank values
+              if (value.trim().length === 0) {
+                return;
+              }
+
               selectItem(value, {
                 type: Downshift.stateChangeTypes.keyDownEnter,
               });


### PR DESCRIPTION
This PR stops users from entering empty accents on the profile page when adding languages.

Thanks @mozgzh 