### PR TITLE
OI-2575: Add clips with metadata to stats api

### DIFF
--- a/common/statistics.ts
+++ b/common/statistics.ts
@@ -3,7 +3,6 @@ export type Filters = 'rejected' | 'hasEmail';
 export type QueryOptions = {
     filter?: Filters;
     groupByColumn?: string;
-    hasMetadata?: boolean;
     isDistinct?: boolean;
     isDuplicate?: boolean;
     year?: number;

--- a/common/statistics.ts
+++ b/common/statistics.ts
@@ -1,9 +1,10 @@
 export type Filters = 'rejected' | 'hasEmail';
 
 export type QueryOptions = {
+    filter?: Filters;
     groupByColumn?: string;
+    hasMetadata?: boolean;
     isDistinct?: boolean;
     isDuplicate?: boolean;
-    filter?: Filters;
     year?: number;
   };

--- a/docs/API/statistics.md
+++ b/docs/API/statistics.md
@@ -30,6 +30,38 @@ Filter by only the rejected clips by using query parameter:
 
 `?filter=rejected`
 
+### Metadata
+
+All clip contributions that contain metadata, e.g. age, gender, accents or variants. The response shows
+clips with metadata in comparison to all clips. The format is as follows: `[clips with metadata]/[all clips]`.
+
+GET `/api/v1/statistics/metadata` HTTP/1.1
+
+
+```json
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+{
+  "yearly_sum": "253/300",
+  "yearly_sum_coverage": 0.84,
+  "total_count": "990/1000",
+  "total_count_coverage": 0.99,
+  "monthly_increase": {
+    "2022-12": "78/100",
+    "2022-11": "80/100",
+    "2022-10": "95/100",
+  },
+  "monthly_increase_coverage": {
+    "2022-12": 0.78,
+    "2022-11": 0.8,
+    "2022-10": 0.95,
+  },
+  "metadata": {
+    "last_fetched": "2023-01-12T12:17:06.864Z"
+  }
+}
+```
+
 ### Speaker
 
 All unique speaker contributors:

--- a/server/src/lib/model/statistics.test.ts
+++ b/server/src/lib/model/statistics.test.ts
@@ -1,0 +1,146 @@
+import { formatMetadataStatistics, StatisticsCount } from './statistics';
+
+const table = [
+  {
+    title: 'Happy path, all data is present and dates are matching',
+    parameters: {
+      yearlySumMetadata: 90,
+      yearlySumClips: 100,
+      totalCountMetadata: 990,
+      totalCountClips: 1000,
+      monthlyIncreaseMetadata: [
+        { date: '2022-05', total_count: 7 },
+        { date: '2022-04', total_count: 2 },
+        { date: '2022-03', total_count: 8 },
+        { date: '2022-02', total_count: 9 },
+      ],
+      monthlyIncreaseClips: [
+        { date: '2022-05', total_count: 10 },
+        { date: '2022-04', total_count: 10 },
+        { date: '2022-03', total_count: 10 },
+        { date: '2022-02', total_count: 10 },
+      ],
+    },
+    expected: {
+      yearly_sum: '90/100',
+      yearly_sum_coverage: 0.9,
+      total_count: '990/1000',
+      total_count_coverage: 0.99,
+      monthly_increase: {
+        '2022-05': '7/10',
+        '2022-04': '2/10',
+        '2022-03': '8/10',
+        '2022-02': '9/10',
+      },
+      monthly_increase_coverage: {
+        '2022-05': 0.7,
+        '2022-04': 0.2,
+        '2022-03': 0.8,
+        '2022-02': 0.9,
+      },
+    },
+  },
+  {
+    title: 'Check when there no clips with metadata in one month',
+    parameters: {
+      yearlySumMetadata: 90,
+      yearlySumClips: 100,
+      totalCountMetadata: 990,
+      totalCountClips: 1000,
+      monthlyIncreaseMetadata: [
+        { date: '2022-04', total_count: 2 },
+        { date: '2022-03', total_count: 8 },
+        { date: '2022-02', total_count: 9 },
+      ],
+      monthlyIncreaseClips: [
+        { date: '2022-05', total_count: 10 },
+        { date: '2022-04', total_count: 10 },
+        { date: '2022-03', total_count: 10 },
+        { date: '2022-02', total_count: 10 },
+      ],
+    },
+    expected: {
+      yearly_sum: '90/100',
+      yearly_sum_coverage: 0.9,
+      total_count: '990/1000',
+      total_count_coverage: 0.99,
+      monthly_increase: {
+        '2022-05': '0/10',
+        '2022-04': '2/10',
+        '2022-03': '8/10',
+        '2022-02': '9/10',
+      },
+      monthly_increase_coverage: {
+        '2022-05': 0,
+        '2022-04': 0.2,
+        '2022-03': 0.8,
+        '2022-02': 0.9,
+      },
+    },
+  },
+  {
+    title: 'Check when there are no clips at all in a given year',
+    parameters: {
+      yearlySumMetadata: 0,
+      yearlySumClips: 0,
+      totalCountMetadata: 990,
+      totalCountClips: 1000,
+      monthlyIncreaseMetadata: [] as StatisticsCount[],
+      monthlyIncreaseClips: [] as StatisticsCount[],
+    },
+    expected: {
+      yearly_sum: '0/0',
+      yearly_sum_coverage: 0,
+      total_count: '990/1000',
+      total_count_coverage: 0.99,
+      monthly_increase: {},
+      monthly_increase_coverage: {},
+    },
+  },
+  {
+    title: 'Check when there are clips but no clips with metadata',
+    parameters: {
+      yearlySumMetadata: 0,
+      yearlySumClips: 100,
+      totalCountMetadata: 990,
+      totalCountClips: 1000,
+      monthlyIncreaseMetadata: [] as StatisticsCount[],
+      monthlyIncreaseClips: [
+        { date: '2022-05', total_count: 10 },
+        { date: '2022-04', total_count: 10 },
+      ],
+    },
+    expected: {
+      yearly_sum: '0/100',
+      yearly_sum_coverage: 0,
+      total_count: '990/1000',
+      total_count_coverage: 0.99,
+      monthly_increase: {
+        '2022-05': '0/10',
+        '2022-04': '0/10',
+      },
+      monthly_increase_coverage: {
+        '2022-05': 0,
+        '2022-04': 0,
+      },
+    },
+  },
+];
+
+describe('format metadata statistics', () => {
+  test.each(table)(
+    '$title',
+    ({ parameters, expected }) => {
+      expect(
+        formatMetadataStatistics(
+          parameters.yearlySumMetadata,
+          parameters.yearlySumClips,
+          parameters.totalCountMetadata,
+          parameters.totalCountClips,
+          parameters.monthlyIncreaseMetadata,
+          parameters.monthlyIncreaseClips
+        )    
+      ).toMatchObject(expected);
+    }
+  );
+});

--- a/server/src/lib/model/statistics.ts
+++ b/server/src/lib/model/statistics.ts
@@ -330,8 +330,7 @@ export const formatMetadataStatistics = (
 // an overlap with the clips endpoint.
 const getMetadataQueryHandlerImpl = async (
   table: TableNames,
-  options?: QueryOptions,
-  route = 'metadata'
+  options?: QueryOptions
 ) => {
   const year = getYearFromOptions(options);
   options = { ...options, year };
@@ -374,7 +373,7 @@ const getMetadataQueryHandlerImpl = async (
 };
 
 export const getMetadataQueryHandler = lazyCache(
-  'get-stats',
+  'get-stats-metadata',
   getMetadataQueryHandlerImpl,
   TimeUnits.DAY
 );

--- a/server/src/lib/model/statistics.ts
+++ b/server/src/lib/model/statistics.ts
@@ -3,17 +3,12 @@ import pick = require('lodash.pick');
 import lazyCache from '../lazy-cache';
 import { getMySQLInstance } from './db/mysql';
 import { QueryOptions, TableNames, TimeUnits } from 'common';
-import Table from './db/table';
 
 const db = getMySQLInstance();
 
 export type StatisticsCount = {
   total_count: number;
   date?: string;
-};
-
-type ClipsMetaDataCount = {
-  clips_metadata_count: number;
 };
 
 const FILTERS = {

--- a/server/src/lib/statistics.ts
+++ b/server/src/lib/statistics.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express';
 import PromiseRouter from 'express-promise-router';
 import Model from './model';
-import { getStatistics } from './model/statistics';
+import { getMetadataQueryHandler, getStatistics } from './model/statistics';
 import { QueryOptions, TableNames } from 'common';
 import {
   accountStatSchema,
@@ -9,6 +9,7 @@ import {
   downloadStatSchema,
   sentenceStatSchema,
   speakerStatSchema,
+  yearStatSchema,
 } from './validation/statistics';
 import validate from './validation';
 
@@ -26,6 +27,7 @@ export default class Statistics {
     const router = PromiseRouter();
 
     router.get('/clips', validate({ query: clipStatSchema }), this.clipCount);
+    router.get('/metadata', validate({ query: yearStatSchema }), this.getMetadata);
     router.get(
       '/downloads',
       validate({ query: downloadStatSchema }),
@@ -87,6 +89,14 @@ export default class Statistics {
 
     return response.json(
       await getStatistics(TableNames.SENTENCES, options)
+    );
+  };
+
+  getMetadata = async (request: Request, response: Response) => {
+    const options = request.query as QueryOptions;
+
+    return response.json(
+      await getMetadataQueryHandler(TableNames.CLIPS, options, 'metadata')
     );
   };
 }

--- a/server/src/lib/statistics.ts
+++ b/server/src/lib/statistics.ts
@@ -96,7 +96,7 @@ export default class Statistics {
     const options = request.query as QueryOptions;
 
     return response.json(
-      await getMetadataQueryHandler(TableNames.CLIPS, options, 'metadata')
+      await getMetadataQueryHandler(TableNames.CLIPS, options)
     );
   };
 }

--- a/server/src/lib/validation/statistics.ts
+++ b/server/src/lib/validation/statistics.ts
@@ -39,6 +39,9 @@ export const clipStatSchema: AllowedSchema = {
       type: 'string',
       enum: ['rejected'],
     },
+    hasMetadata: {
+      type: 'boolean'
+    },
     ...yearStatSchema
   },
 };

--- a/server/src/lib/validation/statistics.ts
+++ b/server/src/lib/validation/statistics.ts
@@ -1,7 +1,7 @@
 import { AllowedSchema } from 'express-json-validator-middleware';
 import { JSONSchema4 } from 'json-schema';
 
-const yearStatSchema: {
+export const yearStatSchema: {
   [k: string]: JSONSchema4
 } = {
   year: {
@@ -38,9 +38,6 @@ export const clipStatSchema: AllowedSchema = {
     filter: {
       type: 'string',
       enum: ['rejected'],
-    },
-    hasMetadata: {
-      type: 'boolean'
     },
     ...yearStatSchema
   },


### PR DESCRIPTION
There is a new stats API endpoint: `/api/v1/statistics/metadata`, that shows clips with metadata in comparison with all clips. This endpoint takes an optional `?year` query parameter as well, which can be used to filter by a given year.