### PR TITLE
fix stats graph's tooltip layout of the metrics data

### DIFF
--- a/web/src/components/pages/home/stats.css
+++ b/web/src/components/pages/home/stats.css
@@ -150,14 +150,7 @@
 
     & .metrics {
         display: flex;
-        flex-direction: row;
-
-        & > * {
-            margin-inline-end: 30px;
-
-            &:last-child {
-                margin-inline-end: 0;
-            }
-        }
+        flex-direction: column;
+        align-items: center;
     }
 }


### PR DESCRIPTION
## Pull Request Form

### Type of Pull Request

- [ ] Bulk sentence upload 

- [x] Related to a listed issue 

* Fixes #3692 

- [ ] Other

* Adjust CSS of the tooltip in the Stats graph so that the metrics are laid out vertically and stays within the border.

### Acknowledging contributors

