### PR TITLE
Add language metadata

### DIFF
--- a/server/src/lib/model/db/migrations/20220509124328-add-isContributable-to-locales.ts
+++ b/server/src/lib/model/db/migrations/20220509124328-add-isContributable-to-locales.ts
@@ -1,0 +1,19 @@
+export const up = async function (db: any): Promise<any> {
+  await db.runSql(
+    `
+    ALTER TABLE locales
+      ADD COLUMN native_name varchar(255) CHARACTER SET utf8mb4,
+      ADD COLUMN isContributable BOOLEAN DEFAULT 0 NOT NULL,
+      ADD COLUMN text_direction ENUM('LTR', 'RTL', 'TTB', 'BTT') DEFAULT 'LTR' NOT NULL
+    `
+  );
+};
+
+export const down = async function (db: any): Promise<any> {
+  return await db.runSql(`
+  ALTER TABLE locales 
+    DROP COLUMN native_name,
+    DROP COLUMN isContributable,
+    DROP COLUMN text_direction
+`);
+};

--- a/server/src/lib/model/db/migrations/202205101212120-add-locale-metadata.ts
+++ b/server/src/lib/model/db/migrations/202205101212120-add-locale-metadata.ts
@@ -1,0 +1,206 @@
+const NATIVE_NAMES: INativeNames = {
+  ab: 'Аԥсуа',
+  ace: 'Bahsa Acèh',
+  af: 'af',
+  am: 'አማርኛ',
+  an: 'Aragonés',
+  ar: 'العربية',
+  arn: 'Mapuzugun',
+  as: 'অসমীয়া',
+  ast: 'Asturianu',
+  az: 'Azərbaycanca',
+  ba: 'Башҡорт',
+  bas: 'Basaa',
+  be: 'Беларуская',
+  bg: 'Български',
+  bn: 'বাংলা',
+  'bn-BD': 'bn-BD',
+  br: 'Brezhoneg',
+  bxr: 'Буряад',
+  ca: 'català',
+  cak: 'Kaqchikel',
+  ckb: 'کوردیی ناوەندی',
+  cnh: 'Laiholh (Hakha)',
+  co: 'Corsu',
+  cs: 'Čeština',
+  cv: 'Чӑвашла',
+  cy: 'Cymraeg',
+  da: 'Dansk',
+  de: 'Deutsch',
+  dsb: 'Dolnoserbšćina',
+  dv: 'ދިވެހި',
+  el: 'Ελληνικά',
+  en: 'English',
+  eo: 'Esperanto',
+  es: 'Español',
+  'es-AR': 'es-AR',
+  'es-CL': 'es-CL',
+  et: 'eesti',
+  eu: 'Euskara',
+  fa: 'فارسی',
+  ff: 'Pulaar-Fulfulde',
+  fi: 'suomi',
+  fo: 'Føroyskt',
+  fr: 'Français',
+  'fy-NL': 'Frysk',
+  'ga-IE': 'Gaeilge',
+  gl: 'Galego',
+  gn: 'Guarani',
+  gom: 'gom',
+  ha: 'Hausa',
+  he: 'עברית',
+  hi: 'हिंदी',
+  hr: 'Hrvatski',
+  hsb: 'Hornjoserbšćina',
+  ht: 'ht',
+  hu: 'Magyar',
+  'hy-AM': 'Հայերեն',
+  ia: 'Interlingua',
+  id: 'Bahasa Indonesia',
+  ie: 'ie',
+  ig: 'Ásụ̀sụ́ Ìgbò',
+  is: 'Íslenska',
+  it: 'Italiano',
+  ja: '日本語',
+  ka: 'ქართული',
+  kab: 'Taqbaylit',
+  kbd: 'Адыгэбзэ (Къэбэрдэй)',
+  kk: 'Қазақ тілі',
+  km: 'km',
+  kmr: 'Kurdî (Kurmancî)',
+  ko: '한국어',
+  kpv: 'Коми кыв',
+  kw: 'Kernowek',
+  ky: 'Кыргызча',
+  lg: 'Luganda',
+  lij: 'Lìgure',
+  lt: 'Lietuvių',
+  lv: 'Latviešu',
+  mdf: 'Мокшень кяль',
+  mhr: 'Марий',
+  mk: 'Македонски',
+  ml: 'മലയാളം',
+  mn: 'Монгол хэл',
+  mni: 'ꯃꯤꯇꯩ ꯂꯣꯟ',
+  mr: 'मराठी',
+  mrj: 'Кырык мары',
+  ms: 'Bahasa Melayu',
+  mt: 'Malti',
+  my: 'ဗမာ',
+  myv: 'Эрзянь кель',
+  'nan-tw': '臺語',
+  'nb-NO': 'Norsk (bokmål)',
+  'ne-NP': 'नेपाली',
+  nia: 'nia',
+  nl: 'Nederlands',
+  'nn-NO': 'Norsk (nynorsk)',
+  nyn: 'nyn',
+  oc: 'Occitan',
+  or: 'ଓଡ଼ିଆ',
+  'pa-IN': 'ਪੰਜਾਬੀ',
+  'pap-AW': 'pap-AW',
+  pl: 'polski',
+  ps: 'ps',
+  pt: 'Português',
+  'rm-sursilv': 'romontsch sursilvan',
+  'rm-vallader': 'Rumantsch vallader',
+  ro: 'Română',
+  ru: 'Русский',
+  rw: 'Ikinyarwanda',
+  sah: 'Саха тыла',
+  sat: 'ᱥᱟᱱᱛᱟᱲᱤ (ᱚᱞ ᱪᱤᱠᱤ)',
+  sc: 'Sardu',
+  scn: 'Sicilianu',
+  si: 'සිංහල',
+  sk: 'slovenčina',
+  skr: 'سرائیکی',
+  sl: 'slovenščina',
+  sq: 'Shqip',
+  sr: 'Српски',
+  'sv-SE': 'Svenska',
+  sw: 'Kiswahili',
+  syr: 'ܣܘܼܪܝܝܐ',
+  ta: 'தமிழ்',
+  te: 'తెలుగు',
+  tg: 'Тоҷикӣ',
+  th: 'ไทย',
+  ti: 'ትግርኛ',
+  tig: 'ትግረይት',
+  tk: 'Türkmençe',
+  tl: 'Tagalog',
+  tok: 'toki pona',
+  tr: 'Türkçe',
+  tt: 'Татар',
+  ug: 'ئۇيغۇرچە',
+  uk: 'Українська',
+  ur: 'اردو',
+  uz: 'O‘zbek',
+  vec: 'Vèneto',
+  vi: 'Việt',
+  vot: 'vad̕d̕a',
+  yue: '粵語',
+  'zh-CN': '汉语（中国大陆）',
+  'zh-HK': '中文（香港）',
+  'zh-TW': '華語（台灣）',
+};
+
+interface INativeNames {
+  [key: string]: any;
+}
+
+const RTL = [
+  'ar',
+  'ckb',
+  'dv',
+  'dyu',
+  'fa',
+  'he',
+  'ps',
+  'skr',
+  'syr',
+  'ug',
+  'ur',
+];
+
+export const up = async function (db: any): Promise<any> {
+  const getLanguagesQuery = await db.runSql(`
+      SELECT l.id, l.name, l.target_sentence_count as target_sentence_count, count(1) as total_sentence_count
+      FROM locales l
+      JOIN sentences s ON s.locale_id = l.id
+      GROUP BY l.id
+    `);
+
+  const getLanguages: INativeNames = getLanguagesQuery.reduce(
+    (obj: any, row: any) => {
+      obj[row.name] = {
+        id: row.id,
+        name: row.name,
+        isContributable: row.total_sentence_count >= row.target_sentence_count,
+      };
+      return obj;
+    },
+    {}
+  );
+
+  await Promise.all([
+    Object.keys(getLanguages).map(languageCode => {
+      if (getLanguages[languageCode].isContributable) {
+        return db.runSql(`
+        UPDATE locales
+        SET isContributable = TRUE,
+         text_direction = ${RTL.includes(languageCode) ? "'RTL'" : "'LTR'"},
+         native_name = "${
+           NATIVE_NAMES[languageCode] ? NATIVE_NAMES[languageCode] : 'NULL'
+         }"
+        WHERE name = "${languageCode}"
+    `);
+      } else {
+        console.log(languageCode);
+      }
+    }),
+  ]);
+};
+
+export const down = function (): Promise<any> {
+  return null;
+};

--- a/web/locales/mrj/messages.ftl
+++ b/web/locales/mrj/messages.ftl
@@ -411,7 +411,9 @@ mycroft-title = Mycroft Ai
 
 data-download-yes = Ане
 data-download-deny = Уке
+data-download-license = Лицензи: <licenseLink>CC-0</licenseLink>
 release-version = Верси
+license = Лицензи: <licenseLink>{ $license }</licenseLink>
 terms-agree = Келшем
 terms-disagree = Ам келшӹ
 review-submit-title = Анжалаш дӓ колташ
@@ -420,6 +422,7 @@ review-recording = Анжен лӓктӓш
 ## Datasets Page
 
 language = Йӹлмӹ
+cv-license = Лицензи
 size-gigabyte = ГБ
 size-megabyte = МБ
 data-other-ted-name = TED-LIUM корпус

--- a/web/locales/mrj/messages.ftl
+++ b/web/locales/mrj/messages.ftl
@@ -444,6 +444,8 @@ contact-required = *обязательный
 
 ## Request Language Modal
 
+request-language-form-language =
+    .label = Йӹлмӹ
 
 ## Request Language Pages
 
@@ -524,6 +526,7 @@ download-request-link-text = Zip #{ $offset } / { $total }
 
 card-button-back = Шайык
 demo-eofy-header = 2019 и мычашты релиз
+demo-account = Аккаунт
 
 ## Demo Account
 


### PR DESCRIPTION
Continue work to refactor how the platform uses language metadata, replacing static .json files and moving all data into the database. Includes:
- Add language metadata to database via migrations
- Add language metadata to queries as needed (and return data via endpoints)
- Update startup scripts to now update database instead of locales files
- Update frontend to make use of new API data
