### PR TITLE
Oi 2532 dataset download links to old versions have permission denied error

### DIFF
--- a/server/src/lib/model/db/migrations/20221209022521-enable-dataset-downloads.ts
+++ b/server/src/lib/model/db/migrations/20221209022521-enable-dataset-downloads.ts
@@ -1,0 +1,21 @@
+export const up = async function (db: any): Promise<any> {
+  await db.runSql(`
+    UPDATE datasets
+    SET is_deprecated = 0
+    WHERE release_dir in (
+      'cv-corpus-1',
+      'cv-corpus-2', 
+      'cv-corpus-3',
+      'cv-corpus-4-2019-12-10',
+      'cv-corpus-5.1-2020-06-22',
+      'cv-corpus-6.1-2020-12-11',   
+      'cv-corpus-7.0-2021-07-21',
+      'cv-corpus-8.0-2022-01-19',
+      'cv-corpus-9.0-2022-04-27'
+      )
+  `);
+};
+
+export const down = function (): Promise<any> {
+  return null;
+};

--- a/web/src/components/pages/datasets/dataset-corpus-download.tsx
+++ b/web/src/components/pages/datasets/dataset-corpus-download.tsx
@@ -60,10 +60,7 @@ const DatasetCorpusDownload = ({
 
     api.getLanguageDatasetStats(locale).then(data => {
       setLanguageDatasets(
-        data.filter(
-          (dataset: LanguageDatasets) =>
-            !!dataset.checksum && !!dataset.download_path
-        )
+        data.filter((dataset: LanguageDatasets) => !!dataset.download_path)
       );
       setSelectedDataset(data[0]);
       setIsLoading(false);


### PR DESCRIPTION
Enable older datasets to be displayed and downloaded on frontend. This will allow users to download any previously released dataset. 