### PR TITLE
Fix overflow in long accent lists and adapt style to variant selector

### DIFF
--- a/web/src/components/pages/profile/info/languages/input-language-accents/input-language-accents-input.tsx
+++ b/web/src/components/pages/profile/info/languages/input-language-accents/input-language-accents-input.tsx
@@ -185,7 +185,11 @@ const InputLanguageAccentsInput = ({
                         style: {
                           backgroundColor:
                             highlightedIndex === index
-                              ? 'var(--light-grey)'
+                              ? '#1967d2'
+                              : 'initial',
+                          color:
+                            highlightedIndex === index
+                              ? '#ffffff'
                               : 'initial',
                         },
                       })}>

--- a/web/src/components/pages/profile/info/languages/languages.css
+++ b/web/src/components/pages/profile/info/languages/languages.css
@@ -54,17 +54,21 @@
         width: 100%;
 
         li {
+            border-bottom: 1px solid var(--light-grey);
             cursor: pointer;
             list-style: none;
-            padding: 15px;
-            border-bottom: 1px solid var(--dark-grey);
+            width: 100%;
+            padding: 13px;
         }
     }
 
     .downshift-open {
-        border: 1px solid var(--light-grey);
-
-        box-shadow: 0 2px 5px 0 var(--light-grey);
-        overflow: hidden;
+        border: 1px solid var(--grey);
+        box-shadow: 0 2px 5px 0 var(--grey);
+        border-radius: 10px;
+        width: 96%;
+        max-height: 500px;
+        overflow-y: auto;
     }
+
 }


### PR DESCRIPTION
- Fixes https://github.com/common-voice/common-voice/issues/4378
- Adapts styling of Downshift (component used in accent select) to variant selector - as much as possible, but I kept the bottom-border for better visibility.

## Example snapshots

**Wide screen - Short list**
![image](https://github.com/user-attachments/assets/7b1bafc4-f0de-4007-99f9-a8a949671242)

**Wide screen - Long list**
![image](https://github.com/user-attachments/assets/9863e9d9-8d7b-4311-90da-cbca71b08b2c)

**Mobile screen - Long list**
![image](https://github.com/user-attachments/assets/f6fc479b-3d54-4c0c-98ef-4d3e3730dba0)



