### PR TITLE
Will not override existing value of is_used

### DIFF
--- a/server/src/lib/model/db/import-sentences.ts
+++ b/server/src/lib/model/db/import-sentences.ts
@@ -124,8 +124,7 @@ async function importLocaleSentences(
                 .join(', ')}
               ON DUPLICATE KEY UPDATE
                 source = VALUES(source),
-                version = VALUES(version),
-                is_used = VALUES(is_used);
+                version = VALUES(version);
             `
             );
           } catch (e) {


### PR DESCRIPTION
## Pull Request Form

### Type of Pull Request

- [ ] Bulk sentence upload 
- [X] Related to a listed issue 

* https://github.com/common-voice/common-voice/issues/4061

- [ ] Other

The `is_used` column of the `sentences` table can be used to hide sentences from the UI, but the current codebase would override any values of this column during the sentence import. This PR will fix that, the value of `is_used` will be preserved.

This will allow removing problematic sentences from the Common Voice UI without removing their recordings.
The use case of this is to remove offensive sentences from the system retaining their recordings.


