### PR TITLE
Migration to update sentence bands for crh, vmw, guc, fuf, wep, qvi, nhe, dag

### DIFF
--- a/server/src/lib/model/db/migrations/20240123163000-update-sentence-bands.ts
+++ b/server/src/lib/model/db/migrations/20240123163000-update-sentence-bands.ts
@@ -1,0 +1,10 @@
+export const up = async function (db: any): Promise<any> {
+  await db.runSql(`
+    UPDATE locales SET target_sentence_count = 750
+    WHERE name IN ('crh', 'vmw', 'guc', 'fuf', 'wep', 'qvi', 'nhe', 'dag')
+  `);
+};
+
+export const down = async function (): Promise<any> {
+  return null;
+};


### PR DESCRIPTION
Languages updated to 750 sentences:

* 'crh', 'vmw', 'guc', 'fuf', 'wep', 'qvi', 'nhe', 'dag'
