### PR TITLE
update buttons in cv-tab-content to be able to fit its content

### DIFF
--- a/web/src/components/pages/about/playbook.css
+++ b/web/src/components/pages/about/playbook.css
@@ -103,12 +103,13 @@
             margin-top: 1rem;
             text-transform: uppercase;
             font-weight: 600;
-            display: inline-block;
+            display: inline-flex;
             line-height: 1.5rem;
             padding: 0.75rem 1rem 0.75rem 2rem;
             border-color: var(--blue);
             background: var(--blue);
             color: var(--white);
+            height: auto;
 
             svg {
                 float: right;


### PR DESCRIPTION
## Pull Request Form

<!-- Thanks for making a contribution to Common Voice, to help us review the request please fill out this form -->

### Type of Pull Request

<!-- To help us understand your pull request, choose the checkboxes most relevant to your request by filling out the checkboxes with [x] here -->

- [ ] Bulk sentence upload 

<!--- Please ensure your sentences are licensed under CC0 before making a submission. Learn how you can do this via our Playbook https://common-voice.github.io/community-playbook/sub_pages/cc0waiver_process.html -->

- [x] Related to a listed issue 

<!--- Please link the issues related to your PR Request -->

* Fixes #3635 

- [ ] Other

<!--- Please describe the pull request-->

* The content should now fit and display correctly without clipping. However, the height does dynamically change if the content within the button is long so I am not sure of the design direction of the buttons require a strict height.


### Acknowledging contributors

<!-- Please list who collaborated with you to make this contribution. Or Community dicussion that helped make this idea possible -->

* @robovoice1 for logging the bug
* @mozgzh for a good solution suggestion

