### PR TITLE
Add sw-katanga variant

### DIFF
--- a/server/src/lib/model/db/language-data/variants.ts
+++ b/server/src/lib/model/db/language-data/variants.ts
@@ -37,6 +37,11 @@ export const VARIANTS: Variant[] = [
   },
   {
     locale_name: 'sw',
+    variant_name: 'Katanga (DRC)',
+    variant_token: 'sw-katanga',
+  },
+  {
+    locale_name: 'sw',
     variant_name: 'Kiswahili Sanifu (EA)',
     variant_token: 'sw-sanifu',
   },


### PR DESCRIPTION
Add variant to `sw` Kiswahili - Katanga (DRC) - sw-katanga 

Tested by running 

```
SELECT l.name, l.native_name, v.variant_name, v.variant_token 
FROM variants v, locales l
WHERE v.locale_id = l.id 
AND l.name = 'sw'
```

|name|native_name|variant_name                              |variant_token|
|----|-----------|------------------------------------------|-------------|
|sw  |Swahili    |Katanga (DRC)                             |sw-katanga   |
|sw  |Swahili    |Kibajuni (KE) - Northern dialect          |sw-kibajuni  |
|sw  |Swahili    |Kimakunduchi/Kikae (TZ) - Southern dialect|sw-kikae     |
|sw  |Swahili    |Kimrima (TZ) - Northern dialect           |sw-kimrima   |
|sw  |Swahili    |Kimvita (KE) - Central dialect            |sw-kimvita   |
|sw  |Swahili    |Kingwana (DRC)                            |sw-kingwana  |
|sw  |Swahili    |Kipemba (TZ) - Southern dialect           |sw-kipemba   |
|sw  |Swahili    |Kiswahili cha Bara ya Kenya               |sw-barake    |
|sw  |Swahili    |Kiswahili cha Bara ya Tanzania            |sw-baratz    |
|sw  |Swahili    |Kiswahili Sanifu (EA)                     |sw-sanifu    |
|sw  |Swahili    |Kiunguja (TZ) - Southern dialect          |sw-kiunguja  |


