### PR TITLE
Fix: Change accents separator to "|" from default "," in bundles/metadata

### DIFF
--- a/bundler/queries/bundleLocale.sql
+++ b/bundler/queries/bundleLocale.sql
@@ -21,7 +21,7 @@ FROM clips
   LEFT JOIN (
     SELECT uca.client_id,
       uca.locale_id,
-      GROUP_CONCAT(a.accent_name) as accent_list
+      GROUP_CONCAT(a.accent_name SEPARATOR '|') as accent_list
     FROM user_client_accents uca
       JOIN accents a ON a.id = uca.accent_id
     WHERE a.accent_name != 'unspecified'


### PR DESCRIPTION
This should fix https://github.com/common-voice/common-voice/issues/4794

- **Not tested** on live data (I don't have it on local dev env)!
- **TODO**: We need to put a note in [cv_dataset repo](https://github.com/common-voice/cv-dataset)'s `CHANGELOG.md` for this change.
- **NOTE**: Older releases will not be affected, so one should check dataset version to determine the separator in post-processing scripts.
