### PR TITLE
Fix horizontal overflow in stats tooltip

### DIFF
--- a/web/src/components/pages/home/stats.css
+++ b/web/src/components/pages/home/stats.css
@@ -149,9 +149,6 @@
     }
 
     & .metrics {
-        display: flex;
-        flex-direction: row;
-
         & > * {
             margin-inline-end: 30px;
 


### PR DESCRIPTION
## Pull Request Form

The numbers corresponding to "Hours Recorded" and "Hours Validated" were positioned horizontally within the tooltip, causing the text to overflow outside of the tooltip bubble. We now use the default `display` styling for the containing `<div>`, which lays the metrics out vertically to avoid overflow.

<!-- Thanks for making a contribution to Common Voice, to help us review the request please fill out this form -->

### Type of Pull Request

<!-- To help us understand your pull request, choose the checkboxes most relevant to your request by filling out the checkboxes with [x] here -->

- [ ] Bulk sentence upload 

<!--- Please ensure your sentences are licensed under CC0 before making a submission. Learn how you can do this via our Playbook https://common-voice.github.io/community-playbook/sub_pages/cc0waiver_process.html -->

- [x] Related to a listed issue 

<!--- Please link the issues related to your PR Request -->

* https://github.com/common-voice/common-voice/issues/3816
* https://github.com/common-voice/common-voice/issues/3692

- [ ] Other

### Screenshots

![common-voice-fix-tooltip-overflow](https://user-images.githubusercontent.com/995051/192503225-6e121011-902e-48f4-a97d-57a00f100dfe.gif)


