### PR TITLE
Fix variant names in speak listen

### DIFF
--- a/web/src/components/pages/contribution/contribution.tsx
+++ b/web/src/components/pages/contribution/contribution.tsx
@@ -450,7 +450,7 @@ class ContributionPage extends React.Component<ContributionPageProps, State> {
                           </div>
                         ) : null}
                         {sentence?.variant && (
-                          <Tag text={`${sentence.variant.name} (${sentence.variant.tag})`} />
+                          <Tag text={`${sentence.variant.name} [${sentence.variant.tag}]`} />
                         )}
                       </div>
                     </div>

--- a/web/src/components/pages/contribution/contribution.tsx
+++ b/web/src/components/pages/contribution/contribution.tsx
@@ -450,7 +450,7 @@ class ContributionPage extends React.Component<ContributionPageProps, State> {
                           </div>
                         ) : null}
                         {sentence?.variant && (
-                          <Tag text={getString(sentence.variant.tag)} />
+                          <Tag text={`${sentence.variant.name} (${sentence.variant.tag})`} />
                         )}
                       </div>
                     </div>

--- a/web/src/components/pages/contribution/tag.css
+++ b/web/src/components/pages/contribution/tag.css
@@ -11,7 +11,7 @@
 
     & p.tag-text {
         font-size: var(--font-size-sm);
-        text-transform: uppercase;
+        text-transform: none;
         font-weight: 600;
     }
 


### PR DESCRIPTION
- Fixes sentence variant display in both SPEAK and LISTEN pages
- Instead of uppercase variant token it now displays a combination of `name (token)` as they come from database (no case manipulation).
- Fixes several reports:
  - https://github.com/common-voice/common-voice/issues/4790
  - https://github.com/common-voice/common-voice/issues/4840
  - https://github.com/common-voice/common-voice/issues/4806 (second part)

Example:

![image](https://github.com/user-attachments/assets/3c677325-27cb-4c0b-9325-4ad8a68a0ae3)
