### PR TITLE
Fix uncleaned metadata text

### DIFF
--- a/bundler/src/core/reportedSentences.ts
+++ b/bundler/src/core/reportedSentences.ts
@@ -19,6 +19,8 @@ const reportedSentencesRowToTsvEntry = (row: ReportedSentencesRow): string =>
 const transformSentences = () =>
   new Transform({
     transform(chunk: ReportedSentencesRow, encoding, callback) {
+      chunk.sentence = chunk.sentence.replace(/\s/gi, ' ')
+      chunk.reason = chunk.reason.replace(/\s/gi, ' ')
       this.push(reportedSentencesRowToTsvEntry(chunk), 'utf-8')
 
       callback()

--- a/bundler/src/core/sentences.ts
+++ b/bundler/src/core/sentences.ts
@@ -37,6 +37,7 @@ const replaceWhitespaces = () =>
       const updatedClipRow = {
         ...chunk,
         sentence: chunk.sentence.replace(/\s/gi, ' '),
+        source: chunk.sentence.replace(/\s/gi, ' '),
       }
 
       callback(null, updatedClipRow)


### PR DESCRIPTION
There are cases where metadata `.tsv` files get malformed because of uncleaned free-form text. This included sentences, sentence sources, sentences in reported and reasons where people use "other" option and write free form.

The problems were reported and analyzed in these topics:
- https://github.com/common-voice/common-voice/issues/4406
- https://github.com/common-voice/common-voice/issues/4429
- https://github.com/common-voice/common-voice/issues/4839

The "sentence" in `*_sentences.tsv` were previously fixed [here](https://github.com/common-voice/common-voice/commit/cebd5c6fc9663a596cadf537ed82df5f9c8a1c41).

This PR extents this to:
- Source fields in `*_sentences.tsv` files
- Sentence and reason fields in `reported.tsv`

Note: This has NOT been tested on real data, but should be OK as the modifications were simple. Should be tested before the next  release, if merged.

