### PR TITLE
Feat text input cleaning

### DIFF
--- a/server/src/application/repository/reports-repository.ts
+++ b/server/src/application/repository/reports-repository.ts
@@ -8,6 +8,7 @@ import {
   ReportKind,
   REPORTED_SENTENCE,
 } from '../reports/use-case/command-handler/command/create-report-command'
+import { cleanText } from '../text-cleaner'
 
 const db = getMySQLInstance()
 
@@ -52,7 +53,7 @@ const insertReport =
             db.query(createQueryForReportKind(report.kind), [
               report.clientId,
               report.id,
-              reason,
+              cleanText(reason),
             ]),
           (err: Error) =>
             createDatabaseError(`Error inserting ${report.kind} report`, err)

--- a/server/src/application/sentences/use-case/command-handler/add-bulk-sentences-command-handler.ts
+++ b/server/src/application/sentences/use-case/command-handler/add-bulk-sentences-command-handler.ts
@@ -12,6 +12,7 @@ import { SentenceSubmission } from '../../../types/sentence-submission'
 import { FetchVariants } from '../../../repository/variant-repository'
 import * as S from 'fp-ts/lib/string'
 import * as A from 'fp-ts/lib/Array'
+import { cleanText } from '../../../text-cleaner'
 
 export const AddBulkSentencesCommandHandler =
   (readTsvIntoMemory: ReadTsvIntoMemory) =>
@@ -55,8 +56,8 @@ export const AddBulkSentencesCommandHandler =
           sentences.map(submission => {
             console.log(submission)
             let sub: SentenceSubmission = {
-              sentence: submission['sentence'].trim().replace(/\s/gi, ' '),
-              source: submission['source'].trim(),
+              sentence: cleanText(submission['sentence']),
+              source: cleanText(submission['source']),
               locale_id: cmd.localeId,
               client_id: clientId,
               domain_ids: O.none,

--- a/server/src/application/sentences/use-case/command-handler/add-multiple-sentences-command-handler.test.ts
+++ b/server/src/application/sentences/use-case/command-handler/add-multiple-sentences-command-handler.test.ts
@@ -28,7 +28,7 @@ describe('AddMultipleSentencesCommandHandler', () => {
       domains: ['general'],
       variant: O.some('standard'),
       clientId: 'test-client',
-      source: 'user',
+      source: 'user\tprovided',
     }
 
     mockFindLocaleByName.mockReturnValue(TE.right(O.some({ id: 1 })))

--- a/server/src/application/sentences/use-case/command-handler/add-multiple-sentences-command-handler.ts
+++ b/server/src/application/sentences/use-case/command-handler/add-multiple-sentences-command-handler.ts
@@ -22,6 +22,7 @@ import { ApplicationError } from '../../../types/error'
 import { SentenceSubmission } from '../../../types/sentence-submission'
 import { toDomainIds } from '../../helper/domain-helper'
 import { AddMultipleSentencesCommand } from './command/add-multiple-sentences-command'
+import { cleanText } from '../../../text-cleaner'
 
 export const MAX_SENTENCES = 1000
 
@@ -83,6 +84,7 @@ export const AddMultipleSentencesCommandHandler =
           variant,
           O.map(v => v.id)
         )
+        const cleanedSource: string = cleanText(cmd.source)
         const sentenceSubmissions: SentenceSubmission[] = pipe(
           sentences,
           A.map(sentence => {
@@ -90,7 +92,7 @@ export const AddMultipleSentencesCommandHandler =
               ...sentence,
               locale_id: localeId,
               client_id: cmd.clientId,
-              source: cmd.source,
+              source: cleanedSource,
               variant_id,
               domain_ids: O.some(domainIds),
             }

--- a/server/src/application/text-cleaner.ts
+++ b/server/src/application/text-cleaner.ts
@@ -1,0 +1,10 @@
+export const cleanText = (s: string): string => {
+  return s.trim().replace(/\s/gi, ' ').replace(/\s+/g, ' ')
+}
+
+export const cleanTextArray = (ss: string[]): string[] => {
+  for (let i = 0; i < ss.length; i++) {
+    ss[i] = ss[i].trim().replace(/\s/gi, ' ').replace(/\s+/g, ' ')
+  }
+  return ss
+}


### PR DESCRIPTION
This fixes several raw text related problems for new sentences and reports.
- Introduces simple central functions
- All free-form text input (sentences, sentence sources, reports' other options) are cleaned before entering the database.
- The `sentence_id` is calculated from the cleaned sentence

Notes/warnings:
- It does not handle any existing data. We still need cleaning in bundler for metadata `.tsv` files so they have correct structure (columns) coming from past malformed data.
- In dev environments, where sentences are imported from files, there might be cases where the `sentence_id`s / even sentences not match, because this time they will be cleaned of invisible characters like TAB or CR/LF (word separating characters).
- Some existing regex cleaning has been replaced by this, but the piped one (server/src/core/sentences/cleaning/multiple-sentences.ts) is untouched.

Limited testing on dev environment - checked from local database (Dockerized):
- Entering a single sentence with TAB chars in sentence and source => OK
- Entering a small batch sentences with (malformed sentence and source) => OK
- Reporting with "other", multiple lines and TAB characters => OK
