### PR TITLE
Revert invalidating cache

### DIFF
--- a/server/src/lib/lazy-cache.ts
+++ b/server/src/lib/lazy-cache.ts
@@ -1,24 +1,17 @@
 import { redis, redlock, useRedis } from './redis';
 
-import { getConfig } from '../config-helper';
-
 type Fn<T, S> = (...args: S[]) => Promise<T>;
 
 function isExpired(at: number, timeMs: number) {
   return Date.now() - at > timeMs;
 }
 
-function memoryCache<T, S>(
-  cacheKey: string,
-  cachedFunction: Fn<T, S>,
-  timeMs: number
-): Fn<T, S> {
+function memoryCache<T, S>(cachedFunction: Fn<T, S>, timeMs: number): Fn<T, S> {
   const caches: {
     [key: string]: { at?: number; promise?: Promise<T>; value?: T };
   } = {};
   return async (...args) => {
-    const { RELEASE_VERSION } = getConfig();
-    const key = cacheKey + JSON.stringify(args) + (RELEASE_VERSION || '');
+    const key = JSON.stringify(args);
 
     let cached = caches[key];
     if (cached) {
@@ -45,14 +38,9 @@ function memoryCache<T, S>(
   };
 }
 
-function redisCache<T, S>(
-  cacheKey: string,
-  cachedFunction: Fn<T, S>,
-  timeMs: number
-): Fn<T, S> {
+function redisCache<T, S>(cachedFunction: Fn<T, S>, timeMs: number): Fn<T, S> {
   return async (...args) => {
-    const { RELEASE_VERSION } = getConfig();
-    const key = cacheKey + JSON.stringify(args) + (RELEASE_VERSION || '');
+    const key = JSON.stringify(args);
 
     const result = await redis.get(key);
 
@@ -98,7 +86,7 @@ export default function lazyCache<T, S>(
   f: Fn<T, S>,
   timeMs: number
 ): Fn<T, S> {
-  const memCache = memoryCache(cacheKey, f, timeMs);
+  const memCache = memoryCache(f, timeMs);
   return async (...args: S[]) =>
     ((await useRedis) ? redisCache(cacheKey, f, timeMs) : memCache)(...args);
 }

--- a/server/src/lib/lazy-cache.ts
+++ b/server/src/lib/lazy-cache.ts
@@ -38,7 +38,11 @@ function memoryCache<T, S>(cachedFunction: Fn<T, S>, timeMs: number): Fn<T, S> {
   };
 }
 
-function redisCache<T, S>(cachedFunction: Fn<T, S>, timeMs: number): Fn<T, S> {
+function redisCache<T, S>(
+  cacheKey: string,
+  cachedFunction: Fn<T, S>,
+  timeMs: number
+): Fn<T, S> {
   return async (...args) => {
     const key = JSON.stringify(args);
 


### PR DESCRIPTION
Reverts the caching logic, such that caches aren't rebuilt on deploy. Tying cache to releases forces a complete cache rebuild and has a large performance penalty on the platform. If there are multiple releases within cache expiry, the redis instance is quickly overburdened by a massive increase in memory required (this is because we aren't flushing old cache, just build new cache on top of the old). 

A (less than ideal) solution is to just rename the cache that is being specifically worked on, thus forcing just that cache to be rebuilt and not causing performance issues. 