### PR TITLE
[FIX] (URGENT) Add generic *-Cyrl variants for ady and kbd for common sentences

### DIFF
--- a/server/src/lib/model/db/language-data/variants.ts
+++ b/server/src/lib/model/db/language-data/variants.ts
@@ -192,6 +192,11 @@ export const VARIANTS: Variant[] = [
   },
   {
     locale_name: 'ady',
+    variant_name: 'Адыгабзэ (Кирил, пстэумэ зэдыряе)',
+    variant_token: 'ady-Cyrl',
+  },
+  {
+    locale_name: 'ady',
     variant_name: 'Адыгабзэ (Кирил, Урысый)',
     variant_token: 'ady-RU',
   },
@@ -214,6 +219,11 @@ export const VARIANTS: Variant[] = [
     locale_name: 'ady',
     variant_name: 'Адыгабзэ (Кирил, Сирие)',
     variant_token: 'ady-Cyrl-SY',
+  },
+  {
+    locale_name: 'kbd',
+    variant_name: 'Адыгэбзэ (Къэбэрдей, Кирил, псоми зэдай)',
+    variant_token: 'kbd-Cyrl',
   },
   {
     locale_name: 'kbd',


### PR DESCRIPTION
This PR adds generic Cyrillic variants for sentences common for all locales. Until now we used empty variant info for those, but whenever we added Latin transliterations, people only see them because they have 0 recordings, and Cyrillic ones have at least one recording. To be able to filter them in the profiles, we need to migrate the `sentence_metadata` to these new variants - next.

The ones in bold are added.
![image](https://github.com/user-attachments/assets/eb671b47-2c09-484d-b0ce-8b2f043bd55f)

Next will follow migrations in both `ady` and `kbd` locales.

This is **urgent** because people cannot skip thousands of Latin sentences, so they stopped recording.
