### PR TITLE
Add Circassian (ady & kbd) variants

### DIFF
--- a/server/src/lib/model/db/import-locales.ts
+++ b/server/src/lib/model/db/import-locales.ts
@@ -220,7 +220,7 @@ const VARIANTS: Variant[] = [
   {
     locale_name: 'ady',
     variant_name: 'Adığabze (Latin, Turk, transliteratse - Batı Çerkesçesi)',
-    variant_token: 'ady-Latn-TR-t-ady-cyrl-tr',
+    variant_token: 'ady-Latn-TR-t-ady-cyrl',
   },
   {
     locale_name: 'ady',
@@ -245,7 +245,7 @@ const VARIANTS: Variant[] = [
   {
     locale_name: 'kbd',
     variant_name: 'Adığebze (Kabardey, Latin, Turk, transliteratse - Doğu Çerkesçesi)',
-    variant_token: 'kbd-Latn-TR-t-kbd-cyrl-tr',
+    variant_token: 'kbd-Latn-TR-t-kbd-cyrl',
   },
   {
     locale_name: 'kbd',

--- a/server/src/lib/model/db/import-locales.ts
+++ b/server/src/lib/model/db/import-locales.ts
@@ -234,27 +234,27 @@ const VARIANTS: Variant[] = [
   },
   {
     locale_name: 'kbd',
-    variant_name: 'Адыгэбзэ (Кирил, Урысей)',
+    variant_name: 'Адыгэбзэ (Къэбэрдей, Кирил, Урысей)',
     variant_token: 'kbd-RU',
   },
   {
     locale_name: 'kbd',
-    variant_name: 'Адыгэбзэ (Кирил, Тырку - Doğu Çerkesçesi)',
+    variant_name: 'Адыгэбзэ (Къэбэрдей, Кирил, Тырку - Doğu Çerkesçesi)',
     variant_token: 'kbd-Cyrl-TR',
   },
   {
     locale_name: 'kbd',
-    variant_name: 'Adığebze (Latin, Turk, transliteratse - Doğu Çerkesçesi)',
+    variant_name: 'Adığebze (Kabardey, Latin, Turk, transliteratse - Doğu Çerkesçesi)',
     variant_token: 'kbd-Latn-TR-t-kbd-cyrl-tr',
   },
   {
     locale_name: 'kbd',
-    variant_name: 'Адыгэбзэ (Кирил, Иордание)',
+    variant_name: 'Адыгэбзэ (Къэбэрдей, Кирил, Иордание)',
     variant_token: 'kbd-Cyrl-JOR',
   },
   {
     locale_name: 'kbd',
-    variant_name: 'Адыгэбзэ (Кирил, Сирие)',
+    variant_name: 'Адыгэбзэ (Къэбэрдей, Кирил, Сирие)',
     variant_token: 'kbd-Cyrl-SY',
   },
 ]

--- a/server/src/lib/model/db/import-locales.ts
+++ b/server/src/lib/model/db/import-locales.ts
@@ -207,6 +207,56 @@ const VARIANTS: Variant[] = [
     variant_name: 'Southern Setswana (Setlhaping, Setlharo)',
     variant_token: 'tn-southern',
   },
+  {
+    locale_name: 'ady',
+    variant_name: 'Адыгабзэ (Кирил, Урысый)',
+    variant_token: 'ady-RU',
+  },
+  {
+    locale_name: 'ady',
+    variant_name: 'Адыгабзэ (Кирил, Тырку - Batı Çerkesçesi)',
+    variant_token: 'ady-Cyrl-TR',
+  },
+  {
+    locale_name: 'ady',
+    variant_name: 'Adığabze (Latin, Turk, transliteratse - Batı Çerkesçesi)',
+    variant_token: 'ady-Latn-TR-t-ady-cyrl-tr',
+  },
+  {
+    locale_name: 'ady',
+    variant_name: 'Адыгабзэ (Кирил, Иордание)',
+    variant_token: 'ady-Cyrl-JOR',
+  },
+  {
+    locale_name: 'ady',
+    variant_name: 'Адыгабзэ (Кирил, Сирие)',
+    variant_token: 'ady-Cyrl-SY',
+  },
+  {
+    locale_name: 'kbd',
+    variant_name: 'Адыгэбзэ (Кирил, Урысей)',
+    variant_token: 'kbd-RU',
+  },
+  {
+    locale_name: 'kbd',
+    variant_name: 'Адыгэбзэ (Кирил, Тырку - Doğu Çerkesçesi)',
+    variant_token: 'kbd-Cyrl-TR',
+  },
+  {
+    locale_name: 'kbd',
+    variant_name: 'Adığebze (Latin, Turk, transliteratse - Doğu Çerkesçesi)',
+    variant_token: 'kbd-Latn-TR-t-kbd-cyrl-tr',
+  },
+  {
+    locale_name: 'kbd',
+    variant_name: 'Адыгэбзэ (Кирил, Иордание)',
+    variant_token: 'kbd-Cyrl-JOR',
+  },
+  {
+    locale_name: 'kbd',
+    variant_name: 'Адыгэбзэ (Кирил, Сирие)',
+    variant_token: 'kbd-Cyrl-SY',
+  },
 ]
 
 type Locale = {


### PR DESCRIPTION
This PR adds variants for Circassian languages (ady & kbd) for different/major countries & scripts.

Here is it in table form:

![image](https://github.com/user-attachments/assets/f92a15a2-667d-412d-99cc-4f6b8094f195)

Reviewer @ftyers 

Edit-1: Added Kabardian reference to variant
Edit-2: Changed transliteration bcp-47 code from `<lc>-Latn-TR-t-<lc>-cyrl-tr` to  `<lc>-Latn-TR-t-<lc>-cyrl` as some of the sentences would be common to all variants and those will also be transliterated to Latin-Turkish.
