### PR TITLE
Improve getRandomClips performance

### DIFF
--- a/server/src/lib/model.ts
+++ b/server/src/lib/model.ts
@@ -1,7 +1,7 @@
 import * as request from 'request-promise-native';
 import { LanguageStats, Sentence } from 'common';
 import DB from './model/db';
-import { DBClipWithVoters } from './model/db/tables/clip-table';
+import { DBClip } from './model/db/tables/clip-table';
 import lazyCache from './lazy-cache';
 
 const locales = require('locales/all.json') as string[];
@@ -135,7 +135,7 @@ export default class Model {
     client_id: string,
     locale: string,
     count: number
-  ): Promise<DBClipWithVoters[]> {
+  ): Promise<DBClip[]> {
     return this.db.findClipsNeedingValidation(
       client_id,
       locale,

--- a/server/src/lib/model/db.ts
+++ b/server/src/lib/model/db.ts
@@ -458,15 +458,15 @@ export default class DB {
         AND NOT EXISTS(
           SELECT clip_id
           FROM votes
-          WHERE client_id = ?
+          WHERE votes.clip_id = clips.id AND client_id = ?
           UNION ALL
           SELECT clip_id
           FROM reported_clips reported
-          WHERE client_id = ?
+          WHERE reported.clip_id = clips.id AND client_id = ?
           UNION ALL
           SELECT clip_id
           FROM skipped_clips skipped
-          WHERE client_id = ?
+          WHERE skipped.clip_id = clips.id AND client_id = ?
         )
         AND sentences.clips_count <= 15
         ${exemptFromSSRL ? '' : 'AND sentences.has_valid_clip = 0'}

--- a/server/src/lib/model/db/tables/clip-table.ts
+++ b/server/src/lib/model/db/tables/clip-table.ts
@@ -8,12 +8,9 @@ export type DBClip = {
   path: string;
   sentence: string;
   original_sentence_id: string;
+  has_valid_clip?: number;
   taxonomy?: TaxonomyType;
 };
-
-export interface DBClipWithVoters extends DBClip {
-  voters: string[];
-}
 
 export default class ClipsTable extends Table {
   constructor(mysql: Mysql) {


### PR DESCRIPTION
This PR is to enable caching for a heavy query that's involved with finding clips to show to a user. By breaking up the query into multiple parts, utilizing caching where it makes sense and ensuring BI is in code (instead of SQL), the DB server can rest easier, ideally, dramatically reducing reads and total rows processed.