### PR TITLE
fix(speak/listen): better loading of data and better error handling

### DIFF
--- a/web/locales/ca/messages.ftl
+++ b/web/locales/ca/messages.ftl
@@ -835,6 +835,9 @@ listen-last-time-instruction = <playIcon></playIcon> L'últim!
 listen-empty-state = No hi ha cap més tall per validar en aquesta llengua...
 speak-empty-state = No hi ha cap més frase per enregistrar en aquesta llengua...
 speak-empty-state-cta = Aporteu frases
+speak-loading-error =
+    No hem pogut carregar les oracions.
+    Si us plau, torneu a intentar-ho més tard.
 record-button-label = Enregistreu la vostra veu
 share-title-new = <bold>Ajudeu-nos</bold> a trobar més veus
 keep-track-profile = Feu seguiment del vostre progrés amb un perfil

--- a/web/locales/en/messages.ftl
+++ b/web/locales/en/messages.ftl
@@ -16,6 +16,7 @@ not-available-abbreviation = N/A
 banner-error-slow-1 = Sorry, Common Voice is running slowly. Thanks for your interest.
 banner-error-slow-2 = We're receiving a lot of traffic and are currently investigating the issues.
 banner-error-slow-link = Status Page
+error-something-went-wrong = Sorry, something went wrong
 
 # Don't rename the following section, its contents are auto-inserted based on the name (see scripts/pontoon-languages-to-ftl.js)
 # [Languages]
@@ -845,8 +846,14 @@ listen-again-instruction = Great work!<playIcon></playIcon> Listen again when yo
 listen-3rd-time-instruction = 2 down, keep it up!<playIcon></playIcon>
 listen-last-time-instruction = <playIcon></playIcon>Last one!
 listen-empty-state = We've run out of clips to validate in this language...
+listen-loading-error =
+    We couldn’t get any audio clips for you to listen to.
+    Please try again later.
 speak-empty-state = We've run out of sentences to record in this language...
 speak-empty-state-cta = Contribute sentences
+speak-loading-error =
+    We couldn’t get any sentences for you to speak.
+    Please try again later.
 record-button-label = Record your voice
 share-title-new = <bold>Help us</bold> find more voices
 keep-track-profile = Keep track of your progress with a profile

--- a/web/src/components/pages/contribution/contribution.css
+++ b/web/src/components/pages/contribution/contribution.css
@@ -23,7 +23,7 @@
     padding: 10px 20px;
     max-width: var(--wide-desktop-width);
     width: 100%;
-    height:  100%;
+    height: 100%;
     box-sizing: border-box;
 
     @media (--md-up) {
@@ -64,7 +64,7 @@
         font-weight: 600;
 
         @media (--md-up) {
-            margin-top:  0;
+            margin-top: 0;
             margin-bottom: 1rem;
         }
 
@@ -142,8 +142,8 @@
         }
 
         .mobile-break {
-            display:  block;
-            width:  1px;
+            display: block;
+            width: 1px;
             height: 1px;
             @media (--md-up) {
                 display: none;
@@ -577,11 +577,20 @@
 
         display: flex;
         flex-direction: column;
-        align-items: center;
         justify-content: center;
 
         background: var(--white);
         box-shadow: 0 6px 12px 0 rgba(0, 0, 0, 0.05);
+
+        h1 {
+            font-weight: 400;
+            font-size: 2em;
+            margin-bottom: 0.5em;
+        }
+
+        p {
+            font-size: 1.25em;
+        }
 
         @media (--md-up) {
             padding: 120px 105px;

--- a/web/src/components/pages/contribution/listen/listen-error-content.tsx
+++ b/web/src/components/pages/contribution/listen/listen-error-content.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import { Localized } from '@fluent/react';
+
+import { MicIcon } from '../../../ui/icons';
+import { LinkButton } from '../../../ui/ui';
+import URLS from '../../../../urls';
+
+const MissingClips = ({ isDemoMode }: { isDemoMode: boolean }) => (
+  <div className="empty-container">
+    <div className="error-card">
+      <h1>
+        <Localized id="listen-empty-state" />
+      </h1>
+      <LinkButton
+        rounded
+        to={isDemoMode ? URLS.DEMO_SPEAK : URLS.SPEAK}
+        className="record-instead">
+        <MicIcon />{' '}
+        <Localized id="record-button-label">
+          <span />
+        </Localized>
+      </LinkButton>
+    </div>
+  </div>
+);
+
+const LoadingError = () => (
+  <div className="empty-container">
+    <div className="error-card">
+      <h1>
+        <Localized id="error-something-went-wrong" />
+      </h1>
+      <p>
+        <Localized id="listen-loading-error" />
+      </p>
+    </div>
+  </div>
+);
+
+interface Props {
+  isLoading: boolean;
+  hasLoadingError: boolean;
+  isMissingClips: boolean;
+  isDemoMode: boolean;
+}
+
+const ListenErrorContent = ({
+  isLoading,
+  hasLoadingError,
+  isMissingClips,
+  isDemoMode,
+}: Props) => {
+  if (isLoading) {
+    return null;
+  }
+
+  if (hasLoadingError) {
+    return <LoadingError />;
+  }
+
+  if (isMissingClips) {
+    return <MissingClips isDemoMode={isDemoMode} />;
+  }
+
+  return null;
+};
+
+export default ListenErrorContent;

--- a/web/src/components/pages/contribution/listen/listen.tsx
+++ b/web/src/components/pages/contribution/listen/listen.tsx
@@ -62,6 +62,7 @@ interface PropsFromState {
 }
 
 interface PropsFromDispatch {
+  loadClips: typeof Clips.actions.refillCache;
   removeClip: typeof Clips.actions.remove;
   vote: typeof Clips.actions.vote;
   addAchievement: typeof Notifications.actions.addAchievement;
@@ -107,6 +108,11 @@ class ListenPage extends React.Component<Props, State> {
     }
 
     return null;
+  }
+
+  componentDidMount(): void {
+    const { loadClips } = this.props;
+    loadClips();
   }
 
   componentWillUnmount() {
@@ -347,27 +353,30 @@ class ListenPage extends React.Component<Props, State> {
               </>
             }
             pills={clips.map(
-              ({ isValid }, i) => (props: ContributionPillProps) => {
-                const isVoted = isValid !== null;
-                const isActive = clipIndex === i;
-                return (
-                  <Pill
-                    className={isVoted ? (isValid ? 'valid' : 'invalid') : ''}
-                    onClick={null}
-                    status={isActive ? 'active' : isVoted ? 'done' : 'pending'}
-                    {...props}>
-                    {isActive ? (
-                      <VolumeIcon />
-                    ) : isVoted ? (
-                      isValid ? (
-                        <CheckIcon />
-                      ) : (
-                        <CrossIcon />
-                      )
-                    ) : null}
-                  </Pill>
-                );
-              }
+              ({ isValid }, i) =>
+                (props: ContributionPillProps) => {
+                  const isVoted = isValid !== null;
+                  const isActive = clipIndex === i;
+                  return (
+                    <Pill
+                      className={isVoted ? (isValid ? 'valid' : 'invalid') : ''}
+                      onClick={null}
+                      status={
+                        isActive ? 'active' : isVoted ? 'done' : 'pending'
+                      }
+                      {...props}>
+                      {isActive ? (
+                        <VolumeIcon />
+                      ) : isVoted ? (
+                        isValid ? (
+                          <CheckIcon />
+                        ) : (
+                          <CrossIcon />
+                        )
+                      ) : null}
+                    </Pill>
+                  );
+                }
             )}
             reportModalProps={{
               reasons: [
@@ -427,6 +436,7 @@ const mapStateToProps = (state: StateTree) => {
 };
 
 const mapDispatchToProps = {
+  loadClips: Clips.actions.refillCache,
   removeClip: Clips.actions.remove,
   vote: Clips.actions.vote,
   addAchievement: Notifications.actions.addAchievement,

--- a/web/src/components/pages/contribution/listen/listen.tsx
+++ b/web/src/components/pages/contribution/listen/listen.tsx
@@ -11,13 +11,11 @@ import URLS from '../../../../urls';
 import {
   CheckIcon,
   CrossIcon,
-  MicIcon,
   OldPlayIcon,
   ThumbsDownIcon,
   ThumbsUpIcon,
   VolumeIcon,
 } from '../../../ui/icons';
-import { LinkButton } from '../../../ui/ui';
 import ContributionPage, {
   ContributionPillProps,
   SET_COUNT,
@@ -25,10 +23,12 @@ import ContributionPage, {
 import { Notifications } from '../../../../stores/notifications';
 import { PlayButton } from '../../../primary-buttons/primary-buttons';
 import Pill from '../pill';
+import ListenErrorContent from './listen-error-content';
 
 import './listen.css';
 import { User } from '@sentry/types';
 import { RouteComponentProps, withRouter } from 'react-router';
+import { Spinner } from '../../../ui/ui';
 
 const VOTE_NO_PLAY_MS = 3000; // Threshold when to allow voting no
 
@@ -54,6 +54,7 @@ interface PropsFromState {
   api: API;
   clips: ClipType[];
   isLoading: boolean;
+  hasLoadingError: boolean;
   locale: Locale.State;
   showFirstContributionToast: boolean;
   hasEarnedSessionToast: boolean;
@@ -267,18 +268,17 @@ class ListenPage extends React.Component<Props, State> {
   private reset = () => this.setState(initialState);
 
   render() {
-    const {
-      clips,
-      hasPlayed,
-      hasPlayedSome,
-      isPlaying,
-      isSubmitted,
-    } = this.state;
+    const { isLoading, hasLoadingError } = this.props;
+    const { clips, hasPlayed, hasPlayedSome, isPlaying, isSubmitted } =
+      this.state;
     const clipIndex = this.getClipIndex();
     const activeClip = clips[clipIndex];
+    const isMissingClips = !isLoading && (clips.length === 0 || !activeClip);
+
     return (
       <>
         <div id="listen-page">
+          {isLoading && <Spinner delayMs={500} />}
           <audio
             {...(activeClip && { src: activeClip.audioSrc })}
             preload="auto"
@@ -288,26 +288,14 @@ class ListenPage extends React.Component<Props, State> {
           <ContributionPage
             activeIndex={clipIndex}
             demoMode={this.demoMode}
+            hasErrors={!isLoading && (isMissingClips || hasLoadingError)}
             errorContent={
-              !this.props.isLoading &&
-              (clips.length === 0 || !activeClip) && (
-                <div className="empty-container">
-                  <div className="error-card card-dimensions">
-                    <Localized id="listen-empty-state">
-                      <span />
-                    </Localized>
-                    <LinkButton
-                      rounded
-                      to={this.demoMode ? URLS.DEMO_SPEAK : URLS.SPEAK}
-                      className="record-instead">
-                      <MicIcon />{' '}
-                      <Localized id="record-button-label">
-                        <span />
-                      </Localized>
-                    </LinkButton>
-                  </div>
-                </div>
-              )
+              <ListenErrorContent
+                isLoading={isLoading}
+                hasLoadingError={hasLoadingError}
+                isMissingClips={isMissingClips}
+                isDemoMode={this.demoMode}
+              />
             }
             instruction={props =>
               activeClip &&
@@ -417,6 +405,7 @@ const mapStateToProps = (state: StateTree) => {
   const {
     clips,
     isLoading,
+    hasLoadingError,
     showFirstContributionToast,
     hasEarnedSessionToast,
     showFirstStreakToast,
@@ -426,6 +415,7 @@ const mapStateToProps = (state: StateTree) => {
   return {
     clips,
     isLoading,
+    hasLoadingError,
     showFirstContributionToast,
     hasEarnedSessionToast,
     showFirstStreakToast,

--- a/web/src/components/pages/contribution/speak/speak-error-content.tsx
+++ b/web/src/components/pages/contribution/speak/speak-error-content.tsx
@@ -1,0 +1,118 @@
+import * as React from 'react';
+import { Localized } from '@fluent/react';
+
+import {
+  ArrowRight,
+  FirefoxColor,
+  ChromeColor,
+  SafariColor,
+} from '../../../ui/icons';
+import { LinkButton } from '../../../ui/ui';
+import { isIOS, isMobileSafari } from '../../../../utility';
+import VisuallyHidden from '../../../visually-hidden/visually-hidden';
+
+const UnsupportedInfo = () => (
+  <div className="empty-container">
+    <div className="error-card unsupported">
+      {isIOS() && !isMobileSafari() ? (
+        <>
+          <h1>
+            <Localized id="record-platform-not-supported-ios-non-safari" />
+          </h1>
+          <SafariColor />
+        </>
+      ) : (
+        <>
+          <h1>
+            <Localized id="record-platform-not-supported" />
+          </h1>
+          <p className="desktop">
+            <Localized id="record-platform-not-supported-desktop" />
+          </p>
+          <div>
+            <a
+              rel="noopener noreferrer"
+              target="_blank"
+              href="https://www.firefox.com/">
+              <VisuallyHidden>Firefox</VisuallyHidden>
+              <FirefoxColor />
+            </a>
+            <a
+              rel="noopener noreferrer"
+              target="_blank"
+              href="https://www.google.com/chrome">
+              <VisuallyHidden>Chrome</VisuallyHidden>
+              <ChromeColor />
+            </a>
+          </div>
+        </>
+      )}
+    </div>
+  </div>
+);
+
+const NoSentencesAvailable = () => (
+  <div className="empty-container">
+    <div className="error-card no-sentences-available">
+      <h1>
+        <Localized id="speak-empty-state" />
+      </h1>
+      <LinkButton
+        rounded
+        blank
+        href="https://common-voice.github.io/sentence-collector/">
+        <ArrowRight className="speak-sc-icon" />{' '}
+        <Localized id="speak-empty-state-cta">
+          <span />
+        </Localized>
+      </LinkButton>
+    </div>
+  </div>
+);
+
+const LoadingError = () => (
+  <div className="empty-container">
+    <div className="error-card">
+      <h1>
+        <Localized id="error-something-went-wrong" />
+      </h1>
+      <p>
+        <Localized id="speak-loading-error" />
+      </p>
+    </div>
+  </div>
+);
+
+interface Props {
+  isLoading: boolean;
+  hasLoadingError: boolean;
+  isUnsupportedPlatform: boolean;
+  isMissingClips: boolean;
+}
+
+const SpeakErrorContent = ({
+  isLoading,
+  hasLoadingError,
+  isUnsupportedPlatform,
+  isMissingClips,
+}: Props) => {
+  if (isLoading) {
+    return null;
+  }
+
+  if (hasLoadingError) {
+    return <LoadingError />;
+  }
+
+  if (isUnsupportedPlatform) {
+    return <UnsupportedInfo />;
+  }
+
+  if (isMissingClips) {
+    return <NoSentencesAvailable />;
+  }
+
+  return null;
+};
+
+export default SpeakErrorContent;

--- a/web/src/components/pages/contribution/speak/speak.tsx
+++ b/web/src/components/pages/contribution/speak/speak.tsx
@@ -4,7 +4,6 @@ import {
   withLocalization,
 } from '@fluent/react';
 import * as React from 'react';
-import BalanceText from 'react-balance-text';
 import { connect } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router';
 const NavigationPrompt = require('react-router-navigation-prompt').default;
@@ -21,18 +20,8 @@ import URLS from '../../../../urls';
 import { localeConnector, LocalePropsFromState } from '../../../locale-helpers';
 import Modal, { ModalButtons } from '../../../modal/modal';
 import TermsModal from '../../../terms-modal';
-import {
-  CheckIcon,
-  MicIcon,
-  StopIcon,
-  ArrowRight,
-  FirefoxColor,
-  ChromeColor,
-  SafariColor,
-  ReturnKeyIcon,
-} from '../../../ui/icons';
-import { Button, TextButton, LinkButton } from '../../../ui/ui';
-import { isIOS, isMobileSafari } from '../../../../utility';
+import { CheckIcon, MicIcon, StopIcon, ReturnKeyIcon } from '../../../ui/icons';
+import { Button, TextButton, Spinner } from '../../../ui/ui';
 import ContributionPage, {
   ContributionPillProps,
   SET_COUNT,
@@ -44,6 +33,7 @@ import {
 import AudioWeb, { AudioError, AudioInfo } from './audio-web';
 import RecordingPill from './recording-pill';
 import { SentenceRecording } from './sentence-recording';
+import SpeakErrorContent from './speak-error-content';
 
 import './speak.css';
 
@@ -58,73 +48,13 @@ enum RecordingError {
   TOO_QUIET = 'TOO_QUIET',
 }
 
-const UnsupportedInfo = () => (
-  <div className="empty-container">
-    <div className="error-card card-dimensions unsupported">
-      {isIOS() && !isMobileSafari() ? (
-        <>
-          <BalanceText>
-            <Localized id="record-platform-not-supported-ios-non-safari" />
-          </BalanceText>
-          <SafariColor />
-        </>
-      ) : (
-        <>
-          <BalanceText>
-            <Localized id="record-platform-not-supported" />
-          </BalanceText>
-          <p className="desktop">
-            <Localized id="record-platform-not-supported-desktop">
-              <BalanceText />
-            </Localized>
-          </p>
-          <div>
-            <a
-              rel="noopener noreferrer"
-              target="_blank"
-              href="https://www.firefox.com/"
-              title="Firefox">
-              <FirefoxColor />
-            </a>{' '}
-            <a
-              rel="noopener noreferrer"
-              target="_blank"
-              href="https://www.google.com/chrome"
-              title="Chrome">
-              <ChromeColor />
-            </a>
-          </div>
-        </>
-      )}
-    </div>
-  </div>
-);
-
-const NoSentencesAvailable = () => (
-  <div className="empty-container">
-    <div className="error-card card-dimensions no-sentences-available">
-      <Localized id="speak-empty-state">
-        <span />
-      </Localized>
-      <LinkButton
-        rounded
-        blank
-        href="https://common-voice.github.io/sentence-collector/">
-        <ArrowRight className="speak-sc-icon" />{' '}
-        <Localized id="speak-empty-state-cta">
-          <span />
-        </Localized>
-      </LinkButton>
-    </div>
-  </div>
-);
-
 interface PropsFromState {
   api: API;
   locale: Locale.State;
   sentences: SentenceType[];
   user: User.State;
   isLoading: boolean;
+  hasLoadingError: boolean;
 }
 
 interface PropsFromDispatch {
@@ -556,21 +486,6 @@ class SpeakPage extends React.Component<Props, State> {
     });
   };
 
-  private displayError = () => {
-    return (
-      this.isUnsupportedPlatform ||
-      (!this.props.isLoading && this.state.clips.length == 0)
-    );
-  };
-
-  private returnSpeakError = () => {
-    return this.isUnsupportedPlatform ? (
-      <UnsupportedInfo />
-    ) : (
-      <NoSentencesAvailable />
-    );
-  };
-
   private resetAndGoHome = () => {
     const { history, toLocaleRoute } = this.props;
     this.resetState(() => {
@@ -583,7 +498,7 @@ class SpeakPage extends React.Component<Props, State> {
   };
 
   render() {
-    const { getString, user } = this.props;
+    const { getString, user, isLoading, hasLoadingError } = this.props;
     const {
       clips,
       isSubmitted,
@@ -594,10 +509,12 @@ class SpeakPage extends React.Component<Props, State> {
       showDiscardModal,
     } = this.state;
     const recordingIndex = this.getRecordingIndex();
+    const isMissingClips = !isLoading && clips.length == 0;
 
     return (
       <>
         <div id="speak-page">
+          {isLoading && <Spinner delayMs={500} />}
           {!isSubmitted && (
             <NavigationPrompt
               when={clips.filter(clip => clip.recording).length > 0}>
@@ -662,7 +579,18 @@ class SpeakPage extends React.Component<Props, State> {
           <ContributionPage
             demoMode={this.demoMode}
             activeIndex={recordingIndex}
-            errorContent={this.displayError() && this.returnSpeakError()}
+            hasErrors={
+              this.isUnsupportedPlatform ||
+              (!isLoading && (hasLoadingError || isMissingClips))
+            }
+            errorContent={
+              <SpeakErrorContent
+                isLoading={isLoading}
+                hasLoadingError={hasLoadingError}
+                isUnsupportedPlatform={this.isUnsupportedPlatform}
+                isMissingClips={isMissingClips}
+              />
+            }
             instruction={props =>
               error ? (
                 <div className="error">
@@ -683,22 +611,24 @@ class SpeakPage extends React.Component<Props, State> {
                   />
                 </div>
               ) : (
-                <Localized
-                  id={
-                    this.isRecording
-                      ? 'record-stop-instruction'
-                      : recordingIndex === SET_COUNT - 1
-                      ? 'record-last-instruction'
-                      : ['record-instruction', 'record-again-instruction'][
-                          recordingIndex
-                        ] || 'record-again-instruction2'
-                  }
-                  elems={{
-                    recordIcon: <MicIcon />,
-                    stopIcon: <StopIcon />,
-                  }}
-                  {...props}
-                />
+                <>
+                  <Localized
+                    id={
+                      this.isRecording
+                        ? 'record-stop-instruction'
+                        : recordingIndex === SET_COUNT - 1
+                        ? 'record-last-instruction'
+                        : ['record-instruction', 'record-again-instruction'][
+                            recordingIndex
+                          ] || 'record-again-instruction2'
+                    }
+                    elems={{
+                      recordIcon: <MicIcon />,
+                      stopIcon: <StopIcon />,
+                    }}
+                    {...props}
+                  />
+                </>
               )
             }
             isFirstSubmit={user.recordTally === 0}
@@ -784,7 +714,8 @@ class SpeakPage extends React.Component<Props, State> {
 }
 
 const mapStateToProps = (state: StateTree) => {
-  const { sentences, isLoading } = Sentences.selectors.localeSentences(state);
+  const { sentences, isLoading, hasLoadingError } =
+    Sentences.selectors.localeSentences(state);
 
   return {
     api: state.api,
@@ -792,6 +723,7 @@ const mapStateToProps = (state: StateTree) => {
     sentences,
     user: state.user,
     isLoading,
+    hasLoadingError,
   };
 };
 

--- a/web/src/components/pages/contribution/speak/speak.tsx
+++ b/web/src/components/pages/contribution/speak/speak.tsx
@@ -131,6 +131,7 @@ interface PropsFromDispatch {
   addUploads: typeof Uploads.actions.add;
   addAchievement: typeof Notifications.actions.addAchievement;
   addNotification: typeof Notifications.actions.addPill;
+  loadSentences: typeof Sentences.actions.refill;
   removeSentences: typeof Sentences.actions.remove;
   tallyRecording: typeof User.actions.tallyRecording;
   refreshUser: typeof User.actions.refresh;
@@ -203,6 +204,9 @@ class SpeakPage extends React.Component<Props, State> {
   }
 
   componentDidMount() {
+    const { loadSentences } = this.props;
+    loadSentences();
+
     this.audio = new AudioWeb();
     this.audio.setVolumeCallback(this.updateVolume.bind(this));
 
@@ -648,8 +652,8 @@ class SpeakPage extends React.Component<Props, State> {
             <Localized id="review-aborted">
               <Modal
                 buttons={{
-                  [getString('review-keep-recordings')]: this
-                    .toggleDiscardModal,
+                  [getString('review-keep-recordings')]:
+                    this.toggleDiscardModal,
                   [getString('review-delete-recordings')]: this.resetAndGoHome,
                 }}
               />
@@ -795,6 +799,7 @@ const mapDispatchToProps = {
   addNotification: Notifications.actions.addPill,
   addAchievement: Notifications.actions.addAchievement,
   addUploads: Uploads.actions.add,
+  loadSentences: Sentences.actions.refill,
   removeSentences: Sentences.actions.remove,
   tallyRecording: User.actions.tallyRecording,
   refreshUser: User.actions.refresh,

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -101,11 +101,11 @@ export default class API {
     return this.getLocalePath() + '/clips';
   }
 
-  fetchRandomSentences(count = 1): Promise<Sentence[]> {
+  async fetchRandomSentences(count = 1): Promise<Sentence[]> {
     return this.fetch(`${this.getLocalePath()}/sentences?count=${count}`);
   }
 
-  fetchRandomClips(count = 1): Promise<Clip[]> {
+  async fetchRandomClips(count = 1): Promise<Clip[]> {
     return this.fetch(`${this.getClipPath()}?count=${count}`);
   }
 

--- a/web/src/stores/clips.ts
+++ b/web/src/stores/clips.ts
@@ -146,12 +146,8 @@ export namespace Clips {
 
           dispatch({ type: ActionType.REFILL_CACHE, clips });
         } catch (err) {
-          if (err instanceof XMLHttpRequest) {
-            dispatch({ type: ActionType.REFILL_CACHE });
-          } else {
-            dispatch({ type: ActionType.LOAD_ERROR });
-            throw err;
-          }
+          dispatch({ type: ActionType.LOAD_ERROR });
+          throw err;
         }
       },
 

--- a/web/src/stores/locale.ts
+++ b/web/src/stores/locale.ts
@@ -1,5 +1,6 @@
 import { Dispatch } from 'redux';
-const contributableLocales = require('../../../locales/contributable.json') as string[];
+const contributableLocales =
+  require('../../../locales/contributable.json') as string[];
 import { Clips } from './clips';
 import { Sentences } from './sentences';
 import StateTree from './tree';
@@ -19,20 +20,15 @@ export namespace Locale {
   export type Action = SetAction;
 
   export const actions = {
-    set: (locale: string) => (
-      dispatch: Dispatch<SetAction | any>,
-      getState: () => StateTree
-    ) => {
-      if (getState().locale === locale) return;
-      dispatch({
-        type: ActionType.SET,
-        locale,
-      });
-      if (contributableLocales.includes(locale)) {
-        dispatch(Sentences.actions.refill());
-        dispatch(Clips.actions.refillCache());
-      }
-    },
+    set:
+      (locale: string) =>
+      (dispatch: Dispatch<SetAction | any>, getState: () => StateTree) => {
+        if (getState().locale === locale) return;
+        dispatch({
+          type: ActionType.SET,
+          locale,
+        });
+      },
   };
 
   export function reducer(state: State = null, action: Action): State {


### PR DESCRIPTION
+ Do not load sentences and clips needed for /speak or /listen pages on any page load. Now loads when needed
+ Add a spinner loading on /speak, /listen page when loading
+ Adds error messaging for when getting random sentences/clips error
+ Tidy up styling/markup for error messages
+ Detect erroring clips and remove them from clips list
+ Do not request clips again if we have a XMLHttpRequest error