### PR TITLE
Fix: Remove variables and revise wording in goals page which crashes in some languages

### DIFF
--- a/web/locales/common-voice/en/pages/dashboard.ftl
+++ b/web/locales/common-voice/en/pages/dashboard.ftl
@@ -52,20 +52,7 @@ help-reach-hours-general-pluralized =
     } in a language with a personal goal
 set-a-goal = Set a goal
 cant-decide = Can't decide?
-activity-needed-calculation-plural =
-    { NUMBER($totalHours) ->
-        [one] { $totalHours } hour
-       *[other] { $totalHours } hours
-    } is achievable in just over { NUMBER($periodMonths) ->
-        [one] { $periodMonths } month
-       *[other] { $periodMonths } months
-    } if { NUMBER($people) ->
-        [one] { $people } person
-       *[other] { $people } people
-    } record { NUMBER($clipsPerDay) ->
-        [one] { $clipsPerDay } clip
-       *[other] { $clipsPerDay } clips
-    } a day.
+activity-needed-calculation-fixed = 100 people recording 100 sentences a day can generate 13 hours of audio. Keeping up this performance, 1000 hours can be reached under 3 months.
 how-many-per-day = Great! How many clips per day?
 how-many-a-week = Great! How many clips a week?
 which-goal-type = Do you want to Speak, Listen or both?

--- a/web/src/components/pages/dashboard/goals/custom-goal-steps.tsx
+++ b/web/src/components/pages/dashboard/goals/custom-goal-steps.tsx
@@ -194,14 +194,7 @@ export default [
           <Localized id="cant-decide">
             <h4 />
           </Localized>
-          <Localized
-            id="activity-needed-calculation-plural"
-            vars={{
-              totalHours: 10000,
-              periodMonths: 6,
-              people: 1000,
-              clipsPerDay: 45,
-            }}>
+          <Localized id="activity-needed-calculation-fixed">
             <p />
           </Localized>
         </div>


### PR DESCRIPTION
Fixes: #3907 

In goals page, there is a complex structure which crashes the page in some languages because of unnecessarily added plurals/variables to the i10n sentence, which creates a thousand possibilities for Fluent. But the variables are not variables, just passed as constants.

Also the calculations are based on 10k hours what could be valid in 2018, but not nowadays. And it also depends on many other variables as explained here:
https://github.com/common-voice/common-voice/issues/3907#issuecomment-2690459311

So, this PR just makes it a single fixed value string with more recent requirements.
