### PR TITLE
OI-3057: check if variant is matching the locale

### DIFF
--- a/server/src/api/sentences/handler/add-sentence-handler.ts
+++ b/server/src/api/sentences/handler/add-sentence-handler.ts
@@ -15,9 +15,9 @@ import { StatusCodes } from 'http-status-codes'
 import { validateSentence } from '../../../core/sentences'
 import {
   findDomainIdByNameInDb,
-  findVariantIdByTokenInDb,
   saveSentenceInDb,
 } from '../../../application/sentences/repository/sentences-repository'
+import { findVariantByTagInDb } from '../../../application/sentences/repository/variant-repository'
 
 export default async (req: Request, res: Response) => {
   const { sentence, localeId, localeName, source, domains, variant } = req.body
@@ -36,7 +36,7 @@ export default async (req: Request, res: Response) => {
     AddSentenceCommandHandler,
     I.ap(validateSentence),
     I.ap(findDomainIdByNameInDb),
-    I.ap(findVariantIdByTokenInDb),
+    I.ap(findVariantByTagInDb),
     I.ap(saveSentenceInDb)
   )
 

--- a/server/src/api/sentences/handler/add-sentence-handler.ts
+++ b/server/src/api/sentences/handler/add-sentence-handler.ts
@@ -1,6 +1,5 @@
 import { Request, Response } from 'express'
 import * as TE from 'fp-ts/TaskEither'
-import * as T from 'fp-ts/Task'
 import * as O from 'fp-ts/Option'
 import * as I from 'fp-ts/Identity'
 import { pipe } from 'fp-ts/function'
@@ -18,14 +17,14 @@ import {
   saveSentenceInDb,
 } from '../../../application/sentences/repository/sentences-repository'
 import { findVariantByTagInDb } from '../../../application/sentences/repository/variant-repository'
+import { findLocaleByNameInDb } from '../../../application/sentences/repository/locale-repository'
 
 export default async (req: Request, res: Response) => {
-  const { sentence, localeId, localeName, source, domains, variant } = req.body
+  const { sentence, localeName, source, domains, variant } = req.body
 
   const command: AddSentenceCommand = {
     clientId: req.client_id,
     sentence: sentence,
-    localeId: localeId,
     localeName: localeName,
     source: source,
     domains: domains,
@@ -37,6 +36,7 @@ export default async (req: Request, res: Response) => {
     I.ap(validateSentence),
     I.ap(findDomainIdByNameInDb),
     I.ap(findVariantByTagInDb),
+    I.ap(findLocaleByNameInDb),
     I.ap(saveSentenceInDb)
   )
 
@@ -49,11 +49,11 @@ export default async (req: Request, res: Response) => {
         switch (err.kind) {
           case SentenceRepositoryErrorKind: {
             res.status(StatusCodes.INTERNAL_SERVER_ERROR)
-            break;
+            break
           }
           case SentenceValidationErrorKind: {
             res.status(StatusCodes.BAD_REQUEST)
-            break;
+            break
           }
         }
 

--- a/server/src/api/sentences/validation/pending-sentences-requests.ts
+++ b/server/src/api/sentences/validation/pending-sentences-requests.ts
@@ -3,17 +3,13 @@ import { sentenceDomains } from 'common'
 
 export const AddSentenceRequest: AllowedSchema = {
   type: 'object',
-  required: ['sentence', 'source', 'localeId', 'localeName', 'domains'],
+  required: ['sentence', 'source', 'localeName', 'domains'],
   properties: {
     sentence: {
       type: 'string',
     },
     source: {
       type: 'string',
-    },
-    localeId: {
-      type: 'integer',
-      minimum: 1,
     },
     localeName: {
       type: 'string',

--- a/server/src/application/sentences/repository/locale-repository.ts
+++ b/server/src/application/sentences/repository/locale-repository.ts
@@ -1,0 +1,53 @@
+import { option as O, taskEither as TE } from 'fp-ts'
+import { ApplicationError } from '../../types/error'
+import { queryDb } from '../../../infrastructure/db/mysql'
+import { pipe } from 'fp-ts/lib/function'
+import { createDatabaseError } from '../../helper/error-helper'
+import { Locale, TextDirection } from '../../../core/types/locale'
+
+export type FindLocaleByName = (
+  localeName: string
+) => TE.TaskEither<ApplicationError, O.Option<Locale>>
+
+type LocaleRow = {
+  id: number
+  name: string
+  targetSentenceCount: number
+  isContributable: number
+  isTranslated: number
+  textDirection: TextDirection
+}
+
+export const findLocaleByNameInDb: FindLocaleByName = (localeName: string) =>
+  pipe(
+    [localeName],
+    queryDb(
+      ` SELECT 
+          id,
+          name,
+          target_sentence_count as targetSentenceCount,
+          is_contributable as isContributable,
+          is_translated as isTranslated,
+          text_direction as textDirection
+        FROM locales
+        WHERE name = ?
+      `
+    ),
+    TE.mapLeft((err: Error) =>
+      createDatabaseError(
+        `Error retrieving locale by name "${localeName}"`,
+        err
+      )
+    ),
+    TE.map(([[result]]: Array<Array<LocaleRow>>) => {
+      return pipe(
+        result,
+        O.fromNullable,
+        O.map(result => ({
+          ...result,
+          isContributable: result.isContributable === 1,
+          isTranslated: result.isTranslated === 1,
+        }))
+      )
+    })
+  )

--- a/server/src/application/sentences/repository/locale-repository.ts
+++ b/server/src/application/sentences/repository/locale-repository.ts
@@ -22,7 +22,7 @@ export const findLocaleByNameInDb: FindLocaleByName = (localeName: string) =>
   pipe(
     [localeName],
     queryDb(
-      ` SELECT 
+      ` SELECT
           id,
           name,
           target_sentence_count as targetSentenceCount,

--- a/server/src/application/sentences/repository/sentences-repository.ts
+++ b/server/src/application/sentences/repository/sentences-repository.ts
@@ -22,9 +22,6 @@ export type SaveSentence =
 export type FindDomainIdByName =
   (domainName: string) => TE.TaskEither<ApplicationError, O.Option<number>>
 
-export type FindVariantIdByToken =
-  (variantToken: string) => TE.TaskEither<ApplicationError, O.Option<number>>
-
 const insertSentenceTransaction = async (
   db: Mysql,
   sentence: SentenceSubmission
@@ -273,31 +270,8 @@ const findDomainIdByName =
           )
       )
 
-const findVariantIdByToken =
-  (db: Mysql) =>
-    (variantToken: string): TE.TaskEither<ApplicationError, O.Option<number>> =>
-      TE.tryCatch(
-        async () => {
-          const [[row]] = await db.query(
-            `
-          SELECT id FROM variants WHERE variant_token = ?
-        `,
-            [variantToken]
-          )
-          return row ? O.some(row.id) : O.none
-        },
-        (err: Error) =>
-          createSentenceRepositoryError(
-            `Error retrieving variant id for token "${variantToken}"`,
-            err
-          )
-      )
-
 export const saveSentenceInDb: SaveSentence = saveSentence(db)
 export const insertBulkSentencesIntoDb = insertBulkSentences(db)
 export const insertSentenceVoteIntoDb = insertSentenceVote(db)
 export const findSentencesForReviewInDb = findSentencesForReview(db)
-
 export const findDomainIdByNameInDb: FindDomainIdByName = findDomainIdByName(db)
-export const findVariantIdByTokenInDb: FindVariantIdByToken =
-  findVariantIdByToken(db)

--- a/server/src/application/sentences/repository/variant-repository.ts
+++ b/server/src/application/sentences/repository/variant-repository.ts
@@ -1,0 +1,28 @@
+import { option as O, taskEither as TE } from 'fp-ts'
+import { ApplicationError } from '../../types/error'
+import { Variant } from '../../../core/types/variant'
+import { queryDb } from '../../../infrastructure/db/mysql'
+import { pipe } from 'fp-ts/lib/function'
+import { createDatabaseError } from '../../helper/error-helper'
+
+export type FindVariantByTag = (
+  variantName: string
+) => TE.TaskEither<ApplicationError, O.Option<Variant>>
+
+export const findVariantByTagInDb: FindVariantByTag = (variantName: string) =>
+  pipe(
+    [variantName],
+    queryDb(
+      ` SELECT v.id, l.name as locale, variant_name as name, variant_token as tag FROM variants v
+        INNER JOIN locales l ON (l.id = v.locale_id)
+        WHERE variant_token = ?
+      `
+    ),
+    TE.mapLeft((err: Error) =>
+      createDatabaseError(
+        `Error retrieving variant by name "${variantName}"`,
+        err
+      )
+    ),
+    TE.map(([[result]]: Array<Array<Variant>>) => O.fromNullable(result))
+  )

--- a/server/src/application/sentences/use-case/command-handler/command/add-sentence-command.ts
+++ b/server/src/application/sentences/use-case/command-handler/command/add-sentence-command.ts
@@ -5,7 +5,6 @@ import { SentenceDomain } from "common"
 export type AddSentenceCommand = {
   clientId: string
   sentence: string
-  localeId: number
   localeName: string
   source: string,
   domains: SentenceDomain[]

--- a/server/src/core/types/locale.ts
+++ b/server/src/core/types/locale.ts
@@ -1,0 +1,10 @@
+export type TextDirection = 'LTR' | 'RTL' | 'TTB' | 'BTT'
+
+export type Locale = {
+  id: number
+  name: string
+  targetSentenceCount: number
+  isContributable: boolean
+  isTranslated: boolean
+  textDirection: TextDirection
+}

--- a/server/src/core/types/variant.ts
+++ b/server/src/core/types/variant.ts
@@ -1,0 +1,6 @@
+export type Variant = {
+  id: number
+  locale: string
+  name: string
+  tag: string
+}

--- a/server/src/test/application/sentences/use-case/command-handler/add-sentence-command-handler.test.ts
+++ b/server/src/test/application/sentences/use-case/command-handler/add-sentence-command-handler.test.ts
@@ -6,11 +6,11 @@ import { AddSentenceCommandHandler } from '../../../../../application/sentences/
 import { ERR_TOO_LONG, ValidateSentence } from '../../../../../core/sentences'
 import {
   FindDomainIdByName,
-  FindVariantIdByToken,
   SaveSentence,
 } from '../../../../../application/sentences/repository/sentences-repository'
 import { AddSentenceCommand } from '../../../../../application/sentences/use-case/command-handler/command/add-sentence-command'
 import { SentenceSubmission } from '../../../../../application/types/sentence-submission'
+import { FindVariantByTag } from '../../../../../application/sentences/repository/variant-repository'
 
 describe('Add sentence command handler', () => {
   it('should save the sentence in the repository', async () => {
@@ -20,8 +20,10 @@ describe('Add sentence command handler', () => {
     const findDomainIdByNameMock: FindDomainIdByName = jest.fn(() =>
       TE.right(O.some(1))
     )
-    const findVariantIdByTokenMock: FindVariantIdByToken = jest.fn(() =>
-      TE.right(O.some(1))
+    const findVariantByTokenMock: FindVariantByTag = jest.fn(() =>
+      TE.right(
+        O.some({ id: 1, name: 'Central', tag: 'ca-central', locale: 'ca' })
+      )
     )
     const saveSentenceMock: SaveSentence = jest.fn(() => TE.right(constVoid()))
 
@@ -48,7 +50,7 @@ describe('Add sentence command handler', () => {
       AddSentenceCommandHandler,
       I.ap(validateSentenceMock),
       I.ap(findDomainIdByNameMock),
-      I.ap(findVariantIdByTokenMock),
+      I.ap(findVariantByTokenMock),
       I.ap(saveSentenceMock)
     )
 
@@ -68,8 +70,10 @@ describe('Add sentence command handler', () => {
     const findDomainIdByNameMock: FindDomainIdByName = jest.fn(() =>
       TE.right(O.some(1))
     )
-    const findVariantIdByTokenMock: FindVariantIdByToken = jest.fn(() =>
-      TE.right(O.some(1))
+    const findVariantByTokenMock: FindVariantByTag = jest.fn(() =>
+      TE.right(
+        O.some({ id: 1, name: 'Central', tag: 'ca-central', locale: 'ca' })
+      )
     )
     const saveSentenceMock: SaveSentence = jest.fn(() => TE.right(constVoid()))
 
@@ -87,7 +91,7 @@ describe('Add sentence command handler', () => {
       AddSentenceCommandHandler,
       I.ap(validateSentenceMock),
       I.ap(findDomainIdByNameMock),
-      I.ap(findVariantIdByTokenMock),
+      I.ap(findVariantByTokenMock),
       I.ap(saveSentenceMock)
     )
 


### PR DESCRIPTION
Make sure that the submitted sentence locale matches the locale that variant belongs to. Also remove the `localeId` from the add sentence endpoint to prevent an additional mismatch between provided `localeName` and `localeId`.