### PR TITLE
staging-hotfix: Make join mailing list checkbox in the datasets page always visible

### DIFF
--- a/web/src/components/pages/datasets/dataset-corpus-download.tsx
+++ b/web/src/components/pages/datasets/dataset-corpus-download.tsx
@@ -21,7 +21,6 @@ import { DeltaReadMoreLink } from '../../shared/links';
 interface Props extends WithLocalizationProps {
   languagesWithDatasets: { id: number; name: string }[];
   initialLanguage: string;
-  isSubscribedToMailingList: boolean;
 }
 
 type LanguageDatasets = {
@@ -35,7 +34,6 @@ const DatasetCorpusDownload = ({
   getString,
   languagesWithDatasets,
   initialLanguage,
-  isSubscribedToMailingList,
 }: Props) => {
   const [isLoading, setIsLoading] = useState(true);
   const [selectedDataset, setSelectedDataset] = useState<LanguageDatasets>();
@@ -124,7 +122,6 @@ const DatasetCorpusDownload = ({
               releaseId={selectedDataset.id.toString()}
               checksum={selectedDataset.checksum}
               size={formatBytes(selectedDataset.size, initialLanguage)}
-              isSubscribedToMailingList={isSubscribedToMailingList}
             />
           )}
         </div>

--- a/web/src/components/pages/datasets/dataset-download-email-prompt.test.tsx
+++ b/web/src/components/pages/datasets/dataset-download-email-prompt.test.tsx
@@ -51,7 +51,6 @@ describe('DatasetDownloadEmailPrompt', () => {
           releaseId={selectedDataset.id.toString()}
           checksum={selectedDataset.checksum}
           size={selectedDataset.size}
-          isSubscribedToMailingList={false}
         />
       );
       const results = await axe(renderResult.container);
@@ -68,7 +67,6 @@ describe('DatasetDownloadEmailPrompt', () => {
           releaseId={selectedDataset.id.toString()}
           checksum={selectedDataset.checksum}
           size={selectedDataset.size}
-          isSubscribedToMailingList={false}
         />
       );
 
@@ -88,7 +86,6 @@ describe('DatasetDownloadEmailPrompt', () => {
           releaseId={selectedDataset.id.toString()}
           checksum={selectedDataset.checksum}
           size={selectedDataset.size}
-          isSubscribedToMailingList={false}
         />
       );
     });
@@ -108,7 +105,6 @@ describe('DatasetDownloadEmailPrompt', () => {
           releaseId={selectedDataset.id.toString()}
           checksum={selectedDataset.checksum}
           size={selectedDataset.size}
-          isSubscribedToMailingList={false}
         />
       );
 
@@ -157,68 +153,6 @@ describe('DatasetDownloadEmailPrompt', () => {
     );
   });
 
-  it('should allow download if user is subscribed to mailing list', async () => {
-    const {
-      getByRole,
-      queryByRole,
-      getByLabelText,
-      queryByLabelText,
-    }: RenderResult = renderWithLocalization(
-      <DatasetDownloadEmailPrompt
-        selectedLocale={locale}
-        downloadPath={selectedDataset.download_path}
-        releaseId={selectedDataset.id.toString()}
-        checksum={selectedDataset.checksum}
-        size={selectedDataset.size}
-        isSubscribedToMailingList
-      />
-    );
-
-    await act(async () => {
-      fireEvent.click(getByRole('button', { name: 'Enter Email to Download' }));
-    });
-
-    // check the download link is disabled
-    const disabledDownloadLink = queryByRole('link', {
-      name: /Enter Email to Download/,
-    });
-    expect(disabledDownloadLink).toBeNull(); // not exist as a link
-
-    // type in email address
-    userEvent.type(getByLabelText(/Email/), 'testemail@example.com');
-
-    // check the checkboxes
-    userEvent.click(
-      getByLabelText(/You are prepared to initiate a download of /)
-    );
-
-    userEvent.click(getByLabelText(/You agree to not attempt to determine/));
-
-    expect(
-      queryByLabelText(/I want to join the Common Voice mailing list/)
-    ).toBeNull();
-
-    // now has the link
-    const downloadLink = getByRole('button', {
-      name: /Download Dataset Bundle/,
-    });
-
-    expect(downloadLink.getAttribute('href')).toBe(
-      'https://example.com/fake/url'
-    );
-
-    // click link
-    fireEvent.click(downloadLink);
-
-    // calls api.saveHasDownloaded correctly
-    expect(mockSaveHasDownload).toBeCalledTimes(1);
-    expect(mockSaveHasDownload).toBeCalledWith(
-      'testemail@example.com',
-      'en',
-      '1'
-    );
-  });
-
   it('should still allow download if user decides not to join mailing list', async () => {
     const { getByRole, queryByRole, getByLabelText }: RenderResult =
       renderWithLocalization(
@@ -228,7 +162,6 @@ describe('DatasetDownloadEmailPrompt', () => {
           releaseId={selectedDataset.id.toString()}
           checksum={selectedDataset.checksum}
           size={selectedDataset.size}
-          isSubscribedToMailingList={false}
         />
       );
 

--- a/web/src/components/pages/datasets/dataset-download-email-prompt.tsx
+++ b/web/src/components/pages/datasets/dataset-download-email-prompt.tsx
@@ -20,7 +20,6 @@ interface DownloadFormProps extends WithLocalizationProps {
   releaseId: string;
   checksum: string;
   size: number | string;
-  isSubscribedToMailingList: boolean;
 }
 
 interface FormState {
@@ -41,7 +40,6 @@ const DatasetDownloadEmailPrompt = ({
   checksum,
   size,
   getString,
-  isSubscribedToMailingList,
 }: DownloadFormProps) => {
   const api = useAPI();
 
@@ -180,14 +178,14 @@ const DatasetDownloadEmailPrompt = ({
               onChange={handleInputChange}
               required
             />
-            {!isSubscribedToMailingList && (
+            {
               <LabeledCheckbox
                 label={<Localized id="confirm-join-mailing-list" />}
                 name="confirmJoinMailingList"
                 checked={confirmJoinMailingList}
                 onChange={handleInputChange}
               />
-            )}
+            }
           </div>
           <div className="input-group">
             <LinkButton

--- a/web/src/components/pages/datasets/dataset-download-email-prompt.tsx
+++ b/web/src/components/pages/datasets/dataset-download-email-prompt.tsx
@@ -178,14 +178,12 @@ const DatasetDownloadEmailPrompt = ({
               onChange={handleInputChange}
               required
             />
-            {
-              <LabeledCheckbox
-                label={<Localized id="confirm-join-mailing-list" />}
-                name="confirmJoinMailingList"
-                checked={confirmJoinMailingList}
-                onChange={handleInputChange}
-              />
-            }
+            <LabeledCheckbox
+              label={<Localized id="confirm-join-mailing-list" />}
+              name="confirmJoinMailingList"
+              checked={confirmJoinMailingList}
+              onChange={handleInputChange}
+            />
           </div>
           <div className="input-group">
             <LinkButton

--- a/web/src/components/pages/datasets/dataset-info.tsx
+++ b/web/src/components/pages/datasets/dataset-info.tsx
@@ -15,13 +15,7 @@ import { Dataset } from 'common';
 
 import './dataset-info.css';
 
-interface PropsFromState {
-  isSubscribedToMailingList: boolean;
-}
-
-const DatasetInfo: React.FC<PropsFromState> = ({
-  isSubscribedToMailingList,
-}) => {
+const DatasetInfo: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
 
   const [languagesWithDatasets, setLanguagesWithDatasets] = useState([]);
@@ -57,7 +51,6 @@ const DatasetInfo: React.FC<PropsFromState> = ({
           <DatasetCorpusDownload
             languagesWithDatasets={languagesWithDatasets}
             initialLanguage={globalLocale}
-            isSubscribedToMailingList={isSubscribedToMailingList}
           />
         )}
       </div>
@@ -68,13 +61,9 @@ const DatasetInfo: React.FC<PropsFromState> = ({
         <DatasetDescription releaseData={currentDataset} />
       )}
 
-      <DatasetSegmentDownload
-        isSubscribedToMailingList={isSubscribedToMailingList}
-      />
+      <DatasetSegmentDownload />
     </div>
   );
 };
 
-export default connect<PropsFromState>(({ user }: StateTree) => ({
-  isSubscribedToMailingList: user.isSubscribedToMailingList,
-}))(DatasetInfo);
+export default DatasetInfo;

--- a/web/src/components/pages/datasets/dataset-segment-download.tsx
+++ b/web/src/components/pages/datasets/dataset-segment-download.tsx
@@ -1,8 +1,4 @@
-import {
-  Localized,
-  withLocalization,
-  WithLocalizationProps,
-} from '@fluent/react';
+import { Localized, withLocalization } from '@fluent/react';
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 
@@ -17,13 +13,7 @@ import { useAPI } from '../../../hooks/store-hooks';
 import { Dataset, Datasets } from 'common';
 import { useLocale } from '../../locale-helpers';
 
-interface Props extends WithLocalizationProps {
-  isSubscribedToMailingList: boolean;
-}
-
-const DatasetSegmentDownload: React.FC<Props> = ({
-  isSubscribedToMailingList,
-}) => {
+const DatasetSegmentDownload: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [releaseData, setReleaseData] = useState<Dataset>();
   const api = useAPI();
@@ -109,7 +99,6 @@ const DatasetSegmentDownload: React.FC<Props> = ({
             size={bundleState.size}
             releaseId={bundleState?.id?.toString()}
             selectedLocale={null}
-            isSubscribedToMailingList={isSubscribedToMailingList}
             isLight
           />
         </div>


### PR DESCRIPTION
The "Join mailing list" checkbox was hidden for users who had signed up for the mailing list but I discovered that the checkbox is still visible for users that download the dataset with an email different from the one they use in their profile. 

On the BE we don't really have a way of knowing if the user is subscribed if they use a different email to sign up. So I think we can just stick with the acceptance criteria and default to always showing the checkbox because we don't have a reliable way to know if a user has signed up to the mailing list or not.