### PR TITLE
Allow long text to fit sentence area

### DIFF
--- a/web/src/components/pages/contribution/contribution.css
+++ b/web/src/components/pages/contribution/contribution.css
@@ -614,14 +614,14 @@
 
         @media (--md-up) {
             padding: 0 25px;
-            font-size: var(--font-size-xl);
+            font-size: var(--font-size-lg);
             font-weight: normal;
-            letter-spacing: 1.3px;
-            line-height: 1.63;
+            letter-spacing: 1.2px;
+            line-height: 1.5;
         }
 
         @media (--lg-up) {
-            padding: 0 100px;
+            padding: 0 50px;
         }
     }
 

--- a/web/src/components/pages/contribution/sentence-collector/review/review.css
+++ b/web/src/components/pages/contribution/sentence-collector/review/review.css
@@ -122,14 +122,14 @@
 
             @media (--md-up) {
                 padding: 0 25px;
-                font-size: var(--font-size-xl);
+                font-size: var(--font-size-lg);
                 font-weight: normal;
-                letter-spacing: 1.3px;
-                line-height: 1.63;
+                letter-spacing: 1.2px;
+                line-height: 1.5;
             }
 
             @media (--lg-up) {
-                padding: 100px 100px 0;
+                padding: 50px 50px 0;
             }
         }
     }


### PR DESCRIPTION
This fixes #4758 for most usual 1080p screens by using smaller font and smaller left/right padding, letter-spacing, and line-height values.

Note that:
- The default 14 words/sentence (estimated from English) should be about 1.5x14 = 21 words for 15 sec recordings.
- Although the recording limit is increased the frontend is not adapted for longer texts.
- Frontend is most probably tested against English texts, where average word length is ~5 symbols. On the other hand we calculated ~7 symbols/word average for Kabardian (similar for Adyghe). Also many symbols are wide, like Ж Д Ш Ю

This is tested for Kabardian ON THE BROWSER for a 21 word sentence for 15 sec recordings. Here are the results:

For Speak:
![image](https://github.com/user-attachments/assets/728c7652-f056-4794-bac6-ad7bfacf0b93)

For Listen with variant pill:
![image](https://github.com/user-attachments/assets/1f52fea3-d9f6-4a6c-b138-9ee63a4c61fb)

