### PR TITLE
fix: update validated sentences job was not triggered anymore

### DIFF
--- a/server/src/api/cli/start-dataset-release.ts
+++ b/server/src/api/cli/start-dataset-release.ts
@@ -14,14 +14,14 @@ type InitDatasetReleaseJob = {
 const startDatasetRelease = async (args: any, options: any) => {
   const run = pipe(
     getQueue<InitDatasetReleaseJob>('datasetRelease')(),
-    addJobToQueue<InitDatasetReleaseJob>({
+    addJobToQueue<InitDatasetReleaseJob>('init')({
       type: args.type,
       from: args.from,
       until: args.until,
       releaseName: args.releaseName,
       previousReleaseName: args.previousReleaseName,
       languages: args.languages || [],
-    })('init')({})
+    })({})
   )
 
   await run()

--- a/server/src/infrastructure/queues/bulkSubmissionQueue.ts
+++ b/server/src/infrastructure/queues/bulkSubmissionQueue.ts
@@ -16,14 +16,18 @@ const BULK_SUBMISSION_UPLOAD_JOB_NAME = 'bulk-submission-upload-job'
 export const setupBulkSubmissionQueue = () => {
   return pipe(
     getQueue<BulkSubmissionUploadJob>(BULK_SUBMISSION_UPLOAD_QUEUE_NAME),
-    IO.chainFirst(addProcessorToQueue(bulkSubmissionUploadProcessor)(BULK_SUBMISSION_UPLOAD_JOB_NAME)),
+    IO.chainFirst(
+      addProcessorToQueue(bulkSubmissionUploadProcessor)(
+        BULK_SUBMISSION_UPLOAD_JOB_NAME
+      )
+    ),
     IO.chainFirst(attachEventHandlerToQueue('error')(console.error)),
     IO.chainFirst(attachEventHandlerToQueue('failure')(console.error))
   )()
 }
 
 const addBulkSubmissionUploadJob = (job: BulkSubmissionUploadJob) =>
-  addJobToQueue(job)(BULK_SUBMISSION_UPLOAD_JOB_NAME)({})(
+  addJobToQueue(BULK_SUBMISSION_UPLOAD_JOB_NAME)(job)({})(
     getQueue<BulkSubmissionUploadJob>(BULK_SUBMISSION_UPLOAD_QUEUE_NAME)()
   )
 

--- a/server/src/infrastructure/queues/queues.ts
+++ b/server/src/infrastructure/queues/queues.ts
@@ -1,7 +1,7 @@
 import * as Queue from 'bull'
 import { CommonVoiceConfig, getConfig } from '../../config-helper'
 import { io as IO, task as T } from 'fp-ts'
-import { constVoid, pipe } from 'fp-ts/lib/function'
+import { constVoid } from 'fp-ts/lib/function'
 
 const getRedisConfig = (config: CommonVoiceConfig): Queue.QueueOptions => {
   const redisUrlParts = config.REDIS_URL?.split('//')
@@ -38,22 +38,23 @@ export const addProcessorToQueue =
   }
 
 export const addSandboxedProcessorToQueue =
-  <T>(processorPath: string) =>
+  <T>(jobName: string) =>
+  (processorPath: string) =>
   (q: Queue.Queue<T>): IO.IO<void> => {
-    q.process(processorPath)
+    q.process(jobName, processorPath)
     return IO.of(constVoid())
   }
 
 export const attachEventHandlerToQueue =
-  (event: string) =>
-  <T>(eventHandler: (job: Queue.Job<T>) => any) =>
+  <T>(event: string) =>
+  (eventHandler: (job: Queue.Job<T>) => any) =>
   (q: Queue.Queue<T>): IO.IO<void> => {
     return IO.of(q.on(event, eventHandler))
   }
 
 export const addJobToQueue =
-  <J>(job: J) =>
-  (jobName: string) =>
+  <J>(jobName: string) =>
+  (job: J) =>
   (options: Queue.JobOptions) =>
   (q: Queue.Queue<J>): T.Task<boolean> =>
   async () => {

--- a/server/src/infrastructure/queues/updateValidatedSentencesQueue.ts
+++ b/server/src/infrastructure/queues/updateValidatedSentencesQueue.ts
@@ -19,7 +19,7 @@ export const setupUpdateValidatedSentencesQueue = () => {
   pipe(
     getQueue<ValidateSentencesJob>(UPDATE_VALIDATED_SENTENCES_QUEUE_NAME),
     IO.chainFirst(
-      addSandboxedProcessorToQueue(
+      addSandboxedProcessorToQueue(UPDATE_VALIDATED_SENTENCES_JOB)(
         `${__dirname}/processors/updateValidatedSentencesProcessor.js`
       )
     ),
@@ -31,8 +31,11 @@ export const setupUpdateValidatedSentencesQueue = () => {
       )
     ),
     IO.chainFirst(
-      addJobToQueue({ name: UPDATE_VALIDATED_SENTENCES_JOB })(UPDATE_VALIDATED_SENTENCES_JOB)({
+      addJobToQueue(UPDATE_VALIDATED_SENTENCES_JOB)({
+        name: UPDATE_VALIDATED_SENTENCES_JOB,
+      })({
         repeat: { cron: REPEAT_EVERY_HOUR },
+        removeOnComplete: true,
       })
     )
   )()


### PR DESCRIPTION
Fixing the the `updateValidatedSentences` job, that stopped working.

* adding the job name to the sand-boxed processor
* change the ordering of some function parameters