### PR TITLE
Fix overlapping subtitle and paragraph text

### DIFF
--- a/web/src/components/pages/about/playbook.css
+++ b/web/src/components/pages/about/playbook.css
@@ -96,7 +96,7 @@
         }
 
         .tab-subtitle {
-            margin-bottom: -1rem;
+            margin-bottom: 1rem;
         }
 
         .button {


### PR DESCRIPTION
## Pull Request Form

Elements of class `tab-subtitle` had `margin-bottom: -1rem;`, causing overlap with the text below. We increase margin-bottom to prevent overlap.

The affected part of the site is located at https://commonvoice.mozilla.org/en/about?tab=how-grow-language#playbook.

<!-- Thanks for making a contribution to Common Voice, to help us review the request please fill out this form -->

### Type of Pull Request

<!-- To help us understand your pull request, choose the checkboxes most relevant to your request by filling out the checkboxes with [x] here -->

- [ ] Bulk sentence upload 

<!--- Please ensure your sentences are licensed under CC0 before making a submission. Learn how you can do this via our Playbook https://common-voice.github.io/community-playbook/sub_pages/cc0waiver_process.html -->

- [x] Related to a listed issue 

<!--- Please link the issues related to your PR Request -->

* https://github.com/common-voice/common-voice/issues/3801

- [ ] Other

### Screenshots

![common-voice-fix-subtitle-margin](https://user-images.githubusercontent.com/995051/192513080-9b0baf9c-7698-4058-9c8b-19bf27f4cc5f.png)
