### PR TITLE
fix(write page): fix domain dropdown

### DIFF
--- a/web/src/components/pages/contribution/sentence-collector/write/sentence-write/index.tsx
+++ b/web/src/components/pages/contribution/sentence-collector/write/sentence-write/index.tsx
@@ -9,6 +9,7 @@ import { SentenceInputAndRules } from '../sentence-input-and-rules/sentence-inpu
 
 import { COMMON_VOICE_EMAIL } from '../../../../../../constants'
 import URLS from '../../../../../../urls'
+import { sentenceDomains as allSentenceDomains } from 'common'
 
 import { StateError } from './types'
 
@@ -30,7 +31,7 @@ type Props = {
   citation: string
   sentence: string
   sentenceVariant: string
-  sentenceDomains: string[]
+  selectedSentenceDomains: string[]
   error?: StateError
   confirmPublicDomain: boolean
 }
@@ -47,7 +48,7 @@ export const SentenceWrite: React.FC<Props> = ({
   citation,
   sentence,
   sentenceVariant,
-  sentenceDomains,
+  selectedSentenceDomains,
   confirmPublicDomain,
   error,
 }) => {
@@ -62,9 +63,9 @@ export const SentenceWrite: React.FC<Props> = ({
           handleCitationChange={handleCitationChange}
           sentence={sentence}
           citation={citation}
-          sentenceDomains={sentenceDomains}
+          sentenceDomains={allSentenceDomains}
           setSelectedSentenceDomains={handleSentenceDomainChange}
-          selectedSentenceDomains={sentenceDomains}
+          selectedSentenceDomains={selectedSentenceDomains}
           error={error}
           handleSentenceVariantChange={handleSentenceVariantChange}
           variantTokens={allVariants}

--- a/web/src/components/pages/contribution/sentence-collector/write/sentence-write/sentence-write.test.tsx
+++ b/web/src/components/pages/contribution/sentence-collector/write/sentence-write/sentence-write.test.tsx
@@ -14,7 +14,6 @@ const allVariants = ['mock-variant-1', 'mock-variant-2']
 const mockCitation = 'mock-citation'
 const mockSentence = 'Mock sentence'
 const mockSentenceVariant = 'mock-variant-1'
-const mockSentenceDomains = ['mock-domain-1', 'mock-domain-2']
 
 jest.mock('../../../../../../hooks/store-hooks', () => ({
   useAction: () => useActionMock,
@@ -53,7 +52,7 @@ describe('Single Submission Write page', () => {
         citation={mockCitation}
         sentence={mockSentence}
         sentenceVariant={mockSentenceVariant}
-        sentenceDomains={mockSentenceDomains}
+        selectedSentenceDomains={[]}
         confirmPublicDomain
       />
     )

--- a/web/src/components/pages/contribution/sentence-collector/write/write-container.tsx
+++ b/web/src/components/pages/contribution/sentence-collector/write/write-container.tsx
@@ -128,7 +128,7 @@ const WriteContainer = () => {
       citation,
       sentence,
       sentenceVariant,
-      sentenceDomains,
+      selectedSentenceDomains: sentenceDomains,
       error,
       confirmPublicDomain,
     }


### PR DESCRIPTION
This pull request includes several changes to the `SentenceWrite` component and its related files to improve the handling of sentence domains. The most important changes include renaming and updating props, adjusting imports, and modifying test cases accordingly.

### Props and State Management:

* [`web/src/components/pages/contribution/sentence-collector/write/sentence-write/index.tsx`](diffhunk://#diff-7255be654677f1208e26ce980a74f57eafb25e425bc35fadf5dc2a6c4e51df79L33-R34): Renamed the `sentenceDomains` prop to `selectedSentenceDomains` and updated its usage throughout the component. [[1]](diffhunk://#diff-7255be654677f1208e26ce980a74f57eafb25e425bc35fadf5dc2a6c4e51df79L33-R34) [[2]](diffhunk://#diff-7255be654677f1208e26ce980a74f57eafb25e425bc35fadf5dc2a6c4e51df79L50-R51)

### Imports:

* [`web/src/components/pages/contribution/sentence-collector/write/sentence-write/index.tsx`](diffhunk://#diff-7255be654677f1208e26ce980a74f57eafb25e425bc35fadf5dc2a6c4e51df79R12): Added an import for `sentenceDomains` from the `common` module to use in the component.

### Test Cases:

* [`web/src/components/pages/contribution/sentence-collector/write/sentence-write/sentence-write.test.tsx`](diffhunk://#diff-45bd7abd6a1a6a6b3ecab6d867c77dad6a284dc04af3596fe6efeb8f1e0c7124L17): Removed the `mockSentenceDomains` constant and updated the test cases to use `selectedSentenceDomains` instead. [[1]](diffhunk://#diff-45bd7abd6a1a6a6b3ecab6d867c77dad6a284dc04af3596fe6efeb8f1e0c7124L17) [[2]](diffhunk://#diff-45bd7abd6a1a6a6b3ecab6d867c77dad6a284dc04af3596fe6efeb8f1e0c7124L56-R55)

### Container Component:

* [`web/src/components/pages/contribution/sentence-collector/write/write-container.tsx`](diffhunk://#diff-7f1467d070b440b0aafe23955f5eb8470888f5003fa0c61a228cb6bb737ebb13L131-R131): Updated the `WriteContainer` component to map `sentenceDomains` to `selectedSentenceDomains` in its props.