### PR TITLE
Simplify custom-goal-steps messages to avoid unnecessary plurals

### DIFF
--- a/web/locales/en/messages.ftl
+++ b/web/locales/en/messages.ftl
@@ -1036,29 +1036,11 @@ want-to-continue = Do you want to continue?
 finish-editing = Finish editing first?
 lose-changes-warning = Leaving now means you’ll lose your changes
 build-custom-goal = Build a custom goal
-help-reach-hours-pluralized = Help reach { NUMBER($hours) ->
-[one] {$hours} hour
-*[other] {$hours} hours
- } in { $language } with a personal goal
-help-reach-hours-general-pluralized = Help Common Voice reach { NUMBER($hours) ->
-  [one] {$hours} hour
-  *[other] {$hours} hours
- } in a language with a personal goal
+help-reach-hours = Help reach { NUMBER(10000) } hours in { $language } with a personal goal
+help-reach-hours-general = Help Common Voice reach { NUMBER(10000) } hours in a language with a personal goal
 set-a-goal = Set a goal
 cant-decide = Can't decide?
-activity-needed-calculation-plural = { NUMBER($totalHours) ->
-  [one] {$totalHours} hour
-  *[other] {$totalHours} hours
- } is achievable in just over { NUMBER($periodMonths) ->
-  [one] {$periodMonths} month
-  *[other] {$periodMonths} months
- } if { NUMBER($people) ->
-  [one] {$people} person
-  *[other] {$people} people
-  } record { NUMBER($clipsPerDay) ->
-  [one] {$clipsPerDay} clip
-  *[other] {$clipsPerDay} clips
-  } a day.
+activity-needed-calculation = { NUMBER(10000) } hours is achievable in just over { NUMBER(6) } months if { NUMBER(1000) } people record { NUMBER(45) } clips a day.
 how-many-per-day = Great! How many clips per day?
 how-many-a-week = Great! How many clips a week?
 which-goal-type = Do you want to Speak, Listen or both?

--- a/web/src/components/pages/dashboard/goals/custom-goal-steps.tsx
+++ b/web/src/components/pages/dashboard/goals/custom-goal-steps.tsx
@@ -118,14 +118,9 @@ export default [
           </Localized>
           <Localized
             id={
-              dashboardLocale
-                ? 'help-reach-hours-pluralized'
-                : 'help-reach-hours-general-pluralized'
+              dashboardLocale ? 'help-reach-hours' : 'help-reach-hours-general'
             }
-            vars={{
-              hours: 10000,
-              language: getString(dashboardLocale),
-            }}>
+            vars={{ language: getString(dashboardLocale) }}>
             <span className="sub-head" />
           </Localized>
         </div>
@@ -194,14 +189,7 @@ export default [
           <Localized id="cant-decide">
             <h4 />
           </Localized>
-          <Localized
-            id="activity-needed-calculation-plural"
-            vars={{
-              totalHours: 10000,
-              periodMonths: 6,
-              people: 1000,
-              clipsPerDay: 45,
-            }}>
+          <Localized id="activity-needed-calculation">
             <p />
           </Localized>
         </div>


### PR DESCRIPTION
## Pull Request Form

### Type of Pull Request

- [ ] Bulk sentence upload 

- [x] Related to a listed issue 

* Fixes #3907

- [ ] Other

### Acknowledging contributors

* @eemeli

The updated messages use a different identifier, and wrap the numeric values as e.g. `{ NUMBER(1000) }` to simultaneously indicate to localisers that they ought to be maintained as exact values as well as taking care of formatting the numbers in a locale-appropriate manner.