### PR TITLE
Fix for clip loading in Listen section

### DIFF
--- a/web/src/components/pages/contribution/listen/listen.tsx
+++ b/web/src/components/pages/contribution/listen/listen.tsx
@@ -108,7 +108,10 @@ class ListenPage extends React.Component<Props, State> {
   demoMode = this.props.location.pathname.includes(URLS.DEMO)
 
   static getDerivedStateFromProps(props: Props, state: State) {
-    if (state.clips.length > 0) return null
+
+    const unvalidatedClips = state.clips.filter(clip => clip.isValid === null).length;
+
+    if (unvalidatedClips > 0) return null
 
     if (props.clips && props.clips.length > 0) {
       return {
@@ -308,6 +311,10 @@ class ListenPage extends React.Component<Props, State> {
       lang => lang.locale === locale
     );
     const isVariantPreferredOption = currentLocale?.variant?.is_preferred_option;
+
+    console.log('isLoading', isLoading)
+    console.log('isMissingClips', isMissingClips, noClips, !activeClip)
+    console.log('clipIndex', clipIndex, clips)
 
     return (
       <>

--- a/web/src/components/pages/contribution/listen/listen.tsx
+++ b/web/src/components/pages/contribution/listen/listen.tsx
@@ -312,10 +312,6 @@ class ListenPage extends React.Component<Props, State> {
     );
     const isVariantPreferredOption = currentLocale?.variant?.is_preferred_option;
 
-    console.log('isLoading', isLoading)
-    console.log('isMissingClips', isMissingClips, noClips, !activeClip)
-    console.log('clipIndex', clipIndex, clips)
-
     return (
       <>
         <div id="listen-page">


### PR DESCRIPTION
## Pull Request Form

### Type of Pull Request

- [ ] Bulk sentence upload 
- [x] Related to a listed issue 

* https://github.com/common-voice/common-voice/issues/3747
* https://github.com/common-voice/common-voice/issues/4233

- [ ] Other

This PR will fix "There are no more clips to validate" error only after first 5 clips for logged in contributors. After each 5 clip batch the next will be loaded without need for users to reload the page.
