### PR TITLE
OI-3078: Provide variant tag on the speak and listen page

### DIFF
--- a/common/clips.ts
+++ b/common/clips.ts
@@ -1,9 +1,11 @@
+import { Variant } from './language';
 import { TaxonomyType } from './taxonomies';
 
 export type Sentence = {
   id: string;
   text: string;
   taxonomy?: TaxonomyType;
+  variant?: Variant;
 };
 
 export type Clip = {

--- a/server/src/application/sentences/repository/variant-repository.ts
+++ b/server/src/application/sentences/repository/variant-repository.ts
@@ -9,6 +9,13 @@ export type FindVariantByTag = (
   variantName: string
 ) => TE.TaskEither<ApplicationError, O.Option<Variant>>
 
+export type FindVariantsBySentenceIds = (
+  sentenceIds: string[]
+) => TE.TaskEither<
+  ApplicationError,
+  { [sentenceId: string]: O.Option<Variant> }[]
+>
+
 export const findVariantByTagInDb: FindVariantByTag = (variantName: string) =>
   pipe(
     [variantName],
@@ -25,4 +32,42 @@ export const findVariantByTagInDb: FindVariantByTag = (variantName: string) =>
       )
     ),
     TE.map(([[result]]: Array<Array<Variant>>) => O.fromNullable(result))
+  )
+
+export const findVariantsBySentenceIdsInDb: FindVariantsBySentenceIds = (
+  sentenceIds: string[]
+) =>
+  pipe(
+    [sentenceIds],
+    queryDb(
+      ` SELECT sm.sentence_id, v.id, l.name as locale, v.variant_name as name, v.variant_token as tag
+        FROM sentence_metadata sm
+        LEFT JOIN variants v ON (v.id = sm.variant_id)
+        LEFT JOIN locales l ON (l.id = v.locale_id)
+        WHERE sentence_id IN (?)
+      `
+    ),
+    TE.mapLeft((err: Error) =>
+      createDatabaseError(
+        `Error retrieving variants by sentence ids "${sentenceIds}"`,
+        err
+      )
+    ),
+    TE.map(
+      ([results]: Array<Array<{ sentence_id: string } & Variant>>) => results
+    ),
+    TE.map(rows =>
+      rows.map(row => {
+        const { sentence_id, ...variant } = row
+        return {
+          [sentence_id]: O.fromPredicate(
+            (v: Variant) =>
+              v.id !== null &&
+              v.name !== null &&
+              v.tag !== null &&
+              v.locale !== null
+          )(variant),
+        }
+      })
+    )
   )

--- a/server/src/infrastructure/db/mysql.ts
+++ b/server/src/infrastructure/db/mysql.ts
@@ -4,9 +4,9 @@ import lazyCache from '../../lib/lazy-cache'
 import { createMd5Hash } from '../crypto/crypto'
 
 const db: Mysql = getMySQLInstance()
-type QueryParams = Array<string | number | boolean> | Array<Array<string | number | boolean>>
-
-
+type QueryParams =
+  | Array<string | number | boolean>
+  | Array<Array<string | number | boolean>>
 
 const lazyQuery =
   (db: Mysql) =>

--- a/server/src/infrastructure/db/mysql.ts
+++ b/server/src/infrastructure/db/mysql.ts
@@ -4,7 +4,9 @@ import lazyCache from '../../lib/lazy-cache'
 import { createMd5Hash } from '../crypto/crypto'
 
 const db: Mysql = getMySQLInstance()
-type QueryParams = Array<string | number | boolean>
+type QueryParams = Array<string | number | boolean> | Array<Array<string | number | boolean>>
+
+
 
 const lazyQuery =
   (db: Mysql) =>


### PR DESCRIPTION
Add variant info to the response object to display it on the speak and listen page.
* feat: add method to retrieve variants by sentence id

* feat: append variant metadata to sentence for listen page

* feat: add variants to sentences for the speak page