### PR TITLE
Will hide problematic sentences

### DIFF
--- a/server/src/lib/model/db/migrations/20230815103600-hide-problematic-sentences.ts
+++ b/server/src/lib/model/db/migrations/20230815103600-hide-problematic-sentences.ts
@@ -1,0 +1,10 @@
+export const up = async function (db: any): Promise<any> {
+  return db.runSql(`
+    UPDATE sentences SET is_used = FALSE
+    WHERE text REGEXP '.*\\\\?[a-z].*' OR text = ''
+  `);
+};
+
+export const down = async function (): Promise<any> {
+  return null;
+};

--- a/server/src/lib/model/db/migrations/20230815103600-hide-problematic-sentences.ts
+++ b/server/src/lib/model/db/migrations/20230815103600-hide-problematic-sentences.ts
@@ -1,7 +1,13 @@
 export const up = async function (db: any): Promise<any> {
-  return db.runSql(`
+  await db.runSql(`
     UPDATE sentences SET is_used = FALSE
     WHERE text REGEXP '.*\\\\?[a-z].*' OR text = ''
+  `);
+
+  await db.runSql(`
+    UPDATE sentences SET is_used = FALSE
+    WHERE locale_id=(SELECT id from locales WHERE name='lv')
+      AND source REGEXP '.*\\\\?[a-z].*' 
   `);
 };
 

--- a/server/src/lib/model/db/migrations/20230815103600-hide-problematic-sentences.ts
+++ b/server/src/lib/model/db/migrations/20230815103600-hide-problematic-sentences.ts
@@ -1,7 +1,7 @@
 export const up = async function (db: any): Promise<any> {
   await db.runSql(`
     UPDATE sentences SET is_used = FALSE
-    WHERE text REGEXP '.*\\\\?[a-z].*' OR text = ''
+    WHERE created_at > '2023-05-01 00:00:00' AND (text REGEXP '.*\\\\?[a-z].*' OR text = '')
   `);
 
   await db.runSql(`

--- a/server/src/lib/model/db/migrations/20230815103600-hide-problematic-sentences.ts
+++ b/server/src/lib/model/db/migrations/20230815103600-hide-problematic-sentences.ts
@@ -1,13 +1,13 @@
 export const up = async function (db: any): Promise<any> {
   await db.runSql(`
     UPDATE sentences SET is_used = FALSE
-    WHERE (created_at > '2023-05-01 00:00:00' AND text REGEXP '.*\\\\?[a-z].*') OR text = ''
+    WHERE (created_at > '2023-05-01 00:00:00' AND text REGEXP '.*\\\\?[a-zāčēģīķļņšūžâîûüöç].*') OR text = ''
   `);
 
   await db.runSql(`
     UPDATE sentences SET is_used = FALSE
     WHERE locale_id=(SELECT id from locales WHERE name='lv')
-      AND source REGEXP '.*\\\\?[a-z].*' 
+      AND source REGEXP '.*\\\\?[a-zāčēģīķļņšūžâîûüöç].*' 
   `);
 };
 

--- a/server/src/lib/model/db/migrations/20230815103600-hide-problematic-sentences.ts
+++ b/server/src/lib/model/db/migrations/20230815103600-hide-problematic-sentences.ts
@@ -1,7 +1,7 @@
 export const up = async function (db: any): Promise<any> {
   await db.runSql(`
     UPDATE sentences SET is_used = FALSE
-    WHERE created_at > '2023-05-01 00:00:00' AND (text REGEXP '.*\\\\?[a-z].*' OR text = '')
+    WHERE (created_at > '2023-05-01 00:00:00' AND text REGEXP '.*\\\\?[a-z].*') OR text = ''
   `);
 
   await db.runSql(`


### PR DESCRIPTION
## Pull Request Form

### Type of Pull Request

- [X] Related to a listed issue 

* https://github.com/common-voice/common-voice/issues/4138

This PR will hide sentences that have `?` in the middle of some words in sentence text.

Check for locale on first query is omitted on purpose as this issue is affecting multiple locales and it is hard to imagine some language where `?` in the middle of the word is a valid grammatical structure. If necessary, I would be happy to adjust the PR.

Checking Latvian sentences noticed also that some sentences do not have any text, so this PR will also hide those.

To run a query manually one would use 
```
UPDATE sentences SET is_used = FALSE
    WHERE (created_at > '2023-05-01 00:00:00' AND text REGEXP '.*\\?[a-zāčēģīķļņšūžâîûüöç].*') OR text = ''
```
and
```
UPDATE sentences SET is_used = FALSE
WHERE locale_id=(SELECT id from locales WHERE name='lv')
  AND source REGEXP '.*\\?[a-zāčēģīķļņšūžâîûüöç].*'
```