### PR TITLE
fix: show localised language name

### DIFF
--- a/server/src/lib/model/db/import-locales.ts
+++ b/server/src/lib/model/db/import-locales.ts
@@ -223,7 +223,7 @@ const buildLocaleNativeNameMapping: any = () => {
     const messagesPath = path.join(
       localeMessagesPath,
       locale,
-      'page',
+      'pages',
       'common.ftl'
     )
 


### PR DESCRIPTION
The language selector only showed language codes instead of the name of the language. Now the language names will be displayed in currently selected language.