### PR TITLE
fix(profile): accents UI on RTL languages have incorrect spacing

### DIFF
--- a/web/src/components/pages/profile/info/languages/input-language-accents/input-language-accents-list.tsx
+++ b/web/src/components/pages/profile/info/languages/input-language-accents/input-language-accents-list.tsx
@@ -39,13 +39,13 @@ const InputLanguageAccents = ({
 
         return (
           <span key={`accent-${index}`} className="selected-accent">
+            {accent.name}
             <button
               className="selected-accent--button"
               onClick={() => removeAccent(locale, index)}>
               <VisuallyHidden>Remove {accent.name} accent</VisuallyHidden>
               <CloseIcon black />
             </button>
-            {accent.name}
           </span>
         );
       })}

--- a/web/src/components/pages/profile/info/languages/input-language-accents/input-language-accents.css
+++ b/web/src/components/pages/profile/info/languages/input-language-accents/input-language-accents.css
@@ -1,8 +1,9 @@
 .selected-accent {
-    display: inline-block;
-    padding-right: 1.5rem;
-    margin-bottom: 1.5rem;
+    display: inline-flex;
+    align-items: center;
+    padding-inline-start: 1.5rem;
     margin-inline-end: 1rem;
+    margin-bottom: 1.5rem;
     background: var(--light-grey);
     border-radius: 15rem;
 }
@@ -10,7 +11,7 @@
 .selected-accent--button {
     border: none;
     padding: 0.8rem 1.5rem;
-    padding-inline-end: 1rem;
+    padding-inline-start: 1rem;
 }
 
 #accent-selection-menu {


### PR DESCRIPTION
+ Fixes some spacing issues for the profile pages accent list on RTL languages
+ Move the 'Close' X to the right on LTR and to the right on RTL

**Before**
<img width="261" alt="Screenshot of broken UI for RTL, the padding is broken" src="https://user-images.githubusercontent.com/93216813/155306917-91039dc5-740d-43de-89f6-aedbde7a31ab.png">

**After**
<img width="249" alt="Screenshot of fixed UI, spacing looks correct" src="https://user-images.githubusercontent.com/93216813/155307434-256ef972-ec2c-40e2-8e11-ff9fcff05bd9.png">

