### PR TITLE
OI-2492

### DIFF
--- a/web/locales/en/messages.ftl
+++ b/web/locales/en/messages.ftl
@@ -414,6 +414,7 @@ why-demographic = Why does this matter?
 why-demographic-explanation-2 = Anonymized user data like age, gender, and accent helps improve the audio data used to train the accuracy of speech recognition engines. Your username and email will never be associated with your submitted data, and you can choose whether to make your username public or anonymous.
 accept-privacy = I'm okay with you handling this info as you explain in Mozilla's <privacyLink>Privacy Policy</privacyLink>
 accept-privacy-title = Privacy Policy
+accept-privacy-and-terms = I agree to Common Voice's <termsLink>Terms</termsLink> and <privacyLink>Privacy Notice</privacyLink>
 login-identity = Login Identity
 login-signup = Log In / Sign Up
 edit = Edit

--- a/web/src/components/pages/contribution/contribution.css
+++ b/web/src/components/pages/contribution/contribution.css
@@ -677,6 +677,10 @@
             margin: 2em 0;
             width: 60%;
             text-align: center;
+
+            a {
+                color: var(--anchor-text-blue);
+            }
         }
     }
 }

--- a/web/src/components/pages/contribution/contribution.css
+++ b/web/src/components/pages/contribution/contribution.css
@@ -667,6 +667,18 @@
             margin-top: 5px;
         }
     }
+
+    .contribution-speak-form {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+
+        .labeled-checkbox {
+            margin: 2em 0;
+            width: 60%;
+            text-align: center;
+        }
+    }
 }
 
 .shortcuts-modal {

--- a/web/src/components/pages/contribution/contribution.tsx
+++ b/web/src/components/pages/contribution/contribution.tsx
@@ -37,8 +37,6 @@ import Wave from './wave';
 
 import './contribution.css';
 
-const HAS_SEEN_ACCOUNT_MODAL_KEY = 'hasSeenAccountModal2';
-
 export const SET_COUNT = 5;
 
 export interface ContributionPillProps {
@@ -72,8 +70,8 @@ interface Props extends WithLocalizationProps, PropsFromState {
   onReset: () => any;
   onSkip: () => any;
   onSubmit?: () => any;
-  onPrivacyAgreedChange: (privacyAgreed: boolean) => void;
-  privacyAgreedChecked: boolean;
+  onPrivacyAgreedChange?: (privacyAgreed: boolean) => void;
+  privacyAgreedChecked?: boolean;
   primaryButtons: React.ReactNode;
   pills: ((props: ContributionPillProps) => React.ReactNode)[];
   sentences: Sentence[];

--- a/web/src/components/pages/contribution/contribution.tsx
+++ b/web/src/components/pages/contribution/contribution.tsx
@@ -13,22 +13,19 @@ import { User } from '../../../stores/user';
 import { Sentence } from 'common';
 import {
   trackListening,
-  trackProfile,
   trackRecording,
   getTrackClass,
 } from '../../../services/tracker';
 import URLS from '../../../urls';
-import { LocaleLink, LocaleNavLink, useLocale } from '../../locale-helpers';
-import Modal, { ModalProps } from '../../modal/modal';
+import { LocaleLink, LocaleNavLink } from '../../locale-helpers';
+import Modal from '../../modal/modal';
 import {
   ArrowLeft,
-  CheckIcon,
   KeyboardIcon,
-  ShareIcon,
   SkipIcon,
   ExternalLinkIcon,
 } from '../../ui/icons';
-import { Button, StyledLink, LinkButton, LabeledCheckbox } from '../../ui/ui';
+import { Button, StyledLink, LabeledCheckbox } from '../../ui/ui';
 import { PrimaryButton } from '../../primary-buttons/primary-buttons';
 import ShareModal from '../../share-modal/share-modal';
 import { ReportButton, ReportModal, ReportModalProps } from './report/report';
@@ -513,7 +510,16 @@ class ContributionPage extends React.Component<Props, State> {
               <form onSubmit={onSubmit} className="contribution-speak-form">
                 {this.isDone && (
                   <LabeledCheckbox
-                    label="I agree to Common Voice's Terms and Privacy Notice"
+                    label={
+                      <Localized
+                        id="accept-privacy-and-terms"
+                        elems={{
+                          termsLink: <LocaleLink to={URLS.TERMS} blank />,
+                          privacyLink: <LocaleLink to={URLS.PRIVACY} blank />,
+                        }}>
+                        <span />
+                      </Localized>
+                    }
                     required
                     onChange={handlePrivacyAgreedChange}
                     checked={privacyAgreedChecked}

--- a/web/src/components/pages/contribution/pill.css
+++ b/web/src/components/pages/contribution/pill.css
@@ -98,8 +98,8 @@
     }
 
     &.open {
-        width: 100%;
-        justify-content: flex-end;
+        justify-content: space-evenly;
+        width: 200px;
 
         @media (--sm-down) {
             width: auto;
@@ -111,7 +111,7 @@
 
         & .num {
             border: solid 1px #f5f4f3;
-            margin: 7px;
+            margin: 7px 15px 7px 7px;
             background: var(--desert-storm);
 
             @media (--md-up) {

--- a/web/src/components/pages/contribution/pill.css
+++ b/web/src/components/pages/contribution/pill.css
@@ -73,7 +73,7 @@
 
         @media (--md-up) {
             border: none;
-            padding-inline-start: 12px;
+            padding-inline-start: 6px;
             width: 85%;
 
             &.closed {
@@ -98,8 +98,8 @@
     }
 
     &.open {
-        justify-content: space-evenly;
-        width: 200px;
+        justify-content: space-between;
+        width: 175px;
 
         @media (--sm-down) {
             width: auto;

--- a/web/src/components/pages/contribution/pill.css
+++ b/web/src/components/pages/contribution/pill.css
@@ -73,7 +73,8 @@
 
         @media (--md-up) {
             border: none;
-            padding-inline-start: 6px;
+            padding-inline-start: 12px;
+            width: 85%;
 
             &.closed {
                 padding-inline-start: 0;
@@ -97,6 +98,7 @@
     }
 
     &.open {
+        width: 100%;
         justify-content: flex-end;
 
         @media (--sm-down) {

--- a/web/src/components/pages/contribution/speak/recording-pill.css
+++ b/web/src/components/pages/contribution/speak/recording-pill.css
@@ -47,6 +47,6 @@
     }
 
     & .placeholder {
-        width: 110px;
+        width: 55px;
     }
 }

--- a/web/src/components/pages/contribution/speak/recording-pill.css
+++ b/web/src/components/pages/contribution/speak/recording-pill.css
@@ -21,7 +21,6 @@
 
     & .padder {
         display: inline-block;
-        border-inline-start: 1px solid var(--desert-storm);
         padding: 0 16px;
     }
 

--- a/web/src/components/pages/contribution/speak/recording-pill.tsx
+++ b/web/src/components/pages/contribution/speak/recording-pill.tsx
@@ -99,13 +99,6 @@ function RecordingPill({
                   </span>
                 </button>
               </Tooltip>
-              <Tooltip arrow title={getString('share-clip')}>
-                <button className="share" type="button" onClick={onShare}>
-                  <span className="padder">
-                    <ShareIcon />
-                  </span>
-                </button>
-              </Tooltip>
             </>
           )}
         </>

--- a/web/src/components/pages/contribution/speak/speak.tsx
+++ b/web/src/components/pages/contribution/speak/speak.tsx
@@ -83,6 +83,7 @@ interface State {
   rerecordIndex?: number;
   showPrivacyModal: boolean;
   showDiscardModal: boolean;
+  privacyAgreedChecked?: boolean;
 }
 
 const initialState: State = {
@@ -96,7 +97,13 @@ const initialState: State = {
 };
 
 class SpeakPage extends React.Component<Props, State> {
-  state: State = initialState;
+  state: State = {
+    ...initialState,
+    privacyAgreedChecked: Boolean(
+      this.props.user.privacyAgreed || this.props.user.account
+    ),
+  };
+
   demoMode = this.props.location.pathname.includes(URLS.DEMO);
 
   audio: AudioWeb;
@@ -354,7 +361,7 @@ class SpeakPage extends React.Component<Props, State> {
     });
   };
 
-  private upload = (hasAgreed: boolean = false) => {
+  private upload = (hasAgreed = false) => {
     const {
       addAchievement,
       addNotification,
@@ -475,8 +482,14 @@ class SpeakPage extends React.Component<Props, State> {
 
   private agreeToTerms = async () => {
     this.setState({ showPrivacyModal: false });
+    this.setState({ privacyAgreedChecked: true });
     this.props.updateUser({ privacyAgreed: true });
     this.upload(true);
+  };
+
+  private onPrivacyAgreedChange = (privacyAgreed: boolean) => {
+    this.setState({ privacyAgreedChecked: privacyAgreed });
+    this.props.updateUser({ privacyAgreed });
   };
 
   private toggleDiscardModal = () => {
@@ -561,7 +574,7 @@ class SpeakPage extends React.Component<Props, State> {
           )}
           {showPrivacyModal && (
             <TermsModal
-              onAgree={this.agreeToTerms}
+              onAgree={() => this.agreeToTerms()}
               onDisagree={this.toggleDiscardModal}
             />
           )}
@@ -637,6 +650,10 @@ class SpeakPage extends React.Component<Props, State> {
             onReset={() => this.resetState()}
             onSkip={this.handleSkip}
             onSubmit={() => this.upload()}
+            onPrivacyAgreedChange={(privacyAgreed: boolean) =>
+              this.onPrivacyAgreedChange(privacyAgreed)
+            }
+            privacyAgreedChecked={this.state.privacyAgreedChecked}
             primaryButtons={
               <RecordButton
                 trackClass="speak-record"


### PR DESCRIPTION
## OI-2492 Metadata expansion on Speak UI individual clips

- Adds a check box for accepting terms and privacy before submitting. Previously, this was done via a modal - the modal is still visible when the user tries to abort before uploading 5 clips
- Remove the share button from the recording pill


https://user-images.githubusercontent.com/113194143/199770020-ac38bc92-9a42-4ebe-8e64-da5f8ab6e7c1.mov