### PR TITLE
Rewrite condition when building image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,9 @@ on:
 jobs:
   test-server:
     # Exclude Pontoon commits from building a new Docker container
-    if: "!contains(github.event.head_commit.message, 'Pontoon:')"
+    # if: "!contains(github.event.head_commit.message, 'Pontoon:')"
+    # Build Docker image if tagged w/ a version
+    if: "contains(github.ref, "-v")
     services:
       mysql:
         image: mysql:5.7

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
     # Exclude Pontoon commits from building a new Docker container
     # if: "!contains(github.event.head_commit.message, 'Pontoon:')"
     # Build Docker image if tagged w/ a version
-    if: "contains(github.ref, "-v")
+    if: "contains(github.ref, '-v')"
     services:
       mysql:
         image: mysql:5.7


### PR DESCRIPTION
Currently, if I'm promoting a branch like `main` to `stage` and am not fast enough (e.g. a pontoon commit is merged first), I cannot build the image. This change should make so any versioned tag can be built even if the last commit is from Pontoon 