### PR TITLE
Ensure contributable langs are translated if exist before

### DIFF
--- a/server/src/lib/model/db/import-locales.ts
+++ b/server/src/lib/model/db/import-locales.ts
@@ -117,14 +117,23 @@ export async function importLocales() {
     }, {});
 
     const newLanguageData = locales.reduce((obj, language) => {
-      const isTranslated = language.translated >= TRANSLATED_MIN_PROGRESS;
-      const hasEnoughSentences =
-        allLanguages[language.code]?.hasEnoughSentences || false;
-      const is_contributable = languagesWithClips[language.code]
+      //if a lang has clips, consider it translated
+      const isTranslated = languagesWithClips[language.code]
         ? 1
-        : isTranslated && hasEnoughSentences
+        : language.translated >= TRANSLATED_MIN_PROGRESS //no previous clips, check if criteria met
         ? 1
         : 0;
+
+      const hasEnoughSentences =
+        allLanguages[language.code]?.hasEnoughSentences || false;
+
+      //if a lang has clips, consider it contributable
+      const is_contributable = languagesWithClips[language.code]
+        ? 1
+        : isTranslated && hasEnoughSentences // no prev clips, check translated and enough sentences
+        ? 1
+        : 0;
+
       obj[language.code] = {
         ...language,
         target_sentence_count:


### PR DESCRIPTION
Even if a language's translation % is less than the cut off, ensure the language remains contributable if it has clips previously submitted.