### PR TITLE
Feat - Move user languages to top of the list

### DIFF
--- a/web/src/components/layout/layout.tsx
+++ b/web/src/components/layout/layout.tsx
@@ -273,6 +273,7 @@ class Layout extends React.PureComponent<LayoutProps, LayoutState> {
               )}
               <LocalizationSelectComplex
                 locale={locale}
+                userLanguages={user.account && user.account.languages ? user.account.languages.map(lang => lang.locale) : []}
                 onLocaleChange={this.handleLocaleChange}
               />
               <button

--- a/web/src/components/localization-select/localization-select-complex.test.tsx
+++ b/web/src/components/localization-select/localization-select-complex.test.tsx
@@ -23,6 +23,9 @@ describe('LocalizationSelectComplex', () => {
       <LocalizationSelectComplex onLocaleChange={onLocalChangeMock} />
     );
 
+    // resets the mock because we call onLocaleChange once on render
+    onLocalChangeMock.mockClear()
+
     // pick an option in the select box
     userEvent.selectOptions(
       screen.getAllByLabelText('Choose language/localization')[1],

--- a/web/src/components/localization-select/localization-select-complex.tsx
+++ b/web/src/components/localization-select/localization-select-complex.tsx
@@ -108,8 +108,8 @@ const LocalizationSelectComplex = ({ locale, userLanguages, onLocaleChange }: Pr
                     classNames(
                       'list-item-wrapper', {
                       'highlighted': index === highlightedIndex,
-                      'userlanguage': userLanguages.length > 0 && index <= userLanguages.length - 1,
-                      'lastuserlanguage': userLanguages.length > 0 && index === userLanguages.length - 1,
+                      'userlanguage': userLanguages && userLanguages.length > 0 && index <= userLanguages.length - 1,
+                      'lastuserlanguage': userLanguages && userLanguages.length > 0 && index === userLanguages.length - 1,
                     }
                     )
                   }

--- a/web/src/components/localization-select/localization-select-complex.tsx
+++ b/web/src/components/localization-select/localization-select-complex.tsx
@@ -15,18 +15,27 @@ import './localization-select.css'
 
 interface Props {
   locale?: string
+  userLanguages?: string[]
   onLocaleChange?: (props: string) => void
 }
 
-function getLocaleWithName(locale: string) {
-  const availableLocalesWithNames = useNativeNameAvailableLocales()
-  return availableLocalesWithNames.find(({ code }) => code === locale)
-}
 
-const LocalizationSelectComplex = ({ locale, onLocaleChange }: Props) => {
+const LocalizationSelectComplex = ({ locale, userLanguages, onLocaleChange }: Props) => {
+
+  function getLocaleWithName(locale: string) {
+    return availableLocalesWithNames.find(({ code }) => code === locale)
+  }
+
   const availableLocales = useAvailableLocales()
-  const availableLocalesWithNames = useNativeNameAvailableLocales()
+  let availableLocalesWithNames = useNativeNameAvailableLocales()
   const { abortStatus } = useAbortContributionModal()
+
+  // Get user languages to top of the list
+  if (userLanguages) {
+    const userLanguagesWithNames = userLanguages.map(lang => getLocaleWithName(lang))
+    availableLocalesWithNames = userLanguagesWithNames.concat(availableLocalesWithNames.filter(item => !userLanguages.includes(item.code)))
+  }
+
   const localWithName = getLocaleWithName(locale)
   const initialSelectedItem = localWithName
     ? localWithName.code
@@ -82,9 +91,11 @@ const LocalizationSelectComplex = ({ locale, onLocaleChange }: Props) => {
                   key={item}
                   className={classNames('list-item-wrapper', {
                     highlighted: index === highlightedIndex,
-                  })}>
+                  })}
+                  style={{ borderBottomColor: userLanguages.length > 0 && index === userLanguages.length-1 ? "#333" : "#f3f2f0" }}
+                >
                   <li {...getItemProps({ item })}>
-                    {getLocaleWithName(item).name}
+                    {userLanguages.includes(item) ? <strong>{getLocaleWithName(item).name}</strong> : getLocaleWithName(item).name}
                   </li>
                   {item === locale && (
                     <img
@@ -94,6 +105,7 @@ const LocalizationSelectComplex = ({ locale, onLocaleChange }: Props) => {
                       height={24}
                     />
                   )}
+                  {userLanguages.length > 0 && index === userLanguages.length ? <hr /> : <></>}
                 </div>
               ))}
             </ul>

--- a/web/src/components/localization-select/localization-select.css
+++ b/web/src/components/localization-select/localization-select.css
@@ -69,6 +69,14 @@
                 &.highlighted {
                     background: var(--light-grey);
                 }
+
+                &.userlanguage {
+                    font-weight: 700;
+                }
+
+                &.lastuserlanguage {
+                    border-bottom-color: var(--near-black);
+                }
             }
 
             [dir='rtl'] & {


### PR DESCRIPTION
This implements the idea presented in https://github.com/common-voice/common-voice/issues/4734

For logged in users who have languages set in their profiles, the user language codes are passed to the language selector component, where the list is re-organized.

When not logged-in or no user languages selected, it behaves normally.

Screenshot:
![image](https://github.com/user-attachments/assets/1290202c-b539-43fe-96e8-155c7d6ba90e)
