### PR TITLE
Add target sentences column and data

### DIFF
--- a/server/src/lib/model.ts
+++ b/server/src/lib/model.ts
@@ -119,7 +119,6 @@ function fetchLocalizedPercentagesByLocale() {
     )
   );
 }
-
 const MINUTE = 1000 * 60;
 const DAY = MINUTE * 60 * 24;
 /**
@@ -204,12 +203,20 @@ export default class Model {
         locale => !contributableLocales.includes(locale)
       );
 
-      function indexCountByLocale(rows: { locale: string; count: number }[]): {
+      function indexCountByLocale(
+        rows: { locale: string; count: number; target_sentence_count: number }[]
+      ): {
         [locale: string]: number;
       } {
         return rows.reduce(
-          (obj: { [locale: string]: number }, { count, locale }: any) => {
-            obj[locale] = count;
+          (
+            obj: { [locale: string]: any },
+            { count, locale, target_sentence_count }: any
+          ) => {
+            obj[locale] = {
+              current_count: count,
+              target_sentence_count: target_sentence_count,
+            };
             return obj;
           },
           {}

--- a/server/src/lib/model/db.ts
+++ b/server/src/lib/model/db.ts
@@ -154,7 +154,7 @@ export default class DB {
   async getSentenceCountByLocale(locales: string[]): Promise<any> {
     const [rows] = await this.mysql.query(
       `
-        SELECT COUNT(*) AS count, locales.name AS locale
+        SELECT COUNT(*) AS count, locales.name AS locale, locales.target_sentence_count as target_sentence_count
         FROM sentences
         LEFT JOIN locales ON sentences.locale_id = locales.id
         WHERE locales.name IN (?) AND sentences.is_used

--- a/server/src/lib/model/db/migrations/20220322130651-locale-target-sentence-criteria.ts
+++ b/server/src/lib/model/db/migrations/20220322130651-locale-target-sentence-criteria.ts
@@ -1,0 +1,231 @@
+type Locale = {
+  localeToken: string;
+  sentenceTarget: number;
+};
+
+const locales: Locale[] = [
+  {
+    localeToken: 'ace',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'ady',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'an',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'arn',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'ast',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'bxr',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'cak',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'co',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'dsb',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'ff',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'gom',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'ht',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'izh',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'kbd',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'ki',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'km',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'knn',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'kpv',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'kw',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'lij',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'mai',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'mg',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'mhr',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'mni',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'mos',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'mrj',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'ms',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'ne-NP',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'nia',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'nyn',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'oc',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'pap-AW',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'ps',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'quc',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'quy',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'sc',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'scn',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'shi',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'skr',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'so',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'syr',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'ti',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'tw',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'ty',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'uby',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'udm',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'vec',
+    sentenceTarget: 750,
+  },
+  {
+    localeToken: 'yi',
+    sentenceTarget: 750,
+  },
+];
+
+export const up = async function (db: any): Promise<any> {
+  db.runSql(`
+  ALTER TABLE locales ADD COLUMN target_sentence_count SMALLINT NOT NULL DEFAULT 5000;
+  `);
+  //remove existing test variant data
+  // const languageQuery = await db.runSql(
+  //   `SELECT id, name FROM locales where name is not null`
+  // );
+  // // {en: 1, fr: 2}
+  // const mappedLanguages = languageQuery.reduce((obj: any, current: any) => {
+  //   obj[current.name] = current.id;
+  //   return obj;
+  // }, {});
+  // for (const row of VARIANTS) {
+  //   await db.runSql(
+  //     `INSERT INTO variants (locale_id, sentenceTarget, variant_name) VALUES ( ${
+  //       mappedLanguages[row['locale_name']] +
+  //       ',"' +
+  //       row['sentenceTarget'] +
+  //       '","' +
+  //       row['variant_name'] +
+  //       '"'
+  //     })`
+  //   );
+  // }
+};
+
+export const down = async function (db: any): Promise<any> {
+  await db.runSql(`
+    `);
+};

--- a/server/src/lib/model/db/migrations/20220322130651-locale-target-sentence-criteria.ts
+++ b/server/src/lib/model/db/migrations/20220322130651-locale-target-sentence-criteria.ts
@@ -196,36 +196,80 @@ const locales: Locale[] = [
     localeToken: 'yi',
     sentenceTarget: 750,
   },
+  {
+    localeToken: 'am',
+    sentenceTarget: 2000,
+  },
+  {
+    localeToken: 'fo',
+    sentenceTarget: 2000,
+  },
+  {
+    localeToken: 'is',
+    sentenceTarget: 2000,
+  },
+  {
+    localeToken: 'kaa',
+    sentenceTarget: 2000,
+  },
+  {
+    localeToken: 'my',
+    sentenceTarget: 2000,
+  },
+  {
+    localeToken: 'si',
+    sentenceTarget: 2000,
+  },
+  {
+    localeToken: 'sq',
+    sentenceTarget: 2000,
+  },
+  {
+    localeToken: 'te',
+    sentenceTarget: 2000,
+  },
+  {
+    localeToken: 'tg',
+    sentenceTarget: 2000,
+  },
+  {
+    localeToken: 'tk',
+    sentenceTarget: 2000,
+  },
+  {
+    localeToken: 'tl',
+    sentenceTarget: 2000,
+  },
+  {
+    localeToken: 'yo',
+    sentenceTarget: 2000,
+  },
 ];
 
 export const up = async function (db: any): Promise<any> {
-  db.runSql(`
-  ALTER TABLE locales ADD COLUMN target_sentence_count SMALLINT NOT NULL DEFAULT 5000;
-  `);
-  //remove existing test variant data
-  // const languageQuery = await db.runSql(
-  //   `SELECT id, name FROM locales where name is not null`
-  // );
-  // // {en: 1, fr: 2}
-  // const mappedLanguages = languageQuery.reduce((obj: any, current: any) => {
-  //   obj[current.name] = current.id;
-  //   return obj;
-  // }, {});
-  // for (const row of VARIANTS) {
-  //   await db.runSql(
-  //     `INSERT INTO variants (locale_id, sentenceTarget, variant_name) VALUES ( ${
-  //       mappedLanguages[row['locale_name']] +
-  //       ',"' +
-  //       row['sentenceTarget'] +
-  //       '","' +
-  //       row['variant_name'] +
-  //       '"'
-  //     })`
-  //   );
-  // }
+  // console.log(locales);
+
+  const targetColumnQuery = await db.runSql(
+    `SELECT target_sentence_count FROM locales`
+  );
+
+  if (targetColumnQuery) {
+    await db.runSql(`
+    ALTER TABLE locales ADD COLUMN target_sentence_count SMALLINT NOT NULL DEFAULT 5000;
+    `);
+    console.log('added column');
+    for (const row of locales) {
+      await db.runSql(` 
+    UPDATE locales
+    SET target_sentence_count = ${row.sentenceTarget}
+    WHERE name = "${row.localeToken}"`);
+    }
+  }
 };
 
 export const down = async function (db: any): Promise<any> {
   await db.runSql(`
-    `);
+    ALTER TABLE locales 
+    DROP COLUMN target_sentence_count
+  `);
 };

--- a/server/src/lib/model/db/migrations/20220323130651-locale-target-sentence-criteria.ts
+++ b/server/src/lib/model/db/migrations/20220323130651-locale-target-sentence-criteria.ts
@@ -248,28 +248,29 @@ const locales: Locale[] = [
 
 export const up = async function (db: any): Promise<any> {
   // console.log(locales);
-
-  const targetColumnQuery = await db.runSql(
-    `SELECT target_sentence_count FROM locales`
+  const checkCol = await db.runSql(
+    `SHOW COLUMNS FROM locales LIKE '%target_sentence_count%'`
   );
 
-  if (targetColumnQuery) {
-    await db.runSql(`
+  if (checkCol.length > 0) {
+    return;
+  }
+
+  await db.runSql(`
     ALTER TABLE locales ADD COLUMN target_sentence_count SMALLINT NOT NULL DEFAULT 5000;
-    `);
-    console.log('added column');
-    for (const row of locales) {
-      await db.runSql(` 
+  `);
+
+  for (const row of locales) {
+    await db.runSql(` 
     UPDATE locales
     SET target_sentence_count = ${row.sentenceTarget}
     WHERE name = "${row.localeToken}"`);
-    }
   }
 };
 
 export const down = async function (db: any): Promise<any> {
   await db.runSql(`
-    ALTER TABLE locales 
+    ALTER TABLE locales
     DROP COLUMN target_sentence_count
   `);
 };


### PR DESCRIPTION
This branch brings changes to how sentence criteria are defined for the platform.
Instead of having the static 5000 sentence criteria hardcoded, it will be added to the database and utilized from queries.
Work includes:
- Create new column in locales and add sentence criteria target.
- Modifying import-locales.js to make use of db
- Modifying /language_stats endpoint to return `sentence_target_count` per locale

`/language_stats` now looks like the following: 
```{
  "inProgress": [
    {
      "locale": "ace",
      "localizedPercentage": 16,
      "sentencesCount": {
        "current_count": 87,
        "target_sentence_count": 750
      }
    }...
```