### PR TITLE
Fix/donate btn

### DIFF
--- a/web/src/components/donate-button/donate-button.css
+++ b/web/src/components/donate-button/donate-button.css
@@ -14,10 +14,7 @@
         @media (--lg-down) {
             display: flex;
         }
-        
-        @media (--sm-down) {
-            display: flex;
-        }
+
     }
 
     svg {

--- a/web/src/components/donate-button/donate-button.css
+++ b/web/src/components/donate-button/donate-button.css
@@ -11,6 +11,10 @@
             height: 2.5rem;
         }
 
+        @media (--lg-down) {
+            display: flex;
+        }
+        
         @media (--sm-down) {
             display: flex;
         }


### PR DESCRIPTION
fix #4174

The donate button text was not aligned properly between the `width <= 1200 and widht >= 700px`.

### Before fix 
<img width="726" alt="Screenshot 2023-10-01 at 8 08 35 PM" src="https://github.com/common-voice/common-voice/assets/85433137/16172c87-1a24-4597-bb41-3c1cbd610b68">


### After fix 

![WhatsApp Image 2023-10-01 at 8 04 32 PM](https://github.com/common-voice/common-voice/assets/85433137/59a9ace5-19e6-42ad-a6f2-f4567527aef6)

