### PR TITLE
Migrate Circassian common sentences to <lc>-Cyrl variants

### DIFF
--- a/server/src/lib/model/db/language-data/variants.ts
+++ b/server/src/lib/model/db/language-data/variants.ts
@@ -192,6 +192,11 @@ export const VARIANTS: Variant[] = [
   },
   {
     locale_name: 'ady',
+    variant_name: 'Адыгабзэ (Кирил, пстэумэ зэдыряе)',
+    variant_token: 'ady-Cyrl',
+  },
+  {
+    locale_name: 'ady',
     variant_name: 'Адыгабзэ (Кирил, Урысый)',
     variant_token: 'ady-RU',
   },
@@ -214,6 +219,11 @@ export const VARIANTS: Variant[] = [
     locale_name: 'ady',
     variant_name: 'Адыгабзэ (Кирил, Сирие)',
     variant_token: 'ady-Cyrl-SY',
+  },
+  {
+    locale_name: 'kbd',
+    variant_name: 'Адыгэбзэ (Къэбэрдей, Кирил, псоми зэдай)',
+    variant_token: 'kbd-Cyrl',
   },
   {
     locale_name: 'kbd',

--- a/server/src/lib/model/db/migrations/20250221120000-set-empty-ady-variants-to-cyrl.ts
+++ b/server/src/lib/model/db/migrations/20250221120000-set-empty-ady-variants-to-cyrl.ts
@@ -1,0 +1,12 @@
+export const up = async function (db: any): Promise<any> {
+  await db.runSql(`
+    UPDATE sentence_metadata
+    SET variant_id=(SELECT id FROM variants WHERE variant_token = 'ady-Cyrl')
+    WHERE locale_id=(SELECT id from locales WHERE name='ady')
+      AND variant_id IS NULL
+  `)
+};
+
+export const down = async function (): Promise<any> {
+  return null;
+};

--- a/server/src/lib/model/db/migrations/20250221120100-set-empty-kbd-variants-to-cyrl.ts
+++ b/server/src/lib/model/db/migrations/20250221120100-set-empty-kbd-variants-to-cyrl.ts
@@ -1,0 +1,12 @@
+export const up = async function (db: any): Promise<any> {
+  await db.runSql(`
+    UPDATE sentence_metadata
+    SET variant_id=(SELECT id FROM variants WHERE variant_token = 'kbd-Cyrl')
+    WHERE locale_id=(SELECT id from locales WHERE name='kbd')
+      AND variant_id IS NULL
+  `)
+};
+
+export const down = async function (): Promise<any> {
+  return null;
+};


### PR DESCRIPTION
This is a follow-up for #4791 for Circassian languages (`ady` and `kbd`).

If the variant field is empty, they get "moved" to `<lc>-Cyrl` to distinguish from others in profile.

Until now, except recently added `<lc>-Latn-TR-t-<lc>-Cyrl` sentences, there are other sentences without variant info, so it is safe.

EDIT: The first commit has already been merged, but here will silently be processed. I hope it is OK.
