### PR TITLE
Fix foundation.mozilla.org URLs

### DIFF
--- a/docs/submitting-bulk-sentences.md
+++ b/docs/submitting-bulk-sentences.md
@@ -14,7 +14,7 @@ Please format your bulk sentences into a [.TSV](https://en.wikipedia.org/wiki/Ta
 - The source for your sentence
 - Additional infomation about why this source is eligible for inclusion in a CC0 dataset
 - A blank column for our team to use in the quality control process
-- An optional column showing the domain for sentences, as described in [this blog post](https://foundation.mozilla.org/en/blog/domain-datasets-common-voice/)
+- An optional column showing the domain for sentences, as described in [this blog post](https://foundation.mozilla.org/blog/domain-datasets-common-voice/)
 - An optional column for the language variant of sentence(s), where applicable
 
 The more information you are able to provide in the Source column, the easier it will be to get your bulk sentence submission validated.

--- a/web/src/components/layout/nav/menu-items.ts
+++ b/web/src/components/layout/nav/menu-items.ts
@@ -108,7 +108,7 @@ export const menuItems: Record<NavItem, MenuConfig> = {
         icon: ShareLinkIcon,
         localizedId: 'press-and-stories',
         externalHref:
-          'https://foundation.mozilla.org/en/blog/topic/common-voice/',
+          'https://foundation.mozilla.org/blog/topic/common-voice/',
         menuItemTooltip: 'press-and-stories-menu-item-tooltip',
         menuItemAriaLabel: 'press-and-stories-menu-item-aria-label',
       },

--- a/web/src/components/pages/about/playbook-content/how-funded.tsx
+++ b/web/src/components/pages/about/playbook-content/how-funded.tsx
@@ -10,7 +10,7 @@ const HowFunded = () => (
       elems={{
         philantropicGrantLink: (
           <a
-            href="https://foundation.mozilla.org/en/blog/mozilla-common-voice-dataset-grows-by-30-and-reaches-87-languages/"
+            href="https://foundation.mozilla.org/blog/mozilla-common-voice-dataset-grows-by-30-and-reaches-87-languages/"
             target="_blank"
             rel="noopener noreferrer"
           />

--- a/web/src/components/pages/about/playbook-content/what-is-language.tsx
+++ b/web/src/components/pages/about/playbook-content/what-is-language.tsx
@@ -15,7 +15,7 @@ const WhatIsLanguage = React.memo(() => {
         elems={{
           ctaLink: (
             <a
-              href="https://foundation.mozilla.org/en/blog/how-we-are-making-common-voice-even-more-linguistically-inclusive/"
+              href="https://foundation.mozilla.org/blog/how-we-are-making-common-voice-even-more-linguistically-inclusive/"
               target="_blank"
               rel="noopener noreferer"
             />

--- a/web/src/components/pages/partner/partner-options.tsx
+++ b/web/src/components/pages/partner/partner-options.tsx
@@ -28,7 +28,7 @@ export const PARTNER_OPTIONS = [
     elems: {
       programmaticWork: (
         <a
-          href="https://foundation.mozilla.org/en/common-voice/in-country-programmes"
+          href="https://foundation.mozilla.org/common-voice/in-country-programmes"
           target="_blank"
           rel="noreferrer">
           programmatic work

--- a/web/src/components/pages/profile/info/info.tsx
+++ b/web/src/components/pages/profile/info/info.tsx
@@ -260,7 +260,7 @@ function ProfileInfo({
           elems={{
             learnMoreLink: (
               <a
-                href="https://foundation.mozilla.org/en/blog/expanding-gender-options-on-common-voice/"
+                href="https://foundation.mozilla.org/blog/expanding-gender-options-on-common-voice/"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="link"


### PR DESCRIPTION

- [x] Other


* Ensure we’re not forcing English pages to users so they can access translated content on foundation.mozilla.org. On the Foundation website, we’re redirecting users according to their browser’s preferred language, so `/en` should always be stripped from URLs for this to happen.

