### PR TITLE
fix(prettier): deprecated option

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "jsxBracketSameLine": true,
+  "bracketSameLine": true,
   "singleQuote": true,
   "arrowParens": "avoid"
 }


### PR DESCRIPTION
https://prettier.io/blog/2021/09/09/2.4.0.html#replace-jsxbracketsameline-option-with-bracketsameline-option-11006httpsgithubcomprettierprettierpull11006-by-kurtztechhttpsgithubcomkurtztech
