### PR TITLE
fix: use host's user:group ids else default back to user:group define…

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -43,6 +43,7 @@ services:
       context: ./bundler
       dockerfile: Dockerfile
     container_name: bundler
+    user: "${UID:-10001}:${GID:-10001}"
     links:
       - db
       - redis
@@ -59,6 +60,7 @@ services:
       context: .
       dockerfile: docker/Dockerfile
     container_name: web
+    user: "${UID:-10001}:${GID:-10001}"
     links:
       - db
       - redis


### PR DESCRIPTION
Use the host's user or fallback to the user defined in the Dockerfile. This should solve the `"EACCES: permission denied` error on linux based systems.

Related Issues:
#4543
#4389
#4003