### PR TITLE
Adjusting speak and listen css so buttons fit screen

### DIFF
--- a/web/src/components/index.css
+++ b/web/src/components/index.css
@@ -212,11 +212,6 @@ button {
         }
     }
 
-    &.write {
-        overflow: auto;
-        height: 100%;
-    }
-
     &.review {
         & .spinner--floating {
             position: fixed;

--- a/web/src/components/index.css
+++ b/web/src/components/index.css
@@ -159,13 +159,17 @@ button {
     &.speak,
     &.listen,
     &.write,
-    &.review {
-        overflow: hidden;
+    &.review  {
+        max-height: calc(100dvh - 2px);
 
         & header {
             @media (--lg-down) {
                 display: none;
             }
+        }
+
+        #content {
+            min-height: 70%;
         }
     }
 

--- a/web/src/components/media.css
+++ b/web/src/components/media.css
@@ -18,6 +18,7 @@
 @custom-media --demo-only (width < 1040px);
 
 @custom-media --tall (height > 800px);
+@custom-media --xl-tall (height > 910px);
 
 @keyframes fade-in {
     from {

--- a/web/src/components/pages/contribution/contribution.css
+++ b/web/src/components/pages/contribution/contribution.css
@@ -1,9 +1,5 @@
 @import url('../../media.css');
 
-.contribution-wrapper {
-    overflow: hidden;
-}
-
 .contribution-wrapper,
 .contribution {
     background-image: linear-gradient(
@@ -32,6 +28,7 @@
     @media (--lg-up) {
         position: initial;
         overflow: visible;
+        justify-content: normal;
         height: 84vh;
     }
 
@@ -352,10 +349,18 @@
     }
 
     .primary-buttons {
-        margin-top: 5vh;
+        margin-top: 6vh;
         display: flex;
         justify-content: center;
         align-items: center;
+
+        @media (-webkit-device-pixel-ratio: 1) {
+            margin-top: 10vh;
+        }
+
+        @media (-webkit-device-pixel-ratio: 2) {
+            margin-top: 10vh;
+        }
 
         & canvas {
             position: absolute;
@@ -375,7 +380,7 @@
     }
 
     .buttons {
-        margin-top: 1rem;
+        margin-top: 4vh;
 
         display: flex;
         justify-content: space-between;

--- a/web/src/components/pages/contribution/contribution.css
+++ b/web/src/components/pages/contribution/contribution.css
@@ -33,7 +33,7 @@
         position: initial;
         overflow: visible;
         justify-content: normal;
-        height: 84vh;
+        min-height: 84vh;
     }
 
     .button {
@@ -362,7 +362,7 @@
             margin-top: 10vh;
         }
 
-        @media (-webkit-device-pixel-ratio: 2) {
+        @media (-webkit-device-pixel-ratio: 2) and (min-height: 910px) {
             margin-top: 10vh;
         }
 

--- a/web/src/components/pages/contribution/contribution.css
+++ b/web/src/components/pages/contribution/contribution.css
@@ -1,5 +1,9 @@
 @import url('../../media.css');
 
+.contribution-wrapper {
+    overflow: hidden;
+}
+
 .contribution-wrapper,
 .contribution {
     background-image: linear-gradient(

--- a/web/src/components/pages/contribution/contribution.css
+++ b/web/src/components/pages/contribution/contribution.css
@@ -31,8 +31,8 @@
 
     @media (--lg-up) {
         position: initial;
-        justify-content: initial;
         overflow: visible;
+        height: 84vh;
     }
 
     .button {
@@ -352,7 +352,7 @@
     }
 
     .primary-buttons {
-        margin-top: 4vh;
+        margin-top: 5vh;
         display: flex;
         justify-content: center;
         align-items: center;
@@ -375,7 +375,7 @@
     }
 
     .buttons {
-        margin-top: 4vh;
+        margin-top: 1rem;
 
         display: flex;
         justify-content: space-between;

--- a/web/src/components/pages/contribution/contribution.css
+++ b/web/src/components/pages/contribution/contribution.css
@@ -23,14 +23,10 @@
     padding: 10px 20px;
     max-width: var(--wide-desktop-width);
     width: 100%;
-    height: 100%;
-
-    @media (--md-up) {
-        padding: 0 20px 60px;
-    }
+    height: calc(100% - var(--header-height));
 
     @media (--tall) {
-        padding-top: 50px;
+        padding-top: 2rem;
     }
 
     @media (--lg-up) {
@@ -59,7 +55,7 @@
         text-transform: uppercase;
         font-size: var(--font-size-sm);
         text-align: center;
-        margin-top: 1.5rem;
+        margin-top: 1rem;
         font-weight: 600;
 
         @media (--md-up) {
@@ -275,7 +271,6 @@
         align-items: center;
         height: 100%;
         width: 100%;
-        margin-top: 30px;
 
         @media (--xl-up) {
             margin-top: 0;
@@ -357,14 +352,10 @@
     }
 
     .primary-buttons {
-        margin-top: 2vh;
+        margin-top: 4vh;
         display: flex;
         justify-content: center;
         align-items: center;
-
-        @media (--xl-up) {
-            margin-top: 12vh;
-        }
 
         & canvas {
             position: absolute;
@@ -384,22 +375,10 @@
     }
 
     .buttons {
-        margin-top: 1rem;
+        margin-top: 4vh;
 
         display: flex;
         justify-content: space-between;
-
-        @media (--xl-up) {
-            margin-top: 3.5vh;
-        }
-
-        @media (--sm-down) {
-            margin-bottom: 3.5rem;
-        }
-
-        @media (--md-only) {
-            margin-bottom: 2.5rem;
-        }
 
         button img {
             margin-inline-end: 10px;
@@ -498,6 +477,8 @@
             }
 
             & .pills {
+                margin-top: 0;
+
                 & .counter {
                     display: flex;
                 }
@@ -528,7 +509,7 @@
 
         @media (--sm-down) {
             margin-bottom: 20px;
-            max-width: 120px;
+            max-width: 220px;
             text-align: center;
             font-size: var(--font-size-xs);
         }
@@ -695,12 +676,17 @@
 
         @media (--md-down) {
             align-items: center;
+            margin-bottom: 2rem;
         }
 
         .labeled-checkbox {
             margin: 0 0 2em;
             width: 60%;
-            text-align: center;
+            text-align: center;`
+
+            @media (--md-down) {
+                width: 80%;
+            }
 
             a {
                 color: var(--anchor-text-blue);

--- a/web/src/components/pages/contribution/contribution.css
+++ b/web/src/components/pages/contribution/contribution.css
@@ -358,7 +358,7 @@
         justify-content: center;
         align-items: center;
 
-        @media (min-height: 910px) {
+        @media (--xl-tall) {
             margin-top: 10vh;
         }
 

--- a/web/src/components/pages/contribution/contribution.css
+++ b/web/src/components/pages/contribution/contribution.css
@@ -358,11 +358,7 @@
         justify-content: center;
         align-items: center;
 
-        @media (-webkit-device-pixel-ratio: 1) {
-            margin-top: 10vh;
-        }
-
-        @media (-webkit-device-pixel-ratio: 2) and (min-height: 910px) {
+        @media (min-height: 910px) {
             margin-top: 10vh;
         }
 

--- a/web/src/components/pages/contribution/contribution.tsx
+++ b/web/src/components/pages/contribution/contribution.tsx
@@ -490,10 +490,12 @@ class ContributionPage extends React.Component<ContributionPageProps, State> {
           children: <div className="instruction hidden-md-up" />,
         }) || <div className="instruction hidden-md-up" />}
 
-        <div className="primary-buttons">
-          <canvas ref={this.canvasRef} />
-          {primaryButtons}
-        </div>
+        {!this.isDone && (
+          <div className="primary-buttons">
+            <canvas ref={this.canvasRef} />
+            {primaryButtons}
+          </div>
+        )}
 
         {!hasErrors && !isSubmitted && (
           <LocaleLink

--- a/web/src/components/pages/contribution/contribution.tsx
+++ b/web/src/components/pages/contribution/contribution.tsx
@@ -490,12 +490,10 @@ class ContributionPage extends React.Component<ContributionPageProps, State> {
           children: <div className="instruction hidden-md-up" />,
         }) || <div className="instruction hidden-md-up" />}
 
-        {!this.isDone && (
-          <div className="primary-buttons">
-            <canvas ref={this.canvasRef} />
-            {primaryButtons}
-          </div>
-        )}
+        <div className="primary-buttons">
+          <canvas ref={this.canvasRef} />
+          {primaryButtons}
+        </div>
 
         {!hasErrors && !isSubmitted && (
           <LocaleLink

--- a/web/src/components/pages/contribution/pill.css
+++ b/web/src/components/pages/contribution/pill.css
@@ -15,19 +15,15 @@
     overflow: hidden;
 
     @media (--md-up) {
-        margin-top: 20px;
+        margin-top: 1rem;
         margin-inline-start: auto;
         padding: 0 12px;
         width: 100%;
-        height: 57px;
+        height: 55px;
 
         display: flex !important;
         flex-direction: row;
         justify-content: space-between;
-
-        &:first-child {
-            margin-top: 0;
-        }
     }
 
     & .num {

--- a/web/src/components/pages/contribution/sentence-collector/review/review.css
+++ b/web/src/components/pages/contribution/sentence-collector/review/review.css
@@ -87,18 +87,18 @@
 
         .card-dimensions {
             padding: 0 20px;
-    
+
             text-align: center;
             font-weight: 600;
             line-height: 1.38;
-    
+
             background: var(--white);
 
             & .source {
                 font-size: var(--font-size-sm);
                 color: var(--near-black);
             }
-    
+
             @media (--md-up) {
                 padding: 0 25px;
                 font-size: var(--font-size-xl);
@@ -106,7 +106,7 @@
                 letter-spacing: 1.3px;
                 line-height: 1.63;
             }
-    
+
             @media (--lg-up) {
                 padding: 100px 100px 0;
             }
@@ -114,12 +114,16 @@
     }
 
     & .waves {
-        margin-top: 12vh;
+        margin-top: 9vh;
         background: url('./images/review-waves.png');
         background-size: 100% 100%;
         height: 15px;
         display: flex;
         align-items: center;
+
+        @media (--tall) {
+            margin-top: 14vh;
+        }
 
         & .vote-buttons {
             display: flex;
@@ -259,41 +263,41 @@
             padding: 30px 25px;
             max-width: 700px;
             width: 100%;
-    
+
             display: flex;
             flex-direction: column;
             justify-content: center;
-    
+
             background: var(--white);
             box-shadow: 0 6px 12px 0 rgba(0, 0, 0, 0.05);
-    
+
             h1 {
                 font-weight: 400;
                 font-size: 2em;
                 margin-bottom: 0.5em;
             }
-    
+
             p {
                 font-size: 1.25em;
             }
-    
+
             @media (--md-up) {
                 padding: 120px 105px;
             }
-    
+
             .button {
                 margin-top: 30px;
                 border: none;
                 background: var(--red);
                 box-shadow: 0 5px 10px color-mod(var(--red) alpha(50%));
                 text-transform: uppercase;
-    
+
                 &:hover {
                     color: var(--white);
                     opacity: 1;
                     background: var(--red);
                     box-shadow: 0 5px 10px var(--red);
-    
+
                     & path {
                         fill: var(--white);
                     }
@@ -305,7 +309,7 @@
             .button {
                 background: var(--blue);
                 box-shadow: 0 5px 10px color-mod(var(--blue) alpha(50%));
-    
+
                 &:hover {
                     background: var(--blue);
                     box-shadow: 0 5px 10px var(--blue);

--- a/web/src/components/pages/contribution/sentence-collector/sentence-collector-wrapper.css
+++ b/web/src/components/pages/contribution/sentence-collector/sentence-collector-wrapper.css
@@ -10,8 +10,6 @@
             var(--desert-storm)
         );
 
-        height: calc(100% - 135px);
-        
         @media (--xl-up) {
             overflow: auto;
         }
@@ -23,7 +21,7 @@
             max-width: var(--wide-desktop-width);
 
             @media (--lg-up) {
-                padding: 50px 20px 10px;
+                padding: 2rem 1rem 0.5rem;
             }
 
             @media (--sm-down) {
@@ -42,16 +40,16 @@
         & .instruction {
             display: flex;
             margin: 2vh auto;
-    
+
             svg {
                 margin: 0 8px;
-    
+
                 @media (--xs-down) {
                     width: 16px;
                     height: 16px;
                 }
             }
-    
+
             @media (--xs-down) {
                 font-size: var(--font-size-xs);
                 margin-bottom: 16px;

--- a/web/src/components/pages/contribution/sentence-collector/write/write.css
+++ b/web/src/components/pages/contribution/sentence-collector/write/write.css
@@ -5,6 +5,7 @@
         display: flex;
         flex-direction: column;
         height: 100%;
+        min-height: 82vh;
         justify-content: space-between;
     }
 
@@ -224,7 +225,7 @@
                 @media (--lg-up) {
                     width: 190px;
                 }
-                
+
 
                 a {
                     color: var(--blue);

--- a/web/src/components/pages/contribution/sentence-collector/write/write.css
+++ b/web/src/components/pages/contribution/sentence-collector/write/write.css
@@ -5,7 +5,7 @@
         display: flex;
         flex-direction: column;
         height: 100%;
-        min-height: 82vh;
+        min-height: 78vh;
         justify-content: space-between;
     }
 

--- a/web/src/components/pages/contribution/speak/firstSubmissionCTA/firstPostSubmissionCTA.css
+++ b/web/src/components/pages/contribution/speak/firstSubmissionCTA/firstPostSubmissionCTA.css
@@ -6,10 +6,6 @@
     width: 70%;
     z-index: 10;
 
-    @media (--xs-only) {
-        height: 90%;
-    }
-
     .header-text-container {
         margin-bottom: 80px;
 

--- a/web/src/components/pages/contribution/speak/secondSubmissionCTA/secondSubmissionCTA.tsx
+++ b/web/src/components/pages/contribution/speak/secondSubmissionCTA/secondSubmissionCTA.tsx
@@ -23,11 +23,13 @@ export const SecondPostSubmissionCTA: React.FC<
     y: height / 4,
   };
 
+  const heightWithoutHeader = height - 75;
+
   return (
     <div data-testid="second-submission-cta">
       <Confetti
         width={width}
-        height={height}
+        height={heightWithoutHeader}
         numberOfPieces={200}
         gravity={0.1}
         recycle={false}


### PR DESCRIPTION
## Pull Request Form

### Type of Pull Request

- [x] Related to a listed issue 
* https://github.com/common-voice/common-voice/issues/3969

This PR fixes the issue where on zoomed screens some buttons do not fit the screen and as zoom is disabled on the contribution pages buttons are unavailable

Changes:
* enabled scroll on `/speak` and `/listen` if contents do not fit the screen (removed `overlay:hidden;`)
* set height of `/speak` and `/listen` to `100dvh - 2px` so it fits mobile screens snugly
* adjusted margins and paddings so the content fits better into the screen
* set min-height to 70%, so content is more compact and does not create a scroll
* ~adjusted `contribution.tsx` to not print primary buttons on `isDone` overlay screen, so the screen is smaller and visible parts fit the screen~

Tested on:
* Firefox, Chrome, Edge, Safari on mobiles, tablets and desktops (Linux, Mac, Windows)
* Zoom of 125% still fits without any scrolls, for larger zooms scroll appears but site is functional  

Screenshots:
* https://i.imgur.com/GehLhd8.png
* https://i.imgur.com/KYDYMNN.png
* https://i.imgur.com/HhaG0sO.png
* https://i.imgur.com/Z1mjLiP.png
* https://i.imgur.com/QD5neek.png
* https://i.imgur.com/kD8rkVE.png
* https://i.imgur.com/PbIPuZS.png