### PR TITLE
Update import-locales.ts with Tamazight variants

### DIFF
--- a/server/src/lib/model/db/import-locales.ts
+++ b/server/src/lib/model/db/import-locales.ts
@@ -161,6 +161,21 @@ const VARIANTS: Variant[] = [
     locale_name: 'ca',
     variant_name: 'Alguerès',
     variant_token: 'ca-algueres',
+  },
+  {
+    locale_name: 'zgh',
+    variant_name: 'ⵜⴰⵛⵍⵃⵉⵜ (Tachelhit)',
+    variant_token: 'zgh-shi',
+  },
+  {
+    locale_name: 'zgh',
+    variant_name: 'ⵜⴰⵎⴰⵣⵉⵖⵜ ⵏ ⵡⴰⵟⵍⴰⵚ ⴰⵏⴰⵎⵎⴰⵙ (Central Atlas Tamazight)',
+    variant_token: 'zgh-tzm',
+  },
+  {
+    locale_name: 'zgh',
+    variant_name: 'ⵜⴰⵔⵉⴼⵉⵜ (Tarifit)',
+    variant_token: 'zgh-rif',
   }
 ];
 


### PR DESCRIPTION
## Pull Request Form

<!-- Thanks for making a contribution to Common Voice, to help us review the request please fill out this form -->

### Type of Pull Request

<!-- To help us understand your pull request, choose the checkboxes most relevant to your request by filling out the checkboxes with [x] here -->

- [ ] Bulk sentence upload 

<!--- Please ensure your sentences are licensed under CC0 before making a submission. Learn how you can do this via our Playbook https://common-voice.github.io/community-playbook/sub_pages/cc0waiver_process.html -->

- [ ] Related to a listed issue 

<!--- Please link the issues related to your PR Request -->

- [x] Other

<!--- Please describe the pull request-->

* Added three main variants of Tamazight (zgh):
  - {shi} ⵜⴰⵛⵍⵃⵉⵜ -- Tachelhit
  - {tzm} ⵜⴰⵎⴰⵣⵉⵖⵜ ⵏ ⵡⴰⵟⵍⴰⵚ ⴰⵏⴰⵎⵎⴰⵙ -- Central Atlas Tamazight
  - {rif} ⵜⴰⵔⵉⴼⵉⵜ -- Tarifit

### Acknowledging contributors

<!-- Please list who collaborated with you to make this contribution. Or Community dicussion that helped make this idea possible -->

* Brahim Essaidi, Yassine Aït-El-Mouden from Pontoon Tamazight team

