### PR TITLE
Footer changes

### DIFF
--- a/web/src/components/layout/footer.css
+++ b/web/src/components/layout/footer.css
@@ -199,7 +199,7 @@ footer {
     }
 
     & .icons {
-        width: 100%;
+        width: 60%;
         display: flex;
         justify-content: space-around;
 

--- a/web/src/components/layout/footer.css
+++ b/web/src/components/layout/footer.css
@@ -199,7 +199,7 @@ footer {
     }
 
     & .icons {
-        width: 60%;
+        width: 100%;
         display: flex;
         justify-content: space-around;
 


### PR DESCRIPTION

### Bug Report: Social Media Icons Not Centered Properly

**Issue ID:** #4571

**Status:** Open

**Reported by:** Manan21st

**Timestamp:** 11 minutes ago

#### Expected Behavior
The social media icons should be centered horizontally and vertically within the designated area.

#### Observed Behavior
The social media icons (link, Facebook, and X icons) are not centered properly. They appear misaligned within their container.

#### Visual Evidence
![UI Bug](path_to_image)

*The provided screenshot shows the misalignment of the icons. The text "Help us find others to donate their voice!" is centered correctly, but the icons below are skewed to the right.*

#### Steps to Reproduce
1. Open the relevant UI component in the application.
2. Observe the alignment of the social media icons.
3. Note the misalignment.

#### Environment
- **Browser:** (specify browser and version)
- **Operating System:** (specify OS and version)
- **Device:** (specify device if applicable)

#### Labels
- Bug

