### PR TITLE
Add Laz language variants accents

### DIFF
--- a/server/src/lib/model/db/language-data/accents.ts
+++ b/server/src/lib/model/db/language-data/accents.ts
@@ -325,4 +325,39 @@ export const ACCENTS: Accent[] = [
     accent_name: '出生地：連江縣',
     accent_token: 'lienchiang_county',
   },
+  {
+    locale_name: 'lzz',
+    accent_name: 'Atina (Pazar)',
+    accent_token: 'atinuri',
+  },
+  {
+    locale_name: 'lzz',
+    accent_name: 'Artaşeni (Ardeşen)',
+    accent_token: 'artaşenuri',
+  },
+  {
+    locale_name: 'lzz',
+    accent_name: 'Vitzi (Fındıklı)',
+    accent_token: 'vitzuri',
+  },
+  {
+    locale_name: 'lzz',
+    accent_name: 'Arkabi (Arhavi)',
+    accent_token: 'arkaburi',
+  },
+  {
+    locale_name: 'lzz',
+    accent_name: 'Xope (Hopa)',
+    accent_token: 'xopuri',
+  },
+  {
+    locale_name: 'lzz',
+    accent_name: 'Çxala (İçkale/Borçka)',
+    accent_token: 'çxaluri',
+  },
+  {
+    locale_name: 'lzz',
+    accent_name: 'Beğlevani (Güreşen)',
+    accent_token: 'beğlevanuri',
+  },
 ]

--- a/server/src/lib/model/db/language-data/variants.ts
+++ b/server/src/lib/model/db/language-data/variants.ts
@@ -416,4 +416,19 @@ export const VARIANTS: Variant[] = [
     variant_name: ' სენაკურ-მარტვილური',
     variant_token: 'xmf-senmar',
   },
+  {
+    locale_name: 'lzz',
+    variant_name: 'Atinuri, Artaşenuri',
+    variant_token: 'lzz-atinuri',
+  },
+  {
+    locale_name: 'lzz',
+    variant_name: 'Vitzuri, Arkaburi',
+    variant_token: 'lzz-arkaburi',
+  },
+  {
+    locale_name: 'lzz',
+    variant_name: 'Xopuri',
+    variant_token: 'lzz-xopuri',
+  },
 ]


### PR DESCRIPTION
This adds Laz language variants and accents.
PR is for İsmail Bucaklisi
For review by @ftyers 


Variants and accents are ordered from west to east.

![image](https://github.com/user-attachments/assets/6c61672a-e487-4148-bf55-ac8760f4ca37)
