### PR TITLE
Fix: Proper padding for header text on About page for small screens

### DIFF
--- a/web/src/components/pages/about/why-common-voice.css
+++ b/web/src/components/pages/about/why-common-voice.css
@@ -45,7 +45,7 @@
         }
 
         @media (--md-down) {
-            padding-right: 1.25rem;
+            padding: 0 1rem;
         }
 
         & h2 {


### PR DESCRIPTION
## Pull Request Form

<!-- Thanks for making a contribution to Common Voice, to help us review the request please fill out this form -->

### Type of Pull Request

<!-- To help us understand your pull request, choose the checkboxes most relevant to your request by filling out the checkboxes with [x] here -->

- [ ] Bulk sentence upload

<!--- Please ensure your sentences are licensed under CC0 before making a submission. Learn how you can do this via our Playbook https://common-voice.github.io/community-playbook/sub_pages/cc0waiver_process.html -->

- [x] Related to a listed issue

<!--- Please link the issues related to your PR Request -->
* [#4677](https://github.com/common-voice/common-voice/issues/4677)

- [ ] Other

<!--- Please describe the pull request-->
* Fixed the misaligned header text on the About page for small screens by correcting the UI padding issue. The issue was causing text to be cut off or misaligned on mobile screens and smaller devices.

### Acknowledging contributors

<!-- Please list who collaborated with you to make this contribution. Or Community discussion that helped make this idea possible -->
* Self
* Feedback and suggestions from @jessicarose regarding the issue
