### PR TITLE
fix: skip button text overflow

### DIFF
--- a/web/src/components/pages/contribution/sentence-collector/review/review.css
+++ b/web/src/components/pages/contribution/sentence-collector/review/review.css
@@ -59,7 +59,8 @@
                 word-wrap: break-word;
 
                 opacity: 1;
-                transition: transform var(--transition-duration-slow) var(--easing),
+                transition: transform var(--transition-duration-slow)
+                        var(--easing),
                     opacity var(--transition-duration-slow) var(--easing);
 
                 &.inactive {
@@ -183,10 +184,10 @@
 
             & .skip-button {
                 box-shadow: 0px 4px 10px rgba(74, 74, 74, 0.3);
-                min-width: 150px;
+                min-width: fit-content;
 
                 @media (--sm-down) {
-                    min-width: 100px;
+                    min-width: 120px;
                 }
 
                 & svg {
@@ -194,6 +195,12 @@
                         transform: rotateY(180deg);
                     }
                 }
+            }
+
+            & .skip-text {
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
             }
         }
 

--- a/web/src/components/pages/contribution/sentence-collector/review/review.css
+++ b/web/src/components/pages/contribution/sentence-collector/review/review.css
@@ -59,8 +59,7 @@
                 word-wrap: break-word;
 
                 opacity: 1;
-                transition: transform var(--transition-duration-slow)
-                        var(--easing),
+                transition: transform var(--transition-duration-slow) var(--easing),
                     opacity var(--transition-duration-slow) var(--easing);
 
                 &.inactive {

--- a/web/src/components/pages/contribution/sentence-collector/review/review.tsx
+++ b/web/src/components/pages/contribution/sentence-collector/review/review.tsx
@@ -303,7 +303,7 @@ const Review: React.FC<Props> = ({ getString }) => {
             data-testid="skip-button">
             <SkipIcon />
             <Localized id="skip">
-              <span />
+              <span className="skip-text" />
             </Localized>{' '}
           </Button>
           <VoteButton


### PR DESCRIPTION
fixes #4142 

Fix: Skip button text-overflow

Previously, translated texts that were too long would spill over from the skip button.

**Before** 

**1. The skip icon is not displayed on the large screen for oversized translated text.** 

<img width="731" alt="Screenshot 2023-08-19 at 8 32 53 PM" src="https://github.com/common-voice/common-voice/assets/85433137/4890b3ef-aec5-4929-87bd-db2fd45a9ef8">








**2. When viewed on a small screen, the icon disappears and the text overflows. for large text**

<img width="342" alt="Screenshot 2023-08-19 at 8 35 52 PM" src="https://github.com/common-voice/common-voice/assets/85433137/c05e6e5b-2343-47cd-ab26-c868f4240252">




****
**After fix** 


1. If the translated text is too long for a small screen, it will be shortened to an ellipsis. 

https://github.com/common-voice/common-voice/assets/85433137/ad341785-dcae-46b3-8fec-d3da306ecf06

2. if the text is not large then it would not be shortened to an ellipsis


![image](https://github.com/common-voice/common-voice/assets/85433137/2eebab0f-44a7-4727-b91f-1f2524f85b0c)







