### PR TITLE
fix: check if variant exists on current language

### DIFF
--- a/web/src/components/pages/contribution/sentence-collector/review/review.tsx
+++ b/web/src/components/pages/contribution/sentence-collector/review/review.tsx
@@ -83,7 +83,7 @@ const Review: React.FC<Props> = ({ getString }) => {
     language => language.locale == currentLocale
   )
 
-  const isVariantPreferredOption = currentLanguage?.variant.is_preferred_option
+  const isVariantPreferredOption = currentLanguage?.variant?.is_preferred_option
 
   const reportModalProps = {
     reasons: [


### PR DESCRIPTION
It crashed when the current language has no variant. Therefore we need to optionally chain the variant property.