### PR TITLE
OI-2557: Fix 'no more clips' issue

### DIFF
--- a/web/src/components/pages/contribution/contribution.tsx
+++ b/web/src/components/pages/contribution/contribution.tsx
@@ -35,6 +35,7 @@ import { Notifications } from '../../../stores/notifications';
 
 import './contribution.css';
 import { SecondPostSubmissionCTA } from './speak/secondSubmissionCTA/secondSubmissionCTA';
+import Success from './success';
 
 export const SET_COUNT = 5;
 
@@ -355,6 +356,10 @@ class ContributionPage extends React.Component<ContributionPageProps, State> {
       user,
     } = this.props;
     const { selectedPill } = this.state;
+
+    if (isSubmitted && type === 'listen') {
+      return <Success onReset={onReset} type={type} />;
+    }
 
     const noUserAccount = !user.account;
     const shouldShowCTA = shouldShowFirstCTA || shouldShowSecondCTA;

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -13,8 +13,7 @@ const HASH_LENGTH = 16; // length specified for our compressed-size action
 const OUTPUT_PATH = path.resolve(__dirname, 'dist');
 
 module.exports = (_env, argv) => {
-  // const IS_DEVELOPMENT = argv.mode === 'development';
-  const IS_DEVELOPMENT = true;
+  const IS_DEVELOPMENT = argv.mode === 'development';
 
   if (IS_DEVELOPMENT) {
     const result = dotenv.config({ path: '../.env-local-docker' });

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -13,7 +13,8 @@ const HASH_LENGTH = 16; // length specified for our compressed-size action
 const OUTPUT_PATH = path.resolve(__dirname, 'dist');
 
 module.exports = (_env, argv) => {
-  const IS_DEVELOPMENT = argv.mode === 'development';
+  // const IS_DEVELOPMENT = argv.mode === 'development';
+  const IS_DEVELOPMENT = true;
 
   if (IS_DEVELOPMENT) {
     const result = dotenv.config({ path: '../.env-local-docker' });


### PR DESCRIPTION
The speak contribution flow changed and impacted the listen contribution flow. Since the speak contribution flow does not follow the normal order, the success page got deleted. The success page is still needed for the listen flow and got re-added in this PR. This closes #3890 by fixing the bug.