### PR TITLE
feat: round hours that are less than 10h to one decimal

### DIFF
--- a/server/src/lib/utils/secondsToHours.test.ts
+++ b/server/src/lib/utils/secondsToHours.test.ts
@@ -1,27 +1,35 @@
-import { secondsToHours } from './secondsToHours';
+import { secondsToHours } from './secondsToHours'
 
 describe('secondsToHours', () => {
   test('converts numerical value into hours', () => {
-    expect(secondsToHours(3600)).toBe(1);
-  });
+    expect(secondsToHours(3600)).toBe(1)
+  })
 
   test('converts large numerical value into hours', () => {
-    expect(secondsToHours(999999999)).toBe(277778);
-  });
+    expect(secondsToHours(999999999)).toBe(277778)
+  })
 
   test('converts 0 value into 0 hours', () => {
-    expect(secondsToHours(0)).toBe(0);
-  });
+    expect(secondsToHours(0)).toBe(0)
+  })
 
   test('converts -1 value into 0 hours', () => {
-    expect(secondsToHours(-1)).toBe(0);
-  });
+    expect(secondsToHours(-1)).toBe(0)
+  })
 
   test('converts -453 value into 0 hours', () => {
-    expect(secondsToHours(-453)).toBe(0);
-  });
+    expect(secondsToHours(-453)).toBe(0)
+  })
 
-  test('converts 60.234 value into 1 hours', () => {
-    expect(secondsToHours(60.234)).toBe(1);
-  });
-});
+  test('converts 4,560 value into 1.3 hours', () => {
+    expect(secondsToHours(4560)).toBe(1.3)
+  })
+
+  test('converts 35,640 value into 9.9 hours', () => {
+    expect(secondsToHours(35640)).toBe(9.9)
+  })
+
+  test('converts 40,320 value into 12 hours', () => {
+    expect(secondsToHours(40320)).toBe(12)
+  })
+})

--- a/server/src/lib/utils/secondsToHours.ts
+++ b/server/src/lib/utils/secondsToHours.ts
@@ -1,11 +1,17 @@
-const HOUR_IN_SECONDS = 3600;
+const HOUR_IN_SECONDS = 3600
 
 /**
- * Converts seconds to hours, defaults to 0 if no seconds provided. Rounds up to nears whole number.
- * 2.1 hours will be returned as 3
+ * Converts seconds to hours, defaults to 0 if no seconds provided. Rounds up to nears whole number for
+ * durations longer than 10 hours. Durations shorter than 10h will be displayed with a decimal.
+ * @example
+ * 2.1 hours will be returned as 2.1 hours
+ * 12.1 hours will be returned as 13 hours
  * @param {number} seconds
  * @return {number} hours
  */
 export const secondsToHours = (seconds: number): number => {
-  return Math.ceil(seconds / HOUR_IN_SECONDS) || 0;
-};
+  if (seconds <= 0) return 0
+
+  const hours = seconds / HOUR_IN_SECONDS
+  return hours >= 10 ? Math.ceil(hours) : parseFloat(hours.toFixed(1))
+}


### PR DESCRIPTION
A quick fix to display hours with one decimal place if a language has fewer than 10 hours collected.
Example:
<img width="1172" alt="image" src="https://github.com/user-attachments/assets/2ff93be6-38c7-4023-8926-2eb74c03f824" />
