### PR TITLE
Feat : Add less more to datasets page

### DIFF
--- a/web/locales/common-voice/en/pages/datasets.ftl
+++ b/web/locales/common-voice/en/pages/datasets.ftl
@@ -104,5 +104,5 @@ download-contribute-menu-tooltip = Download our voice datasets
 # MENU ITEM ARIA LABELS
 download-contribute-menu-aria-label = Download options for accessing Common Voice data
 
-datasets-show-more = See More
-datasets-show-less = See Less
+datasets-show-more = Show All Datasets
+datasets-show-less = Show Latest Datasets

--- a/web/src/components/pages/datasets/dataset-corpus-download-table.css
+++ b/web/src/components/pages/datasets/dataset-corpus-download-table.css
@@ -1,98 +1,110 @@
-
 .dataset-table {
+  width: 100%;
+  border-collapse: collapse;
+  @media (--md-down) {
+    &.table {
+      border-collapse: separate;
+      border-spacing: 0 1em;
+    }
+  }
+  thead,
+  tbody {
     width: 100%;
-    border-collapse: collapse;
-    @media (--md-down) {
-        &.table {
-            border-collapse:separate; 
-            border-spacing: 0 1em;
+  }
+  thead {
+    tr {
+      width: 100%;
+    }
+  }
+
+  tbody {
+    tr {
+      background-color: var(--lighter-grey);
+      border-bottom: 2px solid var(--light-grey);
+
+      &:hover {
+        cursor: pointer;
+        background-color: var(--light-grey);
+      }
+      &.selected {
+        background-color: var(--light-blue);
+      }
+      @media (--lg-up) {
+        & td:first-child {
+          padding-left: 25px;
+        }
+        &.selected {
+          & td:first-child::before {
+            content: '';
+            background: url('./images/checkmark.svg') no-repeat;
+            width: 25px;
+            height: 25px;
+            position: absolute;
+            left: 47px;
+            transform: translateY(5px);
           }
+        }
+      }
     }
-    thead,
-    tbody {
-        width: 100%;
-    }
+  }
+
+  td,
+  th {
+    padding: 15px 5px;
+    text-align: left;
+  }
+
+  @media (--md-down) {
     thead {
-        tr {
-            width: 100%;
-        }
+      display: none;
     }
-
-    tbody {
-        tr {
-            background-color: var(--lighter-grey);
-            border-bottom: 2px solid var(--light-grey);
-            
-            &:hover {
-                cursor: pointer;
-                background-color: var(--light-grey);
-            }
-            &.selected {
-                background-color: var(--light-blue);
-            }
-            @media (--lg-up) {
-                & td:first-child {
-                    padding-left: 25px;
-                }
-                &.selected {
-                    & td:first-child::before {
-                        content: '';
-                        background: url('./images/checkmark.svg') no-repeat;
-                        width: 25px;
-                        height: 25px;
-                        position: absolute;
-                        left: 47px;
-                        transform: translateY(5px);
-                    }
-                }
-            }
-        }
+    tr.selected {
+      td {
+        display: flex;
+      }
     }
+    td {
+      display: none;
+      &.highlight {
+        display: flex;
+      }
 
-    td,
-    th {
-        padding: 15px 5px;
-        text-align: left;
+      &::before {
+        content: attr(data-mobile-label);
+        font-weight: bold;
+        width: 120px;
+        min-width: 120px;
+      }
     }
-
-    @media (--md-down) {
-        thead {
-            display: none;
-        }
-        tr.selected {
-            td {
-                display: flex;
-            }
-        }
-        td {
-            display: none;
-            &.highlight {
-                display: flex;
-            }
-
-            &::before {
-                content: attr(data-mobile-label);
-                font-weight: bold;
-                width: 120px;
-                min-width: 120px;
-            }
-        }
-    }
+  }
 }
 
-.show-all-datasets {
-    display: block;
-    border: 1px solid var(--light-blue);
-    padding: 1rem;
-    width: 100%;
-    font-size: 1rem;
-    background: var(--grey);
+div.show-all-datasets {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  cursor: pointer;
 
-    &:hover {
-        background: var(--light-blue);
-    }
+  border: 1px solid var(--light-blue);
+  background: var(--grey);
+  padding: 1rem;
+  font-size: 1rem;
+  width: 100%;
 
-    &:focus {
-        outline: none;
-    }
+  &:hover {
+    background: var(--light-blue);
+  }
+
+  &:focus {
+    outline: none;
+  }
+
+  svg {
+    position: absolute;
+    right: 1rem;
+  }
+  svg.expanded {
+    transform: rotate(180deg);
+  }
 }

--- a/web/src/components/pages/datasets/dataset-corpus-download-table.tsx
+++ b/web/src/components/pages/datasets/dataset-corpus-download-table.tsx
@@ -2,20 +2,21 @@ import {
   Localized,
   withLocalization,
   WithLocalizationProps,
-} from '@fluent/react';
-import classNames from 'classnames';
-import * as React from 'react';
-import { formatBytes, msToHours } from '../../../utility';
-import { useLocale } from '../../locale-helpers';
+} from '@fluent/react'
+import classNames from 'classnames'
+import * as React from 'react'
+import { ChevronDown } from '../../ui/icons'
+import { formatBytes, msToHours } from '../../../utility'
+import { useLocale } from '../../locale-helpers'
 
-import './dataset-corpus-download-table.css';
+import './dataset-corpus-download-table.css'
 
 const DEFAULT_VISIBLE_COUNT = 6
 
 interface Props {
-  releaseData: any[];
-  onRowSelect: (selectedId: number, index: number) => void;
-  selectedId: number | null;
+  releaseData: any[]
+  onRowSelect: (selectedId: number, index: number) => void
+  selectedId: number | null
 }
 
 // map columns to localized string id
@@ -23,37 +24,37 @@ interface Props {
 const COLUMNS: { [key: string]: any } = {
   name: {
     display: (value: string) => {
-      return value;
+      return value
     },
     label: 'dataset-version',
   },
   release_date: {
     display: (value: string, locale: string) => {
-      return Intl.DateTimeFormat(locale).format(new Date(value));
+      return Intl.DateTimeFormat(locale).format(new Date(value))
     },
     label: 'dataset-date',
   },
   size: {
     display: (value: number, locale: string) => {
-      return formatBytes(value, locale);
+      return formatBytes(value, locale)
     },
     label: 'size',
   },
   total_clips_duration: {
     display: (value: number, locale: string) => {
-      return Intl.NumberFormat(locale).format(msToHours(value));
+      return Intl.NumberFormat(locale).format(msToHours(value))
     },
     label: 'recorded-hours',
   },
   valid_clips_duration: {
     display: (value: number, locale: string) => {
-      return Intl.NumberFormat(locale).format(msToHours(value));
+      return Intl.NumberFormat(locale).format(msToHours(value))
     },
     label: 'validated-hours',
   },
   license: {
     display: () => {
-      return 'CC-0';
+      return 'CC-0'
     },
     label: 'cv-license',
   },
@@ -61,17 +62,17 @@ const COLUMNS: { [key: string]: any } = {
     display: (value: number, locale: string) => {
       return value.toLocaleString(locale, {
         style: 'decimal',
-      });
+      })
     },
     label: 'number-of-voices',
   },
   audio_format: {
     display: () => {
-      return 'MP3';
+      return 'MP3'
     },
     label: 'audio-format',
   },
-};
+}
 
 const DatasetCorpusDownloadTable = ({
   releaseData,
@@ -79,9 +80,9 @@ const DatasetCorpusDownloadTable = ({
   selectedId,
   getString,
 }: Props & WithLocalizationProps) => {
-  const [locale] = useLocale();
+  const [locale] = useLocale()
 
-  const [showAllDownloads, setShowAllDownloads] = React.useState(false);
+  const [showAllDownloads, setShowAllDownloads] = React.useState(false)
 
   const toggleShowAllDownloads = () => {
     setShowAllDownloads(!showAllDownloads)
@@ -93,12 +94,18 @@ const DatasetCorpusDownloadTable = ({
 
   return (
     <React.Fragment>
-        <Localized id={'datasets-show-' + (showAllDownloads ? 'less' : 'more')}>
-          <button
-            className="show-all-datasets hidden-md-down"
-            onClick={toggleShowAllDownloads}
+      {releaseData.length <= DEFAULT_VISIBLE_COUNT ? (
+        <></>
+      ) : (
+        <div
+          className="show-all-datasets hidden-md-down"
+          onClick={toggleShowAllDownloads}>
+          <Localized
+            id={'datasets-show-' + (showAllDownloads ? 'less' : 'more')}
           />
-        </Localized>
+          <ChevronDown className={showAllDownloads ? 'expanded' : ''} />
+        </div>
+      )}
       <table className="table dataset-table hidden-md-down">
         <thead>
           <tr>
@@ -107,7 +114,7 @@ const DatasetCorpusDownloadTable = ({
                 <th key={column.label}>
                   <Localized id={column.label} />
                 </th>
-              );
+              )
             })}
           </tr>
         </thead>
@@ -119,7 +126,7 @@ const DatasetCorpusDownloadTable = ({
                 className={classNames({ selected: row.id === selectedId })}
                 key={row.id + row.release_dir}>
                 {Object.keys(COLUMNS).map((col: string, index) => {
-                  const { label, display } = COLUMNS[col];
+                  const { label, display } = COLUMNS[col]
                   return (
                     <td
                       data-mobile-label={getString(label)}
@@ -127,15 +134,15 @@ const DatasetCorpusDownloadTable = ({
                       className={index < 3 ? 'highlight' : ''}>
                       {display(row[col], locale)}
                     </td>
-                  );
+                  )
                 })}
               </tr>
-            );
+            )
           })}
         </tbody>
       </table>
     </React.Fragment>
-  );
-};
+  )
+}
 
-export default withLocalization(DatasetCorpusDownloadTable);
+export default withLocalization(DatasetCorpusDownloadTable)


### PR DESCRIPTION
- This implements the FR https://github.com/common-voice/common-voice/issues/4303 
- It puts a "see more/less" button at the top of the table. We kept similar styling like in languages page, but used a contrasting gray.
- By default it shows the latest 6 records, when clicked it shows all records.
- It only works on desktop views. On smaller width screens (mobile) it is not displayed (hidden) and the whole list is shown. We assume people would not download datasets on phones - but might like to see what is available. For desktops where the windows width is small, one might just increase the width (see [related comment](https://github.com/common-voice/common-voice/issues/4529#issuecomment-2705427276) in another issue).

Checked on local dev environment (Win 11, WSL Ubuntu 22.04.x, Docker)

These are for different views:

**1080p screen full width**
![image](https://github.com/user-attachments/assets/1a8957ae-047a-4d04-8dfe-4d1810723dc2)

**Medium width**
![image](https://github.com/user-attachments/assets/239ca1bf-07cb-41c8-8e34-47c7f28f9f34)

**Mobile widths**
![image](https://github.com/user-attachments/assets/09e497b9-8e56-4d63-ac63-77b136f0bddb)
