### PR TITLE
Fix for link to add more sentences

### DIFF
--- a/web/src/components/pages/contribution/speak/speak-error-content.tsx
+++ b/web/src/components/pages/contribution/speak/speak-error-content.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Localized } from '@fluent/react';
+import URLS from '../../../../urls'
 
 import {
   ArrowRight,
@@ -59,8 +60,7 @@ const NoSentencesAvailable = () => (
       </h1>
       <LinkButton
         rounded
-        blank
-        href="https://common-voice.github.io/sentence-collector/">
+        to={URLS.WRITE}>
         <ArrowRight className="speak-sc-icon" />{' '}
         <Localized id="speak-empty-state-cta">
           <span />


### PR DESCRIPTION
## Pull Request Form

<!-- Thanks for making a contribution to Common Voice, to help us review the request please fill out this form -->

### Type of Pull Request

- [ ] Bulk sentence upload 
- [ ] Related to a listed issue 
- [x] Other

Pull request will fix link that is visible on the sentence recording screen when there are no sentences to record

![attels](https://github.com/common-voice/common-voice/assets/5319134/ad8a81d9-070a-4d85-99f3-66ab0bc0d0f8)


