### PR TITLE
Fix csp error with loading clips on listen page locally

### DIFF
--- a/.env-local-docker.example
+++ b/.env-local-docker.example
@@ -2,6 +2,7 @@ CV_DB_ROOT_PASS="voicewebroot"
 CV_MYSQLHOST="db"
 CV_S3_CONFIG='{"endpoint": "http://s3proxy:80", "accessKeyId": "local-identity", "secretAccessKey": "local-credential", "s3ForcePathStyle": true}'
 CV_S3_LOCAL_DEVELOPMENT_ENDPOINT="http://localhost:9001"
+CV_GOOGLE_STORAGE_LOCAL_DEVELOPMENT_ENDPOINT="http://localhost:8080"
 CV_STORAGE_LOCAL_DEVELOPMENT_ENDPOINT="http://storage:8080"
 CV_BULK_SUBMISSION_BUCKET_NAME="common-voice-bulk-submissions"
 CV_ENVIRONMENT="local"

--- a/server/src/config-helper.ts
+++ b/server/src/config-helper.ts
@@ -33,7 +33,7 @@ export type CommonVoiceConfig = {
   SECRET: string;
   AWS_SES_CONFIG: SESClientConfig;
   S3_CONFIG: S3.Types.ClientConfiguration;
-  S3_LOCAL_DEVELOPMENT_ENDPOINT?: string;
+  GOOGLE_STORAGE_LOCAL_DEVELOPMENT_ENDPOINT?: string;
   STORAGE_LOCAL_DEVELOPMENT_ENDPOINT: string;
   GCP_CREDENTIALS: object;
   CINCHY_CONFIG: S3.Types.ClientConfiguration;
@@ -96,8 +96,8 @@ const BASE_CONFIG: CommonVoiceConfig = {
   AWS_REGION: configEntry('CV_AWS_REGION', 'us-west-2'),
   AWS_SES_CONFIG: configEntry('CV_AWS_SES_CONFIG', {}, castJson),
   S3_CONFIG: configEntry('CV_S3_CONFIG', {}, castJson),
-  S3_LOCAL_DEVELOPMENT_ENDPOINT: configEntry(
-    'CV_S3_LOCAL_DEVELOPMENT_ENDPOINT',
+  GOOGLE_STORAGE_LOCAL_DEVELOPMENT_ENDPOINT: configEntry(
+    'CV_GOOGLE_STORAGE_LOCAL_DEVELOPMENT_ENDPOINT',
     null
   ),
   STORAGE_LOCAL_DEVELOPMENT_ENDPOINT: configEntry(

--- a/server/src/csp-header-value.test.ts
+++ b/server/src/csp-header-value.test.ts
@@ -1,7 +1,7 @@
 import getCSPHeaderValue from './csp-header-value';
 import { getConfig, injectConfig, CommonVoiceConfig } from './config-helper';
 
-const S3_LOCAL_DEVELOPMENT_ENDPOINT = 'http://localhost:9001';
+const GOOGLE_STORAGE_LOCAL_DEVELOPMENT_ENDPOINT = 'http://localhost:8080';
 
 const initialConfig = getConfig();
 
@@ -19,11 +19,13 @@ describe('getCSPHeaderValue', () => {
   });
 
   it('should return expected header value for production', () => {
-    replaceConfig({ PROD: true, S3_LOCAL_DEVELOPMENT_ENDPOINT });
+    replaceConfig({ PROD: true, GOOGLE_STORAGE_LOCAL_DEVELOPMENT_ENDPOINT });
 
     const CSP_HEADER_VALUE = getCSPHeaderValue();
 
-    expect(CSP_HEADER_VALUE).not.toContain(S3_LOCAL_DEVELOPMENT_ENDPOINT);
+    expect(CSP_HEADER_VALUE).not.toContain(
+      GOOGLE_STORAGE_LOCAL_DEVELOPMENT_ENDPOINT
+    );
     // we allow unsafe-inline for fundraise up styles - https://fundraiseup.com/support/content-security-policy/
     // expect(CSP_HEADER_VALUE).not.toContain('unsafe');
     expect(CSP_HEADER_VALUE).toBe(
@@ -33,10 +35,12 @@ describe('getCSPHeaderValue', () => {
 
   it('should return additional changes for development', () => {
     expect(true).toBeTruthy();
-    replaceConfig({ PROD: false, S3_LOCAL_DEVELOPMENT_ENDPOINT });
+    replaceConfig({ PROD: false, GOOGLE_STORAGE_LOCAL_DEVELOPMENT_ENDPOINT });
 
     const CSP_HEADER_VALUE = getCSPHeaderValue();
-    expect(CSP_HEADER_VALUE).toContain(S3_LOCAL_DEVELOPMENT_ENDPOINT);
+    expect(CSP_HEADER_VALUE).toContain(
+      GOOGLE_STORAGE_LOCAL_DEVELOPMENT_ENDPOINT
+    );
     expect(CSP_HEADER_VALUE).toContain('unsafe');
   });
 });

--- a/server/src/csp-header-value.ts
+++ b/server/src/csp-header-value.ts
@@ -87,7 +87,7 @@ const SOURCES = {
 };
 
 function getCSPHeaderValue() {
-  const { PROD, S3_LOCAL_DEVELOPMENT_ENDPOINT } = getConfig();
+  const { PROD, GOOGLE_STORAGE_LOCAL_DEVELOPMENT_ENDPOINT } = getConfig();
 
   /*
     default to production mode to make sure we
@@ -100,9 +100,9 @@ function getCSPHeaderValue() {
     SOURCES['script-src'].push("'unsafe-eval'");
 
     // add s3proxy to allowed sources in development
-    SOURCES['connect-src'].push(S3_LOCAL_DEVELOPMENT_ENDPOINT);
-    SOURCES['media-src'].push(S3_LOCAL_DEVELOPMENT_ENDPOINT);
-    SOURCES['img-src'].push(S3_LOCAL_DEVELOPMENT_ENDPOINT);
+    SOURCES['connect-src'].push(GOOGLE_STORAGE_LOCAL_DEVELOPMENT_ENDPOINT);
+    SOURCES['media-src'].push(GOOGLE_STORAGE_LOCAL_DEVELOPMENT_ENDPOINT);
+    SOURCES['img-src'].push(GOOGLE_STORAGE_LOCAL_DEVELOPMENT_ENDPOINT);
   }
 
   return Object.entries(SOURCES)


### PR DESCRIPTION
Noticed this error locally when I tried to load clips locally on the listen page but I was getting a CSP error. Seems because the URL for the clips has changed due to the GCP migration we have to add the URL for Google storage and remove the URL for S3.