### PR TITLE
Expand the stats API so users can query by year 

### DIFF
--- a/common/statistics.ts
+++ b/common/statistics.ts
@@ -1,0 +1,9 @@
+export type Filters = 'rejected' | 'hasEmail';
+
+export type QueryOptions = {
+    groupByColumn?: string;
+    isDistinct?: boolean;
+    isDuplicate?: boolean;
+    filter?: Filters;
+    year?: number;
+  };

--- a/docs/API/statistics.md
+++ b/docs/API/statistics.md
@@ -54,7 +54,7 @@ GET `/api/v1/statistics/sentences` HTTP/1.1
 
 Filter by all sentences that have been read (a clip exists) multiple times:
 
-`?filter=duplicate`
+`?isDuplicate=true`
 
 ### Structure of response
 

--- a/docs/API/statistics.md
+++ b/docs/API/statistics.md
@@ -1,6 +1,6 @@
 # Statistics
 
-All statistics provide the increase in metrics over a 12 month period in monthly intervals.
+All statistics provide the increase in metrics for a given year in monthly intervals.
 
 ## How statistics are calculated
 
@@ -11,7 +11,7 @@ All statistics provide the increase in metrics over a 12 month period in monthly
 
 ## Endpoints
 
-Statistics endpoints are accessed at `/api/v1/statistics/<stat name>`
+Statistics endpoints are accessed at `/api/v1/statistics/<stat name>`. All endpoints can be queried by year, e.g. `?year=2022`. By default each endpoint returns the statistics for the current year. Where applicable, it can also be combined with other options, e.g. `?filter=rejected&year=2022`.
 
 ### Downloads
 
@@ -35,6 +35,9 @@ Filter by only the rejected clips by using query parameter:
 All unique speaker contributors:
 
 GET `/api/v1/statistics/speakers` HTTP/1.1
+
+#### Note:
+The number of unique speaker contributors is based on the given year. For example, a person who contributed in 2021 and 2022 will show up as a unique contributor in both time periods but will be counted only once for the time independent `total_count`.
 
 ### Accounts
 
@@ -65,15 +68,15 @@ Content-Type: application/json; charset=utf-8
   "total_count": 109,
   "monthly_increase": {
     "2022-10-26": 3,
-    "2022-7-21": 2,
-    "2022-6-14": 4,
-    "2022-5-13": 2
+    "2022-07-21": 2,
+    "2022-06-14": 4,
+    "2022-05-13": 2
   },
   "monthly_running_totals": {
     "2022-10-26": 11,
-    "2022-7-21": 8,
-    "2022-6-14": 6,
-    "2022-5-13": 2
+    "2022-07-21": 8,
+    "2022-06-14": 6,
+    "2022-05-13": 2
   },
   "metadata": { "last_fetched": "2022-10-26T12:59:56.397Z" }
 }
@@ -83,8 +86,9 @@ Content-Type: application/json; charset=utf-8
 
 `monthly_running_totals` represents the running total of statistics (total existing value + current month value).
 
-`yearly_sum` represents the sum of all monthly increases for the past 12 months
-`total_count` represents total count of all that values in the database (Not dependant on time)
+`yearly_sum` represents the sum of all monthly increases for the given year.
+
+`total_count` represents the total count of all the values in the database (not dependent on time).
 
 ## Implementation Details
 

--- a/server/src/lib/model/statistics.ts
+++ b/server/src/lib/model/statistics.ts
@@ -1,6 +1,7 @@
 import lazyCache from '../lazy-cache';
 import { getMySQLInstance } from './db/mysql';
-import { TableNames, TimeUnits } from 'common';
+import { QueryOptions, TableNames, TimeUnits } from 'common';
+
 const db = getMySQLInstance();
 
 type StatisticsCount = {
@@ -11,16 +12,6 @@ type StatisticsCount = {
 const FILTERS = {
   rejected: 'is_valid = false',
   hasEmail: 'email IS NOT null',
-};
-
-type Filters = 'rejected' | 'hasEmail';
-
-export type QueryOptions = {
-  groupByColumn?: string;
-  isDistinct?: boolean;
-  isDuplicate?: boolean;
-  filter?: Filters;
-  year?: number;
 };
 
 /**
@@ -57,10 +48,12 @@ const queryStatistics = async (
     monthlyIncrease = await getMonthlyContributions(tableName, options);
     totalCount = await getTotal(tableName, options);
   }
+
   const yearlySum = monthlyIncrease.reduce(
     (total: number, row) => (total += row.total_count),
     0
   );
+  
   totalCount = totalCount.total_count;
 
   return { yearlySum, totalCount, monthlyIncrease };

--- a/server/src/lib/model/statistics.ts
+++ b/server/src/lib/model/statistics.ts
@@ -20,7 +20,7 @@ export type QueryOptions = {
   isDistinct?: boolean;
   isDuplicate?: boolean;
   filter?: Filters;
-  year?: string;
+  year?: number;
 };
 
 /**
@@ -40,7 +40,7 @@ const queryStatistics = async (
 ) => {
   const isDistinct = options?.isDistinct ?? false;
   const isDuplicate = options?.isDuplicate ?? false;
-  const year = options?.year ?? String(new Date().getFullYear());
+  const year = options?.year ?? new Date().getFullYear();
   options = { ...options, year };
   let monthlyIncrease, totalCount;
 
@@ -128,10 +128,10 @@ const getUniqueMonthlyContributions = async (
    FROM
     (
       SELECT * 
-      FROM ${tableName} d GROUP BY ${groupByColumn}
+      FROM ${tableName} d 
+      WHERE YEAR(created_at) = ${options.year}
+      GROUP BY ${groupByColumn}
     ) d
-    WHERE
-      YEAR(created_at) = ${options.year}
     GROUP BY
       DATE_FORMAT(created_at, "%Y-%m")
     ORDER BY created_at DESC;

--- a/server/src/lib/model/statistics.ts
+++ b/server/src/lib/model/statistics.ts
@@ -15,11 +15,12 @@ const FILTERS = {
 
 type Filters = 'rejected' | 'hasEmail';
 
-type QueryOptions = {
+export type QueryOptions = {
   groupByColumn?: string;
   isDistinct?: boolean;
   isDuplicate?: boolean;
   filter?: Filters;
+  year?: string;
 };
 
 /**
@@ -39,6 +40,8 @@ const queryStatistics = async (
 ) => {
   const isDistinct = options?.isDistinct ?? false;
   const isDuplicate = options?.isDuplicate ?? false;
+  const year = options?.year ?? String(new Date().getFullYear());
+  options = { ...options, year };
   let monthlyIncrease, totalCount;
 
   if (isDistinct) {
@@ -47,7 +50,7 @@ const queryStatistics = async (
     totalCount = await getUniqueSpeakersTotal();
   } else if (isDuplicate) {
     // Specific query flow since logic is more complicated
-    monthlyIncrease = await getMonthlyDuplicateSentences();
+    monthlyIncrease = await getMonthlyDuplicateSentences(options);
     totalCount = await getTotalDuplicateSentences();
   } else {
     // Simple queries
@@ -92,22 +95,22 @@ const formatStatistics = async (
 
 const getMonthlyContributions = async (
   tableName: TableNames,
-  options?: QueryOptions
+  options: QueryOptions
 ): Promise<StatisticsCount[]> => {
   const filter = options?.filter;
   const conditional = filter && FILTERS[filter];
 
   const [rows] = await db.query(`
     SELECT
-      MAX(DATE_FORMAT(created_at, "%Y-%c-%d")) as date,
+      MAX(DATE_FORMAT(created_at, "%Y-%m-%d")) as date,
       COUNT(created_at) as total_count
     FROM
       ${tableName} d
     WHERE
-      created_at > now() - INTERVAL 12 MONTH
+      YEAR(created_at) = ${options.year}
       ${conditional ? 'AND ' + conditional : ''}
     GROUP BY
-      DATE_FORMAT(created_at, "%Y-%c")
+      DATE_FORMAT(created_at, "%Y-%m")
     ORDER BY created_at DESC;
   `);
   return rows;
@@ -120,7 +123,7 @@ const getUniqueMonthlyContributions = async (
   const { groupByColumn } = options;
   const [rows] = await db.query(`
   SELECT
-      MAX(DATE_FORMAT(created_at, "%Y-%c-%d")) as date,
+      MAX(DATE_FORMAT(created_at, "%Y-%m-%d")) as date,
       COUNT(created_at) as total_count
    FROM
     (
@@ -128,18 +131,20 @@ const getUniqueMonthlyContributions = async (
       FROM ${tableName} d GROUP BY ${groupByColumn}
     ) d
     WHERE
-      created_at > now() - INTERVAL 12 MONTH
+      YEAR(created_at) = ${options.year}
     GROUP BY
-      DATE_FORMAT(created_at, "%Y-%c")
+      DATE_FORMAT(created_at, "%Y-%m")
     ORDER BY created_at DESC;
   `);
   return rows;
 };
 
-const getMonthlyDuplicateSentences = async (): Promise<StatisticsCount[]> => {
+const getMonthlyDuplicateSentences = async (
+  options: QueryOptions
+): Promise<StatisticsCount[]> => {
   const [rows] = await db.query(`
     SELECT
-      MAX(DATE_FORMAT(created_at, "%Y-%c-%d")) as date,
+      MAX(DATE_FORMAT(created_at, "%Y-%m-%d")) as date,
       COUNT(created_at) as total_count
     FROM
       (
@@ -154,9 +159,9 @@ const getMonthlyDuplicateSentences = async (): Promise<StatisticsCount[]> => {
         sentenceCount > 1
         ) d
     WHERE
-      created_at > now() - INTERVAL 12 MONTH
+      YEAR(created_at) = ${options.year}
     GROUP BY
-      DATE_FORMAT(created_at, "%Y-%c")
+      DATE_FORMAT(created_at, "%Y-%m")
     ORDER BY
       created_at DESC;
   `);

--- a/server/src/lib/statistics.ts
+++ b/server/src/lib/statistics.ts
@@ -1,8 +1,8 @@
 import { Request, Response } from 'express';
 import PromiseRouter from 'express-promise-router';
 import Model from './model';
-import { getStatistics, QueryOptions } from './model/statistics';
-import { TableNames } from 'common';
+import { getStatistics } from './model/statistics';
+import { QueryOptions, TableNames } from 'common';
 import {
   accountStatSchema,
   clipStatSchema,
@@ -84,11 +84,6 @@ export default class Statistics {
 
   sentenceCount = async (request: Request, response: Response) => {
     const options = request.query as QueryOptions;
-
-    if (typeof request.query.filter === 'string') {
-      delete options['filter'];
-      options['isDuplicate'] = true;
-    }
 
     return response.json(
       await getStatistics(TableNames.SENTENCES, options)

--- a/server/src/lib/statistics.ts
+++ b/server/src/lib/statistics.ts
@@ -3,7 +3,13 @@ import PromiseRouter from 'express-promise-router';
 import Model from './model';
 import { getStatistics } from './model/statistics';
 import { TableNames } from 'common';
-import { clipStatScehma, sentenceStatScehma } from './validation/statistics';
+import {
+  accountStatSchema,
+  clipStatSchema,
+  downloadStatSchema,
+  sentenceStatSchema,
+  speakerStatSchema,
+} from './validation/statistics';
 import validate from './validation';
 
 /**
@@ -19,13 +25,25 @@ export default class Statistics {
   getRouter() {
     const router = PromiseRouter();
 
-    router.get('/downloads', this.downloadCount);
-    router.get('/clips', validate({ query: clipStatScehma }), this.clipCount);
-    router.get('/speakers', this.uniqueSpeakers);
-    router.get('/accounts', this.accountCount);
+    router.get('/clips', validate({ query: clipStatSchema }), this.clipCount);
+    router.get(
+      '/downloads',
+      validate({ query: downloadStatSchema }),
+      this.downloadCount
+    );
+    router.get(
+      '/speakers',
+      validate({ query: speakerStatSchema }),
+      this.uniqueSpeakers
+    );
+    router.get(
+      '/accounts',
+      validate({ query: accountStatSchema }),
+      this.accountCount
+    );
     router.get(
       '/sentences',
-      validate({ query: sentenceStatScehma }),
+      validate({ query: sentenceStatSchema }),
       this.sentenceCount
     );
 

--- a/server/src/lib/validation/statistics.ts
+++ b/server/src/lib/validation/statistics.ts
@@ -46,9 +46,8 @@ export const clipStatSchema: AllowedSchema = {
 export const sentenceStatSchema: AllowedSchema = {
   type: 'object',
   properties: {
-    filter: {
-      type: 'string',
-      enum: ['duplicate'],
+    isDuplicate: {
+      type: 'boolean'
     },
     ...yearStatSchema
   },

--- a/server/src/lib/validation/statistics.ts
+++ b/server/src/lib/validation/statistics.ts
@@ -5,8 +5,9 @@ const yearStatSchema: {
   [k: string]: JSONSchema4
 } = {
   year: {
-    type: 'string',
-    pattern: '^[12][0-9]{3}$',
+    type: 'number',
+    minimum: 2016,
+    maximum: 2035
   },
 };
 

--- a/server/src/lib/validation/statistics.ts
+++ b/server/src/lib/validation/statistics.ts
@@ -1,21 +1,54 @@
 import { AllowedSchema } from 'express-json-validator-middleware';
+import { JSONSchema4 } from 'json-schema';
 
-export const clipStatScehma: AllowedSchema = {
+const yearStatSchema: {
+  [k: string]: JSONSchema4
+} = {
+  year: {
+    type: 'string',
+    pattern: '^[12][0-9]{3}$',
+  },
+};
+
+export const downloadStatSchema: AllowedSchema = {
+  type: 'object',
+  properties: {
+    ...yearStatSchema
+  },
+};
+
+export const speakerStatSchema: AllowedSchema = {
+  type: 'object',
+  properties: {
+    ...yearStatSchema
+  },
+};
+
+export const accountStatSchema: AllowedSchema = {
+  type: 'object',
+  properties: {
+    ...yearStatSchema
+  },
+};
+
+export const clipStatSchema: AllowedSchema = {
   type: 'object',
   properties: {
     filter: {
       type: 'string',
       enum: ['rejected'],
     },
+    ...yearStatSchema
   },
 };
 
-export const sentenceStatScehma: AllowedSchema = {
+export const sentenceStatSchema: AllowedSchema = {
   type: 'object',
   properties: {
     filter: {
       type: 'string',
       enum: ['duplicate'],
     },
+    ...yearStatSchema
   },
 };


### PR DESCRIPTION
All the stats endpoints can be queried by year now. The current year is used, if the `?year={year}` query parameter is omitted. The `year` query parameter can also be combined with existing query parameters, e.g:

GET `/api/v1/statistics/clips?filter=rejected&year=2021` HTTP/1.1

QA:
- Check the different stats endpoints, e.g. the one mentioned above, and compare whether the `yearly_sum` adds up to the `total_count`[^1]
- Use combined query parameters as well


[^1]: The `speakers` endpoint is the exception, refer to the [documentation](https://github.com/common-voice/common-voice/blob/main/docs/API/statistics.md) for more information