### PR TITLE
Remove localization in spinner after package upgrade throws error

### DIFF
--- a/web/src/components/ui/ui.tsx
+++ b/web/src/components/ui/ui.tsx
@@ -207,7 +207,8 @@ export const Spinner = ({
   return (
     <div className={spinnerClassName}>
       <VisuallyHidden>
-        <Localized id="loading" />
+        {/* Issues with localizing here when used on app load, package changes throw error */}
+        <p> Loading... </p>
       </VisuallyHidden>
       <span className="spinner__shape" />
     </div>


### PR DESCRIPTION
Errors are no longer ignored when Localization component called outside `LanguagesProvider` component. As a result, since the `Spinner` is called early in the app (on app load) and before `LanguagesProvider` it throws an error.

Quick fix is to remove localization on `Spinner` and just hard-code "Loading" for screen readers. 
