### PR TITLE
Oi 3005 update the add sentence endpoint to take in the variant

### DIFF
--- a/server/src/api/sentences/handler/add-sentence-handler.ts
+++ b/server/src/api/sentences/handler/add-sentence-handler.ts
@@ -15,17 +15,17 @@ import { StatusCodes } from 'http-status-codes'
 import { validateSentence } from '../../../core/sentences'
 import {
   findDomainIdByNameInDb,
-  findVariantIdByTokenInDb,
   saveSentenceInDb,
 } from '../../../application/sentences/repository/sentences-repository'
+import { findVariantByTagInDb } from '../../../application/sentences/repository/variant-repository'
+import { getAllLocales } from '../../../application/sentences/repository/locale-repository'
 
 export default async (req: Request, res: Response) => {
-  const { sentence, localeId, localeName, source, domains, variant } = req.body
+  const { sentence, localeName, source, domains, variant } = req.body
 
   const command: AddSentenceCommand = {
     clientId: req.client_id,
     sentence: sentence,
-    localeId: localeId,
     localeName: localeName,
     source: source,
     domains: domains,
@@ -36,7 +36,8 @@ export default async (req: Request, res: Response) => {
     AddSentenceCommandHandler,
     I.ap(validateSentence),
     I.ap(findDomainIdByNameInDb),
-    I.ap(findVariantIdByTokenInDb),
+    I.ap(findVariantByTagInDb),
+    I.ap(getAllLocales),
     I.ap(saveSentenceInDb)
   )
 

--- a/server/src/api/sentences/validation/pending-sentences-requests.ts
+++ b/server/src/api/sentences/validation/pending-sentences-requests.ts
@@ -3,17 +3,13 @@ import { sentenceDomains } from 'common'
 
 export const AddSentenceRequest: AllowedSchema = {
   type: 'object',
-  required: ['sentence', 'source', 'localeId', 'localeName', 'domains'],
+  required: ['sentence', 'source', 'localeName', 'domains'],
   properties: {
     sentence: {
       type: 'string',
     },
     source: {
       type: 'string',
-    },
-    localeId: {
-      type: 'integer',
-      minimum: 1,
     },
     localeName: {
       type: 'string',

--- a/server/src/api/sentences/validation/pending-sentences-requests.ts
+++ b/server/src/api/sentences/validation/pending-sentences-requests.ts
@@ -23,6 +23,7 @@ export const AddSentenceRequest: AllowedSchema = {
       maxItems: 3,
       items: {
         type: 'string',
+        enum: [...sentenceDomains],
       },
       uniqueItems: true,
     },

--- a/server/src/api/sentences/validation/pending-sentences-requests.ts
+++ b/server/src/api/sentences/validation/pending-sentences-requests.ts
@@ -23,9 +23,11 @@ export const AddSentenceRequest: AllowedSchema = {
       maxItems: 3,
       items: {
         type: 'string',
-        enum: [...sentenceDomains],
       },
       uniqueItems: true,
+    },
+    variant: {
+      type: 'string',
     },
   },
 }

--- a/server/src/application/helper/error-helper.ts
+++ b/server/src/application/helper/error-helper.ts
@@ -29,8 +29,8 @@ export const createSentenceValidationError = (
   }
 }
 
-export const createPendingSentencesRepositoryError = createError(
-  'SentencesRepository'
+export const createSentenceRepositoryError = createError(
+  'SentenceRepository'
 )
 export const createDatabaseError = createError('DatabaseError')
 

--- a/server/src/application/sentences/repository/locale-repository.ts
+++ b/server/src/application/sentences/repository/locale-repository.ts
@@ -1,0 +1,24 @@
+import * as TE from 'fp-ts/TaskEither'
+import { ApplicationError } from '../../types/error'
+import { createDatasetError } from '../../helper/error-helper'
+import { pipe } from 'fp-ts/lib/function'
+import { queryDb } from '../../../infrastructure/db/mysql'
+
+export type Locale = Readonly<{
+  id: number
+  name: string
+}>
+
+export type GetAllLocales = () => TE.TaskEither<ApplicationError, Locale[]>
+
+const getAllLocalesQuery = 'SELECT id, name FROM locales'
+
+export const getAllLocales: GetAllLocales = () => {
+  return pipe(
+    queryDb(getAllLocalesQuery)([]),
+    TE.map(([rows]: Array<Array<Locale>> | Array<any>): Locale[] => {
+      return rows.map((row: Locale) => ({ id: row.id, name: row.name }))
+    }),
+    TE.mapLeft(err => createDatasetError('Error retrieving locales', err))
+  )
+}

--- a/server/src/application/sentences/repository/sentences-repository.ts
+++ b/server/src/application/sentences/repository/sentences-repository.ts
@@ -35,7 +35,6 @@ const insertSentenceTransaction = async (
     O.map(variant => variant.id),
     O.getOrElse(() => null)
   )
-  console.log('variantid', sentence.variant)
 
   try {
     await conn.beginTransaction()

--- a/server/src/application/sentences/repository/sentences-repository.ts
+++ b/server/src/application/sentences/repository/sentences-repository.ts
@@ -22,9 +22,6 @@ export type SaveSentence =
 export type FindDomainIdByName =
   (domainName: string) => TE.TaskEither<ApplicationError, O.Option<number>>
 
-export type FindVariantIdByToken =
-  (variantToken: string) => TE.TaskEither<ApplicationError, O.Option<number>>
-
 const insertSentenceTransaction = async (
   db: Mysql,
   sentence: SentenceSubmission
@@ -269,31 +266,8 @@ const findDomainIdByName =
           )
       )
 
-const findVariantIdByToken =
-  (db: Mysql) =>
-    (variantToken: string): TE.TaskEither<ApplicationError, O.Option<number>> =>
-      TE.tryCatch(
-        async () => {
-          const [[row]] = await db.query(
-            `
-          SELECT id FROM variants WHERE variant_token = ?
-        `,
-            [variantToken]
-          )
-          return row ? O.some(row.id) : O.none
-        },
-        (err: Error) =>
-          createSentenceRepositoryError(
-            `Error retrieving variant id for token "${variantToken}"`,
-            err
-          )
-      )
-
 export const saveSentenceInDb: SaveSentence = saveSentence(db)
 export const insertBulkSentencesIntoDb = insertBulkSentences(db)
 export const insertSentenceVoteIntoDb = insertSentenceVote(db)
 export const findSentencesForReviewInDb = findSentencesForReview(db)
-
 export const findDomainIdByNameInDb: FindDomainIdByName = findDomainIdByName(db)
-export const findVariantIdByTokenInDb: FindVariantIdByToken =
-  findVariantIdByToken(db)

--- a/server/src/application/sentences/repository/variant-repository.ts
+++ b/server/src/application/sentences/repository/variant-repository.ts
@@ -1,0 +1,44 @@
+import { getMySQLInstance } from '../../../lib/model/db/mysql'
+import * as O from 'fp-ts/Option'
+import * as TE from 'fp-ts/TaskEither'
+import { ApplicationError } from '../../types/error'
+import { createDatabaseError } from '../../helper/error-helper'
+import { Variant } from '../../../core/types/variant'
+import lazyCache from '../../../lib/lazy-cache'
+
+const db = getMySQLInstance()
+
+export type FindVariantByTag = (
+  variantToken: string
+) => TE.TaskEither<ApplicationError, O.Option<Variant>>
+
+const lazyFindVariantByTag = lazyCache(
+  'sentence-find-variant-by-id',
+  async (variantToken: string): Promise<O.Option<Variant>> => {
+    const [[row]] = await db.query(
+      `
+        SELECT v.id, l.name as locale, variant_name as name, variant_token as tag FROM variants v
+        JOIN locales l
+        ON v.locale_id = l.id
+        WHERE variant_token = ?
+      `,
+      [variantToken]
+    )
+    return row ? O.some(row) : O.none
+  },
+  24 * 60 * 60 * 1000
+)
+
+const findVariantByTag = (
+  variantToken: string
+): TE.TaskEither<ApplicationError, O.Option<Variant>> =>
+  TE.tryCatch(
+    () => lazyFindVariantByTag(variantToken),
+    (err: Error) =>
+      createDatabaseError(
+        `Error retrieving variant information for token "${variantToken}"`,
+        err
+      )
+  )
+
+export const findVariantByTagInDb: FindVariantByTag = findVariantByTag

--- a/server/src/application/sentences/use-case/command-handler/add-sentence-command-handler.ts
+++ b/server/src/application/sentences/use-case/command-handler/add-sentence-command-handler.ts
@@ -78,5 +78,5 @@ export const AddSentenceCommandHandler =
           }
         }
       ),
-      TE.chain(sentenceSubmission => saveSentence(sentenceSubmission))
+      TE.chain(saveSentence)
     )

--- a/server/src/application/sentences/use-case/command-handler/add-sentence-command-handler.ts
+++ b/server/src/application/sentences/use-case/command-handler/add-sentence-command-handler.ts
@@ -1,82 +1,130 @@
 import * as O from 'fp-ts/Option'
 import * as Id from 'fp-ts/Identity'
+import * as A from 'fp-ts/Array'
 import { pipe } from 'fp-ts/lib/function'
 import { ValidateSentence, ValidatedSentence } from '../../../../core/sentences'
 import {
   FindDomainIdByName,
-  FindVariantIdByToken,
   SaveSentence,
 } from '../../repository/sentences-repository'
 import { AddSentenceCommand } from './command/add-sentence-command'
 import { either as E, taskEither as TE } from 'fp-ts'
 import { ApplicationError } from '../../../types/error'
-import { createSentenceValidationError } from '../../../helper/error-helper'
+import {
+  createSentenceValidationError,
+  createValidationError,
+} from '../../../helper/error-helper'
 import { SentenceSubmission } from '../../../types/sentence-submission'
+import { FindVariantByTag } from '../../repository/variant-repository'
+import {
+  GetAllLocales,
+  Locale,
+  getAllLocales,
+} from '../../repository/locale-repository'
+import { Variant } from '../../../../core/types/variant'
 
 const toValidatedSentence =
   (validateSentence: ValidateSentence) =>
-  (sentence: string) =>
-  (localeName: string): TE.TaskEither<ApplicationError, ValidatedSentence> =>
-    pipe(
-      sentence,
-      validateSentence(localeName),
-      E.mapLeft(createSentenceValidationError),
-      TE.fromEither
-    )
+    (sentence: string) =>
+      (localeName: string): TE.TaskEither<ApplicationError, ValidatedSentence> =>
+        pipe(
+          sentence,
+          validateSentence(localeName),
+          E.mapLeft(createSentenceValidationError),
+          TE.fromEither
+        )
 
 const toDomainIds =
   (findDomainId: FindDomainIdByName) =>
-  (domains: string[]): TE.TaskEither<ApplicationError, number[]> => {
-    const findDomainIds = domains.map(domain => findDomainId(domain))
-    return pipe(
-      findDomainIds,
-      TE.sequenceArray,
-      TE.map(domainIds => pipe(domainIds, O.sequenceArray)),
-      TE.map(domainIds =>
-        pipe(
-          domainIds,
-          O.getOrElse(() => [])
+    (domains: string[]): TE.TaskEither<ApplicationError, number[]> => {
+      const findDomainIds = domains.map(domain => findDomainId(domain))
+      return pipe(
+        findDomainIds,
+        TE.sequenceArray,
+        TE.map(domainIds => pipe(domainIds, O.sequenceArray)),
+        TE.map(domainIds =>
+          pipe(
+            domainIds,
+            O.getOrElse(() => [])
+          )
         )
       )
-    )
+    }
+
+const validateVariantWithLocale =
+  (localeName: string) => (variant: Variant) => {
+    return variant.locale === localeName
   }
 
 export const AddSentenceCommandHandler =
   (validateSentence: ValidateSentence) =>
-  (findDomainIdByName: FindDomainIdByName) =>
-  (findVariantIdByToken: FindVariantIdByToken) =>
-  (saveSentence: SaveSentence) =>
-  (command: AddSentenceCommand): TE.TaskEither<ApplicationError, void> =>
-    pipe(
-      TE.Do,
-      TE.bind('validatedSentence', () =>
-        pipe(
-          toValidatedSentence,
-          Id.ap(validateSentence),
-          Id.ap(command.sentence),
-          Id.ap(command.localeName)
-        )
-      ),
-      TE.bind('domainIds', () =>
-        toDomainIds(findDomainIdByName)(command.domains)
-      ),
-      TE.bind('variantId', () =>
-        pipe(
-          command.variant,
-          O.match(() => TE.of(O.none), findVariantIdByToken)
-        )
-      ),
-      TE.map(
-        ({ validatedSentence, domainIds, variantId }): SentenceSubmission => {
-          return {
-            sentence: validatedSentence,
-            source: command.source,
-            locale_id: command.localeId,
-            client_id: command.clientId,
-            domain_ids: [...domainIds],
-            variant_id: variantId,
-          }
-        }
-      ),
-      TE.chain(saveSentence)
-    )
+    (findDomainIdByName: FindDomainIdByName) =>
+      (findVariantByTag: FindVariantByTag) =>
+        (getAllLocales: GetAllLocales) =>
+          (saveSentence: SaveSentence) =>
+            (command: AddSentenceCommand): TE.TaskEither<ApplicationError, void> =>
+              pipe(
+                TE.Do,
+                TE.bind('validatedSentence', () =>
+                  pipe(
+                    toValidatedSentence,
+                    Id.ap(validateSentence),
+                    Id.ap(command.sentence),
+                    Id.ap(command.localeName)
+                  )
+                ),
+                TE.bind('domainIds', () =>
+                  toDomainIds(findDomainIdByName)(command.domains)
+                ),
+                TE.bind('variant', () =>
+                  pipe(
+                    command.variant,
+                    O.match(() => TE.of(O.none), findVariantByTag)
+                  )
+                ),
+                TE.bind('isLocaleMatching', ({ variant }) => {
+                  const doesNotMatchErr = createValidationError(
+                    'Sentence variant does not match locale'
+                  )
+
+                  return pipe(
+                    variant,
+                    O.map(validateVariantWithLocale(command.localeName)),
+                    O.map(res => (res ? TE.right(true) : TE.left(doesNotMatchErr))),
+                    O.getOrElse(() => TE.left(doesNotMatchErr))
+                  )
+                }),
+                TE.bind('localeId', () =>
+                  pipe(
+                    getAllLocales(),
+                    TE.chain(locales =>
+                      pipe(
+                        locales,
+                        A.findFirst(locale => locale.name === command.localeName),
+                        O.map(({ id }) => id),
+                        TE.fromOption(() =>
+                          createValidationError('Locale not found')
+                        )
+                      )
+                    )
+                  )
+                ),
+                TE.map(
+                  ({
+                    validatedSentence,
+                    localeId,
+                    domainIds,
+                    variant,
+                  }): SentenceSubmission => {
+                    return {
+                      sentence: validatedSentence,
+                      source: command.source,
+                      locale_id: localeId,
+                      client_id: command.clientId,
+                      domain_ids: [...domainIds],
+                      variant: variant,
+                    }
+                  }
+                ),
+                TE.chain(saveSentence)
+              )

--- a/server/src/application/sentences/use-case/command-handler/add-sentence-command-handler.ts
+++ b/server/src/application/sentences/use-case/command-handler/add-sentence-command-handler.ts
@@ -1,67 +1,82 @@
+import * as O from 'fp-ts/Option'
+import * as Id from 'fp-ts/Identity'
 import { pipe } from 'fp-ts/lib/function'
-import { validateSentence } from '../../../../core/sentences'
+import { ValidateSentence, ValidatedSentence } from '../../../../core/sentences'
 import {
-  insertSentenceIntoDb,
-  findDomainIdByNameInDb,
+  FindDomainIdByName,
+  FindVariantIdByToken,
+  SaveSentence,
 } from '../../repository/sentences-repository'
 import { AddSentenceCommand } from './command/add-sentence-command'
-import {
-  either as E,
-  task as T,
-  taskEither as TE,
-  taskOption as TO,
-} from 'fp-ts'
-import { ApplicationError, OtherErrorKind } from '../../../types/error'
-import {
-  createError,
-  createSentenceValidationError,
-} from '../../../helper/error-helper'
+import { either as E, taskEither as TE } from 'fp-ts'
+import { ApplicationError } from '../../../types/error'
+import { createSentenceValidationError } from '../../../helper/error-helper'
 import { SentenceSubmission } from '../../../types/sentence-submission'
 
-const createSentenceSubmissionFromCommand = (
-  command: AddSentenceCommand
-): E.Either<ApplicationError, SentenceSubmission> =>
-  pipe(
-    command.sentence,
-    validateSentence(command.localeName),
-    E.mapLeft(createSentenceValidationError),
-    E.map(validatedSentence => ({
-      client_id: command.clientId,
-      locale_id: command.localeId,
-      sentence: validatedSentence,
-      source: command.source,
-    }))
-  )
+const toValidatedSentence =
+  (validateSentence: ValidateSentence) =>
+  (sentence: string) =>
+  (localeName: string): TE.TaskEither<ApplicationError, ValidatedSentence> =>
+    pipe(
+      sentence,
+      validateSentence(localeName),
+      E.mapLeft(createSentenceValidationError),
+      TE.fromEither
+    )
 
-export const AddSentenceCommandHandler = (
-  command: AddSentenceCommand
-): TE.TaskEither<ApplicationError, unknown> => {
-  return pipe(
-    TE.Do,
-    TE.bind('sentenceSubmission', () =>
-      TE.fromEither(createSentenceSubmissionFromCommand(command))
-    ),
-    TE.bind('domainIds', () => {
-      const domains = command.domains ?? []
-      const findDomainIds = domains.map(domain =>
-        findDomainIdByNameInDb(domain)
-      )
-      return pipe(
-        findDomainIds,
-        TO.sequenceArray,
-        TE.fromTaskOption(() =>
-          createError(OtherErrorKind)(
-            `Could not find a matching domain in ${command.domains}`
-          )
+const toDomainIds =
+  (findDomainId: FindDomainIdByName) =>
+  (domains: string[]): TE.TaskEither<ApplicationError, number[]> => {
+    const findDomainIds = domains.map(domain => findDomainId(domain))
+    return pipe(
+      findDomainIds,
+      TE.sequenceArray,
+      TE.map(domainIds => pipe(domainIds, O.sequenceArray)),
+      TE.map(domainIds =>
+        pipe(
+          domainIds,
+          O.getOrElse(() => [])
         )
       )
-    }),
-    TE.map(({ sentenceSubmission, domainIds }): SentenceSubmission => {
-      return {
-        ...sentenceSubmission,
-        domain_ids: [...domainIds],
-      }
-    }),
-    TE.chain(sentenceSubmission => insertSentenceIntoDb(sentenceSubmission))
-  )
-}
+    )
+  }
+
+export const AddSentenceCommandHandler =
+  (validateSentence: ValidateSentence) =>
+  (findDomainIdByName: FindDomainIdByName) =>
+  (findVariantIdByToken: FindVariantIdByToken) =>
+  (saveSentence: SaveSentence) =>
+  (command: AddSentenceCommand): TE.TaskEither<ApplicationError, void> =>
+    pipe(
+      TE.Do,
+      TE.bind('validatedSentence', () =>
+        pipe(
+          toValidatedSentence,
+          Id.ap(validateSentence),
+          Id.ap(command.sentence),
+          Id.ap(command.localeName)
+        )
+      ),
+      TE.bind('domainIds', () =>
+        toDomainIds(findDomainIdByName)(command.domains)
+      ),
+      TE.bind('variantId', () =>
+        pipe(
+          command.variant,
+          O.match(() => TE.of(O.none), findVariantIdByToken)
+        )
+      ),
+      TE.map(
+        ({ validatedSentence, domainIds, variantId }): SentenceSubmission => {
+          return {
+            sentence: validatedSentence,
+            source: command.source,
+            locale_id: command.localeId,
+            client_id: command.clientId,
+            domain_ids: [...domainIds],
+            variant_id: variantId,
+          }
+        }
+      ),
+      TE.chain(sentenceSubmission => saveSentence(sentenceSubmission))
+    )

--- a/server/src/application/sentences/use-case/command-handler/command/add-sentence-command.ts
+++ b/server/src/application/sentences/use-case/command-handler/command/add-sentence-command.ts
@@ -1,13 +1,12 @@
 import { Option } from 'fp-ts/Option'
 
-import { SentenceDomain } from "common"
+import { SentenceDomain } from 'common'
 
 export type AddSentenceCommand = {
   clientId: string
   sentence: string
-  localeId: number
   localeName: string
-  source: string,
+  source: string
   domains: SentenceDomain[]
-  variant: Option<string> 
+  variant: Option<string>
 }

--- a/server/src/application/sentences/use-case/command-handler/command/add-sentence-command.ts
+++ b/server/src/application/sentences/use-case/command-handler/command/add-sentence-command.ts
@@ -1,3 +1,5 @@
+import { Option } from 'fp-ts/Option'
+
 import { SentenceDomain } from "common"
 
 export type AddSentenceCommand = {
@@ -7,4 +9,5 @@ export type AddSentenceCommand = {
   localeName: string
   source: string,
   domains: SentenceDomain[]
+  variant: Option<string> 
 }

--- a/server/src/application/types/error.ts
+++ b/server/src/application/types/error.ts
@@ -1,6 +1,6 @@
 import { ValidatorRuleErrorType } from '../../core/sentences'
 
-export const SentencesRepositoryErrorKind = 'SentencesRepository'
+export const SentenceRepositoryErrorKind = 'SentenceRepository'
 export const SentenceValidationErrorKind = 'SentenceValidation'
 export const ValidationErrorKind = 'Validation'
 export const DatabaseErrorKind = 'DatabaseError'
@@ -10,7 +10,7 @@ export const OtherErrorKind = 'Other'
 
 export const ApplicationErrorKinds = [
   ValidationErrorKind,
-  SentencesRepositoryErrorKind,
+  SentenceRepositoryErrorKind,
   SentenceValidationErrorKind,
   DatabaseErrorKind,
   BulkSubmissionErrorKind,

--- a/server/src/application/types/sentence-submission.ts
+++ b/server/src/application/types/sentence-submission.ts
@@ -1,7 +1,10 @@
+import { Option } from 'fp-ts/Option'
+
 export type SentenceSubmission = {
   sentence: string;
   source: string;
   locale_id: number;
   client_id: string;
   domain_ids?: number[] | null
+  variant_id: Option<number>
 };

--- a/server/src/application/types/sentence-submission.ts
+++ b/server/src/application/types/sentence-submission.ts
@@ -1,10 +1,11 @@
 import { Option } from 'fp-ts/Option'
+import { Variant } from '../../core/types/variant'
 
 export type SentenceSubmission = {
-  sentence: string;
-  source: string;
-  locale_id: number;
-  client_id: string;
+  sentence: string
+  source: string
+  locale_id: number
+  client_id: string
   domain_ids?: number[] | null
-  variant_id: Option<number>
-};
+  variant: Option<Variant>
+}

--- a/server/src/core/sentences/types/sentence.ts
+++ b/server/src/core/sentences/types/sentence.ts
@@ -4,3 +4,5 @@ export type UnvalidatedSentence = {
   source: string
   localeId: number
 }
+
+export type ValidatedSentence = string

--- a/server/src/core/sentences/types/validators.ts
+++ b/server/src/core/sentences/types/validators.ts
@@ -22,12 +22,12 @@ const ValidatorLocales = [
   'default_locale',
 ] as const
 
-export const ERR_TOO_LONG = 'TOO_LONG'
-export const ERR_NO_NUMBERS = 'NO_NUMBERS'
-export const ERR_NO_SYMBOLS = 'NO_SYMBOLS'
-export const ERR_NO_ABBREVIATIONS = 'NO_ABBREVIATIONS'
-export const ERR_NO_FOREIGN_SCRIPT = 'NO_FOREIGN_SCRIPT'
-export const ERR_OTHER = 'OTHER'
+export const ERR_TOO_LONG = 'TOO_LONG' as const
+export const ERR_NO_NUMBERS = 'NO_NUMBERS' as const
+export const ERR_NO_SYMBOLS = 'NO_SYMBOLS' as const
+export const ERR_NO_ABBREVIATIONS = 'NO_ABBREVIATIONS' as const
+export const ERR_NO_FOREIGN_SCRIPT = 'NO_FOREIGN_SCRIPT' as const
+export const ERR_OTHER = 'OTHER' as const
 
 export const ERROR_TYPES = [
   ERR_TOO_LONG,

--- a/server/src/core/sentences/validation/validation.ts
+++ b/server/src/core/sentences/validation/validation.ts
@@ -26,6 +26,7 @@ import { flow, pipe } from 'fp-ts/function'
 import { Validators } from '..'
 import {
   isValidatorLocale,
+  ValidatedSentence,
   ValidatorLocale,
   ValidatorRule,
   ValidatorRuleError,
@@ -88,10 +89,16 @@ const normalizeForLocale = (locale: string) => (sentence: string) =>
 
 const validateSentenceForLocale = flow(getValidatorFor, runValidatorOnSentence)
 
-export const validateSentence = (locale: string) => (sentence: string) => {
-  return pipe(
-    sentence,
-    normalizeForLocale(locale),
-    validateSentenceForLocale(locale)
-  )
-}
+export type ValidateSentence = (
+  locale: string
+) => (sentence: string) => E.Either<ValidatorRuleError, ValidatedSentence>
+
+export const validateSentence: ValidateSentence =
+  (locale: string) =>
+  (sentence: string): E.Either<ValidatorRuleError, ValidatedSentence> => {
+    return pipe(
+      sentence,
+      normalizeForLocale(locale),
+      validateSentenceForLocale(locale)
+    )
+  }

--- a/server/src/core/types/variant.ts
+++ b/server/src/core/types/variant.ts
@@ -1,0 +1,6 @@
+export type Variant = {
+  id: number
+  locale: string
+  name: string
+  tag: string
+}

--- a/server/src/test/application/sentences/use-case/command-handler/add-sentence-command-handler.test.ts
+++ b/server/src/test/application/sentences/use-case/command-handler/add-sentence-command-handler.test.ts
@@ -3,21 +3,19 @@ import { constVoid, pipe } from 'fp-ts/lib/function'
 import * as I from 'fp-ts/Identity'
 import * as O from 'fp-ts/Option'
 import { AddSentenceCommandHandler } from '../../../../../application/sentences/use-case/command-handler/add-sentence-command-handler'
-import {
-  ERR_TOO_LONG,
-  ValidateSentence,
-} from '../../../../../core/sentences'
+import { ERR_TOO_LONG, ValidateSentence } from '../../../../../core/sentences'
 import {
   FindDomainIdByName,
   FindVariantIdByToken,
   SaveSentence,
 } from '../../../../../application/sentences/repository/sentences-repository'
 import { AddSentenceCommand } from '../../../../../application/sentences/use-case/command-handler/command/add-sentence-command'
+import { SentenceSubmission } from '../../../../../application/types/sentence-submission'
 
 describe('Add sentence command handler', () => {
   it('should save the sentence in the repository', async () => {
     const validateSentenceMock: ValidateSentence = jest.fn(
-      () => () => E.right('Correct Sentence')
+      () => () => E.right('This is a sentence')
     )
     const findDomainIdByNameMock: FindDomainIdByName = jest.fn(() =>
       TE.right(O.some(1))
@@ -37,6 +35,15 @@ describe('Add sentence command handler', () => {
       variant: O.none,
     }
 
+    const expectedSentenceSubmission: SentenceSubmission = {
+      sentence: 'This is a sentence',
+      source: 'Myself',
+      locale_id: 1,
+      client_id: 'abc',
+      domain_ids: [1],
+      variant_id: O.none,
+    }
+
     const cmdHandler = pipe(
       AddSentenceCommandHandler,
       I.ap(validateSentenceMock),
@@ -46,13 +53,14 @@ describe('Add sentence command handler', () => {
     )
 
     const result = await pipe(cmd, cmdHandler)()
+    expect(saveSentenceMock).toBeCalledWith(expectedSentenceSubmission)
     expect(E.isRight(result)).toBeTruthy()
   })
 
   it('should return validation error', async () => {
     const validationError = {
       error: 'Oops',
-      errorType: ERR_TOO_LONG
+      errorType: ERR_TOO_LONG,
     }
     const validateSentenceMock: ValidateSentence = jest.fn(
       () => () => E.left(validationError)

--- a/server/src/test/application/sentences/use-case/command-handler/add-sentence-command-handler.test.ts
+++ b/server/src/test/application/sentences/use-case/command-handler/add-sentence-command-handler.test.ts
@@ -1,0 +1,90 @@
+import { either as E, taskEither as TE } from 'fp-ts'
+import { constVoid, pipe } from 'fp-ts/lib/function'
+import * as I from 'fp-ts/Identity'
+import * as O from 'fp-ts/Option'
+import { AddSentenceCommandHandler } from '../../../../../application/sentences/use-case/command-handler/add-sentence-command-handler'
+import {
+  ERR_TOO_LONG,
+  ValidateSentence,
+} from '../../../../../core/sentences'
+import {
+  FindDomainIdByName,
+  FindVariantIdByToken,
+  SaveSentence,
+} from '../../../../../application/sentences/repository/sentences-repository'
+import { AddSentenceCommand } from '../../../../../application/sentences/use-case/command-handler/command/add-sentence-command'
+
+describe('Add sentence command handler', () => {
+  it('should save the sentence in the repository', async () => {
+    const validateSentenceMock: ValidateSentence = jest.fn(
+      () => () => E.right('Correct Sentence')
+    )
+    const findDomainIdByNameMock: FindDomainIdByName = jest.fn(() =>
+      TE.right(O.some(1))
+    )
+    const findVariantIdByTokenMock: FindVariantIdByToken = jest.fn(() =>
+      TE.right(O.some(1))
+    )
+    const saveSentenceMock: SaveSentence = jest.fn(() => TE.right(constVoid()))
+
+    const cmd: AddSentenceCommand = {
+      clientId: 'abc',
+      sentence: 'This is a sentence',
+      localeId: 1,
+      localeName: 'en',
+      source: 'Myself',
+      domains: ['finance'],
+      variant: O.none,
+    }
+
+    const cmdHandler = pipe(
+      AddSentenceCommandHandler,
+      I.ap(validateSentenceMock),
+      I.ap(findDomainIdByNameMock),
+      I.ap(findVariantIdByTokenMock),
+      I.ap(saveSentenceMock)
+    )
+
+    const result = await pipe(cmd, cmdHandler)()
+    expect(E.isRight(result)).toBeTruthy()
+  })
+
+  it('should return validation error', async () => {
+    const validationError = {
+      error: 'Oops',
+      errorType: ERR_TOO_LONG
+    }
+    const validateSentenceMock: ValidateSentence = jest.fn(
+      () => () => E.left(validationError)
+    )
+    const findDomainIdByNameMock: FindDomainIdByName = jest.fn(() =>
+      TE.right(O.some(1))
+    )
+    const findVariantIdByTokenMock: FindVariantIdByToken = jest.fn(() =>
+      TE.right(O.some(1))
+    )
+    const saveSentenceMock: SaveSentence = jest.fn(() => TE.right(constVoid()))
+
+    const cmd: AddSentenceCommand = {
+      clientId: 'abc',
+      sentence: 'This is a sentence',
+      localeId: 1,
+      localeName: 'en',
+      source: 'Myself',
+      domains: ['finance'],
+      variant: O.none,
+    }
+
+    const cmdHandler = pipe(
+      AddSentenceCommandHandler,
+      I.ap(validateSentenceMock),
+      I.ap(findDomainIdByNameMock),
+      I.ap(findVariantIdByTokenMock),
+      I.ap(saveSentenceMock)
+    )
+
+    const result = await pipe(cmd, cmdHandler)()
+    expect(E.isLeft(result)).toBeTruthy()
+    expect(saveSentenceMock).toHaveBeenCalledTimes(0)
+  })
+})


### PR DESCRIPTION
* add the variant tag and remove locale id from the `add-sentence` endpoint request
  * the `variant` property is optional on the request
* some small naming changes
* refactor add sentence command handler to be easier to test
* add a test for the add sentence command handler