### PR TITLE
fix(translation): never let google chrome auto translate sentences

### DIFF
--- a/web/src/components/pages/contribution/contribution.tsx
+++ b/web/src/components/pages/contribution/contribution.tsx
@@ -450,6 +450,9 @@ class ContributionPage extends React.Component<Props, State> {
                     const isActive = i === activeSentenceIndex;
                     return (
                       <div
+                        // don't let Chrome auto-translate
+                        // https://html.spec.whatwg.org/multipage/dom.html#the-translate-attribute
+                        translate="no"
                         key={sentence ? sentence.text : i}
                         className={
                           'card card-dimensions ' + (isActive ? '' : 'inactive')


### PR DESCRIPTION
Tell Google Chrome to never translate sentences that people should read.

Thanks to the great issue from @jmontane. This doesn't fully resolve the issue but does help.

Partially fixes #3491