### PR TITLE
fix: add message object to error object from api.ts

### DIFF
--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -97,7 +97,10 @@ export default class API {
 
     if (response.status === 429) {
       const error = new Error(response.statusText)
-      Object.assign(error, { retryAfter: response.headers.get('retry-after') })
+      Object.assign(error, {
+        message: 'Too Many Requests',
+        retryAfter: response.headers.get('retry-after'),
+      })
       throw error
     }
 


### PR DESCRIPTION
This pull request includes a small but important change to the error handling in the `API` class within the `web/src/services/api.ts` file. The change enhances the error message for status code 429 (Too Many Requests).

* [`web/src/services/api.ts`](diffhunk://#diff-fb672af0df2ceca2419f307187aac752b05a3f0a64cf9116c9df9b3946aa8b10L100-R103): Enhanced the error message for status code 429 to include a more descriptive message ('Too Many Requests') along with the `retryAfter` header.