### PR TITLE
Update sentence bands for luo/dav/kln/azz

### DIFF
--- a/server/src/lib/model/db/migrations/20240312124200-update-sentence-bands.ts
+++ b/server/src/lib/model/db/migrations/20240312124200-update-sentence-bands.ts
@@ -1,0 +1,10 @@
+export const up = async function (db: any): Promise<any> {
+  await db.runSql(`
+    UPDATE locales SET target_sentence_count = 750
+    WHERE name IN ('luo', 'azz', 'dav', 'kln')
+  `);
+};
+
+export const down = async function (): Promise<any> {
+  return null;
+};


### PR DESCRIPTION
Update the sentence bands to 750 sentences for `kln`, `dav`, `luo` and `azz`.