### PR TITLE
Add metrics endpoint

### DIFF
--- a/server/src/lib/api.ts
+++ b/server/src/lib/api.ts
@@ -51,6 +51,13 @@ export default class API {
     const router = PromiseRouter();
 
     router.use(authMiddleware);
+    router.get('/metrics', (request: Request, response: Response) => {
+      console.log('Received a metrics request', {
+        referer: request.header('Referer'),
+        query: request.query,
+      });
+      response.redirect('/');
+    });
 
     router.get('/golem', (request: Request, response: Response) => {
       console.log('Received a Golem request', {


### PR DESCRIPTION
/metrics route is used in various systems-checking. Remove said endpoint breaks systems health checks and to fix would require additional systems changes. Since the focus of the image queue PR is not related to that, I've created a hollow endpoint to that allows the healthchecks to work as normal. 