### PR TITLE
fix: remove unused client_id

### DIFF
--- a/server/src/lib/api.ts
+++ b/server/src/lib/api.ts
@@ -298,7 +298,9 @@ export default class API {
     const project = isProject(req.query?.project)
       ? req.query.project
       : 'common-voice'
-    const availableLanguages = getFolderNames(path.join(LOCALES_PATH, project))()
+    const availableLanguages = getFolderNames(
+      path.join(LOCALES_PATH, project)
+    )()
     res.json({
       project,
       availableLanguages,
@@ -733,18 +735,8 @@ export default class API {
     )
   }
 
-  getVariants = async (
-    {
-      session: {
-        user: { client_id },
-      },
-      params,
-    }: Request,
-    response: Response
-  ) => {
-    response.json(
-      await this.model.db.getVariants(client_id, params?.locale || null)
-    )
+  getVariants = async ({ params }: Request, response: Response) => {
+    response.json(await this.model.db.getVariants(params?.locale || null))
   }
 
   sendLanguageRequest = async (

--- a/server/src/lib/model/db.ts
+++ b/server/src/lib/model/db.ts
@@ -1232,7 +1232,7 @@ export default class DB {
     )[0][0].count
   }
 
-  async getVariants(client_id: string, locale?: string) {
+  async getVariants(locale?: string) {
     const [variants] = await this.mysql.query(
       `
       SELECT name as lang, variant_token AS tag, v.id AS variant_id, variant_name FROM variants v


### PR DESCRIPTION
The `client_id` was destructered in the `getVariants` function call although it is not even used. The destructing also caused an error because the `client_id` is not always present but was assumed to be.