### PR TITLE
736 make transition from scripted speech to spontaneous speech seamless as if both platforms are one

### DIFF
--- a/server/src/infrastructure/authentication/authentication.ts
+++ b/server/src/infrastructure/authentication/authentication.ts
@@ -2,12 +2,12 @@ import { Environment } from '../../config-helper'
 
 export const CALLBACK_URL = '/callback'
 
-const CALLBACK_MAP: Readonly<Record<Environment, string>> = {
-  stage: 'https://commonvoice.allizom.org',
+export const COMMON_VOICE_DOMAIN_MAP: Readonly<Record<Environment, string>> = {
   prod: 'https://commonvoice.mozilla.org',
+  stage: 'https://commonvoice.allizom.org',
   sandbox: 'https://sandbox.commonvoice.allizom.org',
   local: 'http://localhost:9000', // TODO: use SERVER_PORT
 }
 
 export const callbackURL = (env: Environment) =>
-  CALLBACK_MAP[env] + CALLBACK_URL
+  COMMON_VOICE_DOMAIN_MAP[env] + CALLBACK_URL

--- a/web/src/components/app.tsx
+++ b/web/src/components/app.tsx
@@ -1,45 +1,45 @@
-import * as React from 'react';
-import * as Modal from 'react-modal';
-import { Suspense } from 'react';
-import { connect, Provider as ReduxProvider } from 'react-redux';
+import * as React from 'react'
+import * as Modal from 'react-modal'
+import { Suspense } from 'react'
+import { connect, Provider as ReduxProvider } from 'react-redux'
 import {
   Redirect,
   Route,
   RouteComponentProps,
   Switch,
   withRouter,
-} from 'react-router';
-import { Router } from 'react-router-dom';
-import * as Sentry from '@sentry/react';
-import { BrowserTracing } from '@sentry/tracing';
-import { createBrowserHistory } from 'history';
+} from 'react-router'
+import { Router, useHistory } from 'react-router-dom'
+import * as Sentry from '@sentry/react'
+import { BrowserTracing } from '@sentry/tracing'
+import { createBrowserHistory } from 'history'
 
-import { UserClient } from 'common';
-import store from '../stores/root';
-import URLS from '../urls';
-import { isMobileSafari, isProduction, shouldEmitErrors } from '../utility';
-import API from '../services/api';
-import { Locale } from '../stores/locale';
-import * as Languages from '../stores/languages';
-import { Notifications } from '../stores/notifications';
-import StateTree from '../stores/tree';
-import { Uploads } from '../stores/uploads';
-import { User } from '../stores/user';
-import Layout from './layout/layout';
-import NotificationPill from './notification-pill/notification-pill';
-import { Spinner } from './ui/ui';
-import { localeConnector, LocalePropsFromState } from './locale-helpers';
-import { Flags } from '../stores/flags';
+import { UserClient } from 'common'
+import store from '../stores/root'
+import URLS from '../urls'
+import { isMobileSafari, isProduction, shouldEmitErrors } from '../utility'
+import API from '../services/api'
+import { Locale } from '../stores/locale'
+import * as Languages from '../stores/languages'
+import { Notifications } from '../stores/notifications'
+import StateTree from '../stores/tree'
+import { Uploads } from '../stores/uploads'
+import { User } from '../stores/user'
+import Layout from './layout/layout'
+import NotificationPill from './notification-pill/notification-pill'
+import { Spinner } from './ui/ui'
+import { localeConnector, LocalePropsFromState } from './locale-helpers'
+import { Flags } from '../stores/flags'
 
-import LanguagesProvider from './languages-provider';
-import ErrorBoundary from './error-boundary/error-boundary';
-import LocalizedErrorBoundary from './error-boundary/localized-error-boundary';
-import { AB_TESTING_SPLIT_KEY, SPLIT_A, SPLIT_B } from '../constants';
+import LanguagesProvider from './languages-provider'
+import ErrorBoundary from './error-boundary/error-boundary'
+import LocalizedErrorBoundary from './error-boundary/localized-error-boundary'
+import { AB_TESTING_SPLIT_KEY, SPLIT_A, SPLIT_B } from '../constants'
 
 const ListenPage = React.lazy(
   () => import('./pages/contribution/listen/listen')
-);
-const SpeakPage = React.lazy(() => import('./pages/contribution/speak/speak'));
+)
+const SpeakPage = React.lazy(() => import('./pages/contribution/speak/speak'))
 const WritePage = React.lazy(
   () => import('./pages/contribution/sentence-collector/write/write-container')
 )
@@ -96,8 +96,7 @@ let LocalizedPage: any = class extends React.Component<
   state: LocalizedPagesState = {
     uploadPercentage: null,
   }
-
-  isUploading = false;
+  isUploading = false
 
   async componentDidMount() {
     this.props.updateUser({})
@@ -190,7 +189,7 @@ let LocalizedPage: any = class extends React.Component<
   }
 
   setABSplit() {
-    const randomValue = Math.random();
+    const randomValue = Math.random()
 
     if (randomValue < 0.5) {
       localStorage.setItem(AB_TESTING_SPLIT_KEY, SPLIT_A)
@@ -203,8 +202,16 @@ let LocalizedPage: any = class extends React.Component<
     const { locale, notifications, toLocaleRoute, location, languages } =
       this.props
     const { uploadPercentage } = this.state
-
     const isContributable = languages.contributableLocales.includes(locale)
+    const isSpontSpeechRedirect = location.pathname.includes(
+      URLS.SPONTANEOUS_SPEECH_REDIRECT
+    )
+
+    if (isSpontSpeechRedirect) {
+      // There's most probably a better way and place to do that
+      window.location.href = URLS.SPONTANEOUS_SPEECH
+      return
+    }
 
     return (
       <>
@@ -270,7 +277,7 @@ let LocalizedPage: any = class extends React.Component<
   }
 }
 
-LocalizedPage.displayName = 'LocalizedPage';
+LocalizedPage.displayName = 'LocalizedPage'
 
 LocalizedPage = withRouter(
   localeConnector(
@@ -292,10 +299,10 @@ LocalizedPage = withRouter(
       }
     )(LocalizedPage)
   )
-);
+)
 
 const App = () => {
-  const history = createBrowserHistory();
+  const history = createBrowserHistory()
 
   return (
     <Suspense fallback={<Spinner />}>
@@ -311,7 +318,7 @@ const App = () => {
         </ReduxProvider>
       </ErrorBoundary>
     </Suspense>
-  );
-};
+  )
+}
 
-export default App;
+export default App

--- a/web/src/urls.ts
+++ b/web/src/urls.ts
@@ -1,6 +1,7 @@
-const PROFILE = '/profile';
-const DASHBOARD = '/dashboard';
-const DEMO = '/demo';
+const PROFILE = '/profile'
+const DASHBOARD = '/dashboard'
+const DEMO = '/demo'
+const SPONTANEOUS_SPEECH = '/spontaneous-speech/beta'
 
 export default Object.freeze({
   ROOT: '',
@@ -37,6 +38,9 @@ export default Object.freeze({
   PARTNER: '/partner',
   GUIDELINES: '/guidelines',
   SENTENCE_COLLECTOR_REDIRECT: '/sentence-collector-redirect',
+
+  SPONTANEOUS_SPEECH,
+  SPONTANEOUS_SPEECH_REDIRECT: '/spontaneous-speech-redirect',
 
   LANGUAGES: '/languages',
   LANGUAGE_REQUEST: '/language/request',


### PR DESCRIPTION
* added some logic to create a redirect url for seamless integration between CV and SS
* updated the JWT payload as well to contain the issuer, audience and whether or not the user is anonymous
* changed the JWT claim `client_id` to the more appropriate `sub` claim