### PR TITLE
Oi 2816 add timestamp to language stats

### DIFF
--- a/server/src/lib/model/db.ts
+++ b/server/src/lib/model/db.ts
@@ -997,6 +997,9 @@ export default class DB {
       ) s ON l.id = s.locale_id
       `
     );
+
+    const lastFetched = new Date()
+
     return rows.map(
       (row: {
         id: number;
@@ -1012,6 +1015,7 @@ export default class DB {
           targetSentenceCount: row.target_sentence_count,
           currentCount: row.total_sentence_count,
         },
+        lastFetched,
       })
     );
   }

--- a/server/src/lib/model/db.ts
+++ b/server/src/lib/model/db.ts
@@ -981,16 +981,21 @@ export default class DB {
 
   async getLanguages(): Promise<Language[]> {
     const [rows] = await this.mysql.query(
-      `SELECT 
+      `
+      SELECT
         l.id,
         l.name,
         l.target_sentence_count as target_sentence_count,
-        count(s.id) as total_sentence_count,
+        COALESCE(s.total_sentence_count, 0) as total_sentence_count,
         l.is_contributable
       FROM locales l
-      LEFT JOIN sentences s ON s.locale_id = l.id
-      AND s.is_validated = TRUE
-      GROUP BY l.id`
+      LEFT JOIN (
+        SELECT locale_id, COUNT(*) as total_sentence_count
+        FROM sentences
+        WHERE is_validated = TRUE
+        GROUP BY locale_id
+      ) s ON l.id = s.locale_id
+      `
     );
     return rows.map(
       (row: {


### PR DESCRIPTION
Updated the query to use a sub query which runs about 20% faster than the previous query.

Relates to #4195