### PR TITLE
[FIX] 4708 update AUTH to FXA prefix in env / docs

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -230,10 +230,12 @@ If you want to work with login-related features (Profile, Dashboard, Goals, ...)
 For Docker, in `.env-local-docker`:
 
 ```Dotenv
-CV_AUTH0_DOMAIN="<domain_here>"
-CV_AUTH0_CLIENT_ID="<client_id_here>"
-CV_AUTH0_CLIENT_SECRET="<client_secret_here>"
+CV_FXA_DOMAIN="<domain_here>"
+CV_FXA_CLIENT_ID="<client_id_here>"
+CV_FXA_CLIENT_SECRET="<client_secret_here>"
 ```
+> [!TIP]
+> Use the FXA prefix even though you're using Auth0 to generate the credentials.
 
 For local development, in `config.json`:
 


### PR DESCRIPTION
## Pull Request Form

<!-- Thanks for making a contribution to Common Voice, to help us review the request please fill out this form -->

### Type of Pull Request

<!-- To help us understand your pull request, choose the checkboxes most relevant to your request by filling out the checkboxes with [x] here -->

- [ ] Bulk sentence upload 

<!--- Please ensure your sentences are licensed under CC0 before making a submission. Learn how you can do this via our Playbook https://common-voice.github.io/community-playbook/sub_pages/cc0waiver_process.html -->

- [x] Related to a listed issue 

<!--- Please link the issues related to your PR Request -->

* #4708
*

- [ ] Other

<!--- Please describe the pull request-->

Fixes _part_ of #4708

In the setup docs it instructs the developer to create an auth application with Auth0 and add the credentials to the env file for docker. 

However in #4684 Auth0 was replaced throughout the application with Mozilla Accounts (FXA) so this cannot work and the site won't run in dev. 

I looked around a bit and while I eventually found this https://mozilla.github.io/ecosystem-platform/relying-parties/tutorials/integration-with-fxa it looks like a mountain to climb as a first step in onboarding! (Especially compared to the absolute breeze of creating an Auth0 app. ) 

I'm sure there's a simple way to get an FXA detailed somewhere. For now, I've just edited the docs to call the auth0 creds FXA. Can I suggest a subsequent ticket to write a step by step for new users on how they are to acquire their creds. 

### Acknowledging contributors

<!-- Please list who collaborated with you to make this contribution. Or Community discussion that helped make this idea possible -->

*
*

