### PR TITLE
602 build validation pipeline for multiple sentences

### DIFF
--- a/server/src/api/sentences/handler/add-small-sentence-batch-handler.ts
+++ b/server/src/api/sentences/handler/add-small-sentence-batch-handler.ts
@@ -1,0 +1,51 @@
+import { Request, Response } from 'express'
+import * as I from 'fp-ts/Identity'
+import * as O from 'fp-ts/Option'
+import * as TE from 'fp-ts/TaskEither'
+import { pipe } from 'fp-ts/function'
+import { StatusCodes } from 'http-status-codes'
+import { createPresentableError } from '../../../application/helper/error-helper'
+import { findLocaleByNameInDb } from '../../../application/repository/locale-repository'
+import {
+  findDomainIdByNameInDb,
+  insertBulkSentencesIntoDb,
+} from '../../../application/repository/sentences-repository'
+import { findVariantByTagInDb } from '../../../application/repository/variant-repository'
+import { AddMultipleSentencesCommandHandler } from '../../../application/sentences/use-case/command-handler/add-multiple-sentences-command-handler'
+import { AddMultipleSentencesCommand } from '../../../application/sentences/use-case/command-handler/command/add-multiple-sentences-command'
+
+export default async (req: Request, res: Response) => {
+  const { sentences, localeName, source, domains, variant } = req.body
+
+  const command: AddMultipleSentencesCommand = {
+    clientId: req.client_id,
+    rawSentenceInput: sentences,
+    localeName: localeName,
+    source: source,
+    domains: domains,
+    variant: O.fromNullable(variant),
+  }
+
+  const cmdHandler = pipe(
+    AddMultipleSentencesCommandHandler,
+    I.ap(findDomainIdByNameInDb),
+    I.ap(findVariantByTagInDb),
+    I.ap(findLocaleByNameInDb),
+    I.ap(insertBulkSentencesIntoDb)
+  )
+
+  const result = await pipe(
+    command,
+    cmdHandler,
+    TE.mapLeft(createPresentableError),
+    TE.matchW(
+      err => {
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR)
+        return err
+      },
+      sentencesWithErrors => sentencesWithErrors
+    )
+  )()
+
+  return res.json(result)
+}

--- a/server/src/api/sentences/handler/add-small-sentence-batch-handler.ts
+++ b/server/src/api/sentences/handler/add-small-sentence-batch-handler.ts
@@ -52,7 +52,7 @@ export default async (req: Request, res: Response) => {
         return err
       },
       handlerResponse => ({
-        message: 'Sentences added succesfully',
+        message: 'Valid sentences have been added succesfully',
         ...handlerResponse,
       })
     )

--- a/server/src/api/sentences/handler/add-small-sentence-batch-handler.ts
+++ b/server/src/api/sentences/handler/add-small-sentence-batch-handler.ts
@@ -13,6 +13,7 @@ import {
 import { findVariantByTagInDb } from '../../../application/repository/variant-repository'
 import { AddMultipleSentencesCommandHandler } from '../../../application/sentences/use-case/command-handler/add-multiple-sentences-command-handler'
 import { AddMultipleSentencesCommand } from '../../../application/sentences/use-case/command-handler/command/add-multiple-sentences-command'
+import { ValidationErrorKind } from '../../../application/types/error'
 
 export default async (req: Request, res: Response) => {
   const { sentences, localeName, source, domains, variant } = req.body
@@ -40,7 +41,14 @@ export default async (req: Request, res: Response) => {
     TE.mapLeft(createPresentableError),
     TE.matchW(
       err => {
-        res.status(StatusCodes.INTERNAL_SERVER_ERROR)
+        switch (err.kind) {
+          case ValidationErrorKind:
+            res.status(StatusCodes.BAD_REQUEST)
+            break
+          default:
+            res.status(StatusCodes.INTERNAL_SERVER_ERROR)
+        }
+
         return err
       },
       sentencesWithErrors => sentencesWithErrors

--- a/server/src/api/sentences/handler/add-small-sentence-batch-handler.ts
+++ b/server/src/api/sentences/handler/add-small-sentence-batch-handler.ts
@@ -51,7 +51,10 @@ export default async (req: Request, res: Response) => {
 
         return err
       },
-      sentencesWithErrors => sentencesWithErrors
+      handlerResponse => ({
+        message: 'Sentences added succesfully',
+        ...handlerResponse,
+      })
     )
   )()
 

--- a/server/src/api/sentences/routes.ts
+++ b/server/src/api/sentences/routes.ts
@@ -4,11 +4,13 @@ import rateLimiter from '../../lib/rate-limiter-middleware'
 import {
   AddSentenceRequest,
   AddSentenceVoteRequest,
+  AddSmallSentenceBatchRequest,
   GetSentencesForReviewRequest,
 } from './validation/pending-sentences-requests'
 import validate, { validateStrict } from '../../lib/validation'
 import getSentenceHandler from './handler/get-sentences-for-review-handler'
 import addSentenceVoteHandler from './handler/add-sentence-vote-handler'
+import addSmallSentenceBatchHandler from './handler/add-small-sentence-batch-handler'
 
 export default PromiseRouter({ mergeParams: true })
   .post(
@@ -16,6 +18,12 @@ export default PromiseRouter({ mergeParams: true })
     rateLimiter('api/v1/sentences/', { points: 10, duration: 60 }),
     validateStrict({ body: AddSentenceRequest }),
     addSentenceHandler
+  )
+  .post(
+    '/batch',
+    rateLimiter('api/v1/sentences/batch', { points: 10, duration: 60 }),
+    validateStrict({ body: AddSmallSentenceBatchRequest }),
+    addSmallSentenceBatchHandler
   )
   .post(
     '/vote',

--- a/server/src/api/sentences/validation/pending-sentences-requests.ts
+++ b/server/src/api/sentences/validation/pending-sentences-requests.ts
@@ -29,6 +29,34 @@ export const AddSentenceRequest: AllowedSchema = {
   },
 }
 
+export const AddSmallSentenceBatchRequest: AllowedSchema = {
+  type: 'object',
+  required: ['sentences', 'source', 'localeName', 'domains'],
+  properties: {
+    sentences: {
+      type: 'string',
+    },
+    source: {
+      type: 'string',
+    },
+    localeName: {
+      type: 'string',
+    },
+    domains: {
+      type: 'array',
+      maxItems: 3,
+      items: {
+        type: 'string',
+        enum: [...sentenceDomains],
+      },
+      uniqueItems: true,
+    },
+    variant: {
+      type: 'string',
+    },
+  },
+}
+
 export const AddSentenceVoteRequest: AllowedSchema = {
   type: 'object',
   required: ['sentence_id', 'vote'],

--- a/server/src/application/sentences/helper/domain-helper.ts
+++ b/server/src/application/sentences/helper/domain-helper.ts
@@ -1,0 +1,22 @@
+import { pipe } from 'fp-ts/lib/function'
+import * as TE from 'fp-ts/TaskEither'
+import * as O from 'fp-ts/Option'
+import { FindDomainIdByName } from '../../repository/sentences-repository'
+import { ApplicationError } from '../../types/error'
+
+export const toDomainIds =
+  (findDomainId: FindDomainIdByName) =>
+  (domains: string[]): TE.TaskEither<ApplicationError, number[]> => {
+    const findDomainIds = domains.map(domain => findDomainId(domain))
+    return pipe(
+      findDomainIds,
+      TE.sequenceArray,
+      TE.map(domainIds => pipe(domainIds, O.sequenceArray)),
+      TE.map(domainIds =>
+        pipe(
+          domainIds,
+          O.getOrElse(() => [])
+        )
+      )
+    )
+  }

--- a/server/src/application/sentences/use-case/command-handler/add-bulk-sentences-command-handler.ts
+++ b/server/src/application/sentences/use-case/command-handler/add-bulk-sentences-command-handler.ts
@@ -55,6 +55,7 @@ export const AddBulkSentencesCommandHandler =
               source: submission['Source (mandatory)'].trim(),
               locale_id: cmd.localeId,
               client_id: clientId,
+              domain_ids: O.none,
               variant_id: O.none,
             }
 
@@ -69,7 +70,7 @@ export const AddBulkSentencesCommandHandler =
               if (domain) {
                 sub = {
                   ...sub,
-                  domain_ids: [domain.id],
+                  domain_ids: O.some([domain.id]),
                 }
               }
             }

--- a/server/src/application/sentences/use-case/command-handler/add-multiple-sentences-command-handler.test.ts
+++ b/server/src/application/sentences/use-case/command-handler/add-multiple-sentences-command-handler.test.ts
@@ -40,7 +40,8 @@ describe('AddMultipleSentencesCommandHandler', () => {
 
     expect(E.isRight(result)).toBe(true)
     if (E.isRight(result)) {
-      expect(result.right).toHaveLength(0) // Assuming all sentences are valid
+      expect(result.right.invalid_sentences).toHaveLength(0) // Assuming all sentences are valid
+      expect(result.right.valid_sentences_count).toBe(2)
     }
 
     expect(mockFindLocaleByName).toHaveBeenCalledWith('en')
@@ -92,9 +93,11 @@ describe('AddMultipleSentencesCommandHandler', () => {
 
     expect(E.isRight(result)).toBe(true)
     if (E.isRight(result)) {
-      expect(result.right).toHaveLength(2) // Both sentences should have errors
-      expect(result.right[0].errorType).toBeDefined()
-      expect(result.right[1].errorType).toBeDefined()
+      expect(result.right.total_count).toBe(2) // Both sentences should have errors
+      expect(result.right.invalid_sentences_count).toBe(2) // Both sentences should have errors
+      expect(result.right.invalid_sentences).toHaveLength(2) // Both sentences should have errors
+      expect(result.right.invalid_sentences[0].errorType).toBeDefined()
+      expect(result.right.invalid_sentences[1].errorType).toBeDefined()
     }
   })
 

--- a/server/src/application/sentences/use-case/command-handler/add-multiple-sentences-command-handler.test.ts
+++ b/server/src/application/sentences/use-case/command-handler/add-multiple-sentences-command-handler.test.ts
@@ -65,8 +65,8 @@ describe('AddMultipleSentencesCommandHandler', () => {
     expect(E.isRight(result)).toBe(true)
     if (E.isRight(result)) {
       expect(result.right).toHaveLength(2) // Both sentences should have errors
-      expect(result.right[0].err).toBeDefined()
-      expect(result.right[1].err).toBeDefined()
+      expect(result.right[0].errorType).toBeDefined()
+      expect(result.right[1].errorType).toBeDefined()
     }
   })
 

--- a/server/src/application/sentences/use-case/command-handler/add-multiple-sentences-command-handler.test.ts
+++ b/server/src/application/sentences/use-case/command-handler/add-multiple-sentences-command-handler.test.ts
@@ -1,0 +1,117 @@
+import * as TE from 'fp-ts/TaskEither'
+import * as E from 'fp-ts/Either'
+import * as O from 'fp-ts/Option'
+import { AddMultipleSentencesCommandHandler } from './add-multiple-sentences-command-handler'
+import { AddMultipleSentencesCommand } from './command/add-multiple-sentences-command'
+
+describe('AddMultipleSentencesCommandHandler', () => {
+  const mockFindDomainIdByName = jest.fn()
+  const mockFindVariantByTag = jest.fn()
+  const mockFindLocaleByName = jest.fn()
+  const mockInsertBulkSentences = jest.fn()
+
+  const handler = AddMultipleSentencesCommandHandler(mockFindDomainIdByName)(
+    mockFindVariantByTag
+  )(mockFindLocaleByName)(mockInsertBulkSentences)
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should successfully add multiple sentences', async () => {
+    const command: AddMultipleSentencesCommand = {
+      rawSentenceInput: 'Sentence one.\nSentence two.',
+      localeName: 'en',
+      domains: ['general'],
+      variant: O.some('standard'),
+      clientId: 'test-client',
+      source: 'user',
+    }
+
+    mockFindLocaleByName.mockReturnValue(TE.right(O.some({ id: 1 })))
+    mockFindDomainIdByName.mockReturnValue(TE.right(O.some([1])))
+    mockFindVariantByTag.mockReturnValue(TE.right(O.some({ id: 1 })))
+    mockInsertBulkSentences.mockReturnValue(TE.right(undefined))
+
+    const result = await handler(command)()
+
+    expect(E.isRight(result)).toBe(true)
+    if (E.isRight(result)) {
+      expect(result.right).toHaveLength(0) // Assuming all sentences are valid
+    }
+
+    expect(mockFindLocaleByName).toHaveBeenCalledWith('en')
+    expect(mockFindDomainIdByName).toHaveBeenCalledWith('general')
+    expect(mockFindVariantByTag).toHaveBeenCalledWith('standard')
+    expect(mockInsertBulkSentences).toHaveBeenCalled()
+  })
+
+  it('should return validation errors for invalid sentences', async () => {
+    const command: AddMultipleSentencesCommand = {
+      rawSentenceInput: 'Invalid sentence 1!\nAnother invalid sentence 2?',
+      localeName: 'en',
+      domains: ['general'],
+      variant: O.none,
+      clientId: 'test-client',
+      source: 'user',
+    }
+
+    mockFindLocaleByName.mockReturnValue(TE.right(O.some({ id: 1 })))
+    mockFindDomainIdByName.mockReturnValue(TE.right(O.some(1)))
+    mockInsertBulkSentences.mockReturnValue(TE.right(undefined))
+
+    const result = await handler(command)()
+
+    expect(E.isRight(result)).toBe(true)
+    if (E.isRight(result)) {
+      expect(result.right).toHaveLength(2) // Both sentences should have errors
+      expect(result.right[0].err).toBeDefined()
+      expect(result.right[1].err).toBeDefined()
+    }
+  })
+
+  it('should handle locale not found error', async () => {
+    const command: AddMultipleSentencesCommand = {
+      rawSentenceInput: 'Test sentence.',
+      localeName: 'invalid-locale',
+      domains: [],
+      variant: O.none,
+      clientId: 'test-client',
+      source: 'user',
+    }
+
+    mockFindLocaleByName.mockReturnValue(TE.right(O.none))
+
+    const result = await handler(command)()
+
+    expect(E.isLeft(result)).toBe(true)
+    if (E.isLeft(result)) {
+      expect(result.left.message).toContain('Locale not found')
+    }
+  })
+
+  it('should handle database error', async () => {
+    const command: AddMultipleSentencesCommand = {
+      rawSentenceInput: 'Test sentence.',
+      localeName: 'en-US',
+      domains: [],
+      variant: O.none,
+      clientId: 'test-client',
+      source: 'user',
+    }
+
+    mockFindLocaleByName.mockReturnValue(TE.right(O.some({ id: 1 })))
+    mockInsertBulkSentences.mockReturnValue(
+      TE.left(new Error('Database error'))
+    )
+
+    const result = await handler(command)()
+
+    expect(E.isLeft(result)).toBe(true)
+    if (E.isLeft(result)) {
+      expect(result.left.message).toContain(
+        'Error inserting small sentence batch'
+      )
+    }
+  })
+})

--- a/server/src/application/sentences/use-case/command-handler/add-multiple-sentences-command-handler.ts
+++ b/server/src/application/sentences/use-case/command-handler/add-multiple-sentences-command-handler.ts
@@ -1,0 +1,132 @@
+import * as A from 'fp-ts/Array'
+import * as E from 'fp-ts/Either'
+import * as O from 'fp-ts/Option'
+import * as TE from 'fp-ts/TaskEither'
+import { pipe } from 'fp-ts/function'
+import {
+  ValidatorRuleError,
+  validateSentence,
+} from '../../../../core/sentences'
+import { cleanRawMultipleSentencesInput } from '../../../../core/sentences/cleaning/multiple-sentences'
+import {
+  createDatabaseError,
+  createValidationError,
+} from '../../../helper/error-helper'
+import { FindLocaleByName } from '../../../repository/locale-repository'
+import {
+  FindDomainIdByName,
+  InsertBulkSentences,
+} from '../../../repository/sentences-repository'
+import { FindVariantByTag } from '../../../repository/variant-repository'
+import { ApplicationError } from '../../../types/error'
+import { SentenceSubmission } from '../../../types/sentence-submission'
+import { toDomainIds } from '../../helper/domain-helper'
+import { AddMultipleSentencesCommand } from './command/add-multiple-sentences-command'
+
+export const AddMultipleSentencesCommandHandler =
+  (findDomainIdByName: FindDomainIdByName) =>
+  (findVariantByTag: FindVariantByTag) =>
+  (findLocaleByName: FindLocaleByName) =>
+  (insertBulkSentences: InsertBulkSentences) =>
+  (
+    cmd: AddMultipleSentencesCommand
+  ): TE.TaskEither<ApplicationError, SentenceWithError[]> =>
+    pipe(
+      TE.Do,
+      TE.let('cleanedSentences', () =>
+        cleanRawMultipleSentencesInput(cmd.rawSentenceInput)
+      ),
+      TE.let('validatedSentences', ({ cleanedSentences }) =>
+        validateSentences(cmd.localeName)(cleanedSentences)
+      ),
+      TE.bind('localeId', () =>
+        pipe(
+          findLocaleByName(cmd.localeName),
+          TE.chain(locale =>
+            pipe(
+              locale,
+              O.match(
+                () => TE.left(createValidationError('Locale not found')),
+                locale => TE.right(locale.id)
+              )
+            )
+          )
+        )
+      ),
+      TE.bind('domainIds', () => toDomainIds(findDomainIdByName)(cmd.domains)),
+      TE.bind('variant', () =>
+        pipe(
+          cmd.variant,
+          O.match(
+            () => TE.right(O.none),
+            variant => findVariantByTag(variant)
+          )
+        )
+      ),
+      TE.chainFirst(({ localeId, variant, domainIds, validatedSentences }) => {
+        const sentences = validatedSentences.left
+        const variant_id = pipe(
+          variant,
+          O.map(v => v.id)
+        )
+        const sentenceSubmissions: SentenceSubmission[] = pipe(
+          sentences,
+          A.map(sentence => {
+            return {
+              ...sentence,
+              locale_id: localeId,
+              client_id: cmd.clientId,
+              source: cmd.source,
+              variant_id,
+              domain_ids: O.some(domainIds),
+            }
+          })
+        )
+        return pipe(
+          insertBulkSentences(sentenceSubmissions, {
+            isUsed: false,
+            isValidated: false,
+          }),
+          TE.mapLeft(e =>
+            createDatabaseError('Error inserting small sentence batch', e)
+          )
+        )
+      }),
+      TE.map(({ validatedSentences }) => validatedSentences.right)
+    )
+
+const validateSentences =
+  (locale: string) =>
+  (
+    sentences: string[]
+  ): { left: ValidatedSentence[]; right: SentenceWithError[] } =>
+    pipe(
+      sentences,
+      A.map(sentence =>
+        pipe(
+          sentence,
+          validateSentence(locale),
+          E.match(
+            err => ({ sentence: sentence, err: err }),
+            () => ({ sentence: sentence })
+          )
+        )
+      ),
+      A.partition(isSentenceWithError)
+    )
+
+const isSentenceWithError = (
+  sentence: SentenceValidationResult
+): sentence is SentenceWithError => 'err' in sentence
+
+type SentenceValidationResult = ValidatedSentence | SentenceWithError
+
+type Sentence = {
+  sentence: string
+}
+
+type ValidatedSentence = Sentence
+
+type SentenceWithError = Sentence & {
+  err: ValidatorRuleError
+}

--- a/server/src/application/sentences/use-case/command-handler/add-multiple-sentences-command-handler.ts
+++ b/server/src/application/sentences/use-case/command-handler/add-multiple-sentences-command-handler.ts
@@ -5,6 +5,7 @@ import * as TE from 'fp-ts/TaskEither'
 import { pipe } from 'fp-ts/function'
 import {
   ValidatorRuleError,
+  ValidatorRuleErrorType,
   validateSentence,
 } from '../../../../core/sentences'
 import { cleanRawMultipleSentencesInput } from '../../../../core/sentences/cleaning/multiple-sentences'
@@ -107,7 +108,7 @@ const validateSentences =
           sentence,
           validateSentence(locale),
           E.match(
-            err => ({ sentence: sentence, err: err }),
+            err => ({ sentence: sentence, errorType: err.errorType }),
             () => ({ sentence: sentence })
           )
         )
@@ -117,7 +118,7 @@ const validateSentences =
 
 const isSentenceWithError = (
   sentence: SentenceValidationResult
-): sentence is SentenceWithError => 'err' in sentence
+): sentence is SentenceWithError => 'errorType' in sentence
 
 type SentenceValidationResult = ValidatedSentence | SentenceWithError
 
@@ -128,5 +129,5 @@ type Sentence = {
 type ValidatedSentence = Sentence
 
 type SentenceWithError = Sentence & {
-  err: ValidatorRuleError
+  errorType: ValidatorRuleErrorType
 }

--- a/server/src/application/sentences/use-case/command-handler/add-multiple-sentences-command-handler.ts
+++ b/server/src/application/sentences/use-case/command-handler/add-multiple-sentences-command-handler.ts
@@ -25,6 +25,13 @@ import { AddMultipleSentencesCommand } from './command/add-multiple-sentences-co
 
 export const MAX_SENTENCES = 1000
 
+export type AddMultipleSentencesResponse = {
+  total_count: number
+  valid_sentences_count: number
+  invalid_sentences_count: number
+  invalid_sentences: SentenceWithError[]
+}
+
 export const AddMultipleSentencesCommandHandler =
   (findDomainIdByName: FindDomainIdByName) =>
   (findVariantByTag: FindVariantByTag) =>
@@ -32,7 +39,7 @@ export const AddMultipleSentencesCommandHandler =
   (insertBulkSentences: InsertBulkSentences) =>
   (
     cmd: AddMultipleSentencesCommand
-  ): TE.TaskEither<ApplicationError, SentenceWithError[]> =>
+  ): TE.TaskEither<ApplicationError, AddMultipleSentencesResponse> =>
     pipe(
       TE.Do,
       TE.let('cleanedSentences', () =>
@@ -99,7 +106,12 @@ export const AddMultipleSentencesCommandHandler =
           )
         )
       }),
-      TE.map(({ validatedSentences }) => validatedSentences.right)
+      TE.map(({ cleanedSentences, validatedSentences }) => ({
+        total_count: cleanedSentences.length,
+        valid_sentences_count: validatedSentences.left.length,
+        invalid_sentences_count: validatedSentences.right.length,
+        invalid_sentences: validatedSentences.right,
+      }))
     )
 
 const validateSentences =

--- a/server/src/application/sentences/use-case/command-handler/add-sentence-command-handler.ts
+++ b/server/src/application/sentences/use-case/command-handler/add-sentence-command-handler.ts
@@ -17,6 +17,7 @@ import { SentenceSubmission } from '../../../types/sentence-submission'
 import { FindVariantByTag } from '../../../repository/variant-repository'
 import { Variant } from '../../../../core/variants/variant'
 import { FindLocaleByName } from '../../../repository/locale-repository'
+import { toDomainIds } from '../../helper/domain-helper'
 
 const toValidatedSentence =
   (validateSentence: ValidateSentence) =>
@@ -28,23 +29,6 @@ const toValidatedSentence =
       E.mapLeft(createSentenceValidationError),
       TE.fromEither
     )
-
-const toDomainIds =
-  (findDomainId: FindDomainIdByName) =>
-  (domains: string[]): TE.TaskEither<ApplicationError, number[]> => {
-    const findDomainIds = domains.map(domain => findDomainId(domain))
-    return pipe(
-      findDomainIds,
-      TE.sequenceArray,
-      TE.map(domainIds => pipe(domainIds, O.sequenceArray)),
-      TE.map(domainIds =>
-        pipe(
-          domainIds,
-          O.getOrElse(() => [])
-        )
-      )
-    )
-  }
 
 const doesLocaleMatchVariant =
   (locale: string) =>
@@ -126,7 +110,7 @@ export const AddSentenceCommandHandler =
             source: command.source,
             locale_id: localeId,
             client_id: command.clientId,
-            domain_ids: [...domainIds],
+            domain_ids: O.some(domainIds),
             variant_id: variantId,
           }
         }

--- a/server/src/application/sentences/use-case/command-handler/command/add-multiple-sentences-command.ts
+++ b/server/src/application/sentences/use-case/command-handler/command/add-multiple-sentences-command.ts
@@ -1,0 +1,12 @@
+import { Option } from 'fp-ts/Option'
+
+import { SentenceDomain } from 'common'
+
+export type AddMultipleSentencesCommand = {
+  clientId: string
+  rawSentenceInput: string
+  localeName: string
+  source: string
+  domains: SentenceDomain[]
+  variant: Option<string>
+}

--- a/server/src/application/types/sentence-submission.ts
+++ b/server/src/application/types/sentence-submission.ts
@@ -1,10 +1,10 @@
 import { Option } from 'fp-ts/Option'
 
 export type SentenceSubmission = {
-  sentence: string;
-  source: string;
-  locale_id: number;
-  client_id: string;
-  domain_ids?: number[] | null
+  sentence: string
+  source: string
+  locale_id: number
+  client_id: string
+  domain_ids: Option<number[]>
   variant_id: Option<number>
-};
+}

--- a/server/src/core/sentences/cleaning/multiple-sentences.test.ts
+++ b/server/src/core/sentences/cleaning/multiple-sentences.test.ts
@@ -1,0 +1,60 @@
+import { cleanRawMultipleSentencesInput } from './multiple-sentences'
+
+describe('clean raw multiple sentences input', () => {
+  it('should clean and split multiple sentences with newlines and multiple spaces', () => {
+    const input = `This is the first   sentence.
+
+    This  is the second sentence with    extra spaces.
+
+Another sentence on a new line.
+
+    Last    sentence  with mixed     spacing.`
+
+    const expected = [
+      'This is the first sentence.',
+      'This is the second sentence with extra spaces.',
+      'Another sentence on a new line.',
+      'Last sentence with mixed spacing.',
+    ]
+
+    const result = cleanRawMultipleSentencesInput(input)
+
+    expect(result).toEqual(expected)
+  })
+
+  it('should handle empty lines and lines with only spaces', () => {
+    const input = `First sentence.
+
+
+Second sentence.
+
+Third sentence.`
+
+    const expected = ['First sentence.', 'Second sentence.', 'Third sentence.']
+
+    const result = cleanRawMultipleSentencesInput(input)
+
+    expect(result).toEqual(expected)
+  })
+
+  it('should return an empty array for an empty string', () => {
+    const input = ''
+    const result = cleanRawMultipleSentencesInput(input)
+    expect(result).toEqual([])
+  })
+
+  it('should handle a string with only whitespace', () => {
+    const input = '    \n   \t   \n  '
+    const result = cleanRawMultipleSentencesInput(input)
+    expect(result).toEqual([])
+  })
+
+  it('should clean multiple occurrences of extra spaces within a single sentence', () => {
+    const input = 'This   sentence   has   multiple   spaces   between   words.'
+    const expected = ['This sentence has multiple spaces between words.']
+
+    const result = cleanRawMultipleSentencesInput(input)
+
+    expect(result).toEqual(expected)
+  })
+})

--- a/server/src/core/sentences/cleaning/multiple-sentences.ts
+++ b/server/src/core/sentences/cleaning/multiple-sentences.ts
@@ -1,0 +1,9 @@
+import { pipe } from 'fp-ts/lib/function'
+import * as A from 'fp-ts/Array'
+
+export const cleanRawMultipleSentencesInput = (sentences: string) =>
+  pipe(
+    sentences.split('\n'),
+    A.map(s => s.replace(/\s+/g, ' ').trim()),
+    A.filter(s => s.length > 0)
+  )

--- a/server/src/test/application/sentences/use-case/command-handler/add-sentence-command-handler.test.ts
+++ b/server/src/test/application/sentences/use-case/command-handler/add-sentence-command-handler.test.ts
@@ -55,7 +55,7 @@ describe('Add sentence command handler', () => {
       source: 'Myself',
       locale_id: 27,
       client_id: 'abc',
-      domain_ids: [1],
+      domain_ids: O.some([1]),
       variant_id: O.none,
     }
 


### PR DESCRIPTION
Add functionality to allow processing of small sentences batches (<1k sentences). Pass the complete sentences string as `sentences` in the request body. The backend will validate the incoming input and process all valid sentences and return a list of invalid sentences with their corresponding error, if there are any.

Example request:
```
POST /api/v1/sentences/batch
```
Post body:
```json
{
    "sentences" : "This is the first sentence.\nHere is another sentence. \n\nI left   some    spaces.",
    "source": "me",
    "localeName": "cy",
    "domains": ["general", "finance"],
    "variant": "cy-midwales"
}

```

Example response:
```json
{
    "message": "Valid sentences have been added succesfully",
    "total_count": 10,
    "valid_sentences_count": 9,
    "invalid_sentences_count": 1,
    "invalid_sentences": [
        {
            "sentence": "That's 1 sentence.",
            "errorType": "NO_NUMBERS"
        }
    ]
}
```