### PR TITLE
1071-Fix ambiuquity in SQL which prevents selection of sentences when "only sentences in my variant" is set in profile

### DIFF
--- a/server/src/application/repository/sentences-repository.ts
+++ b/server/src/application/repository/sentences-repository.ts
@@ -444,7 +444,7 @@ export const findVariantSentences: FindVariantSentences = (
           LEFT JOIN variants ON (variants.id=sm.variant_id)
           WHERE
             is_used
-            AND locale_id = (SELECT id FROM locales WHERE name = ?)
+            AND s.locale_id = (SELECT id FROM locales WHERE name = ?)
             AND clips_count <= 15
             AND ${
               sentencesWithVariant


### PR DESCRIPTION
This was reported by the Circassian community in their Telegram channel.

- Examination of raw sentence data addition workflow (first suspect) did not reveal anything.
- Creating a similar environment with Circassian sentences and testing in detail, revealed an error caused by ambiguity in SQL.

```
common-voice  | [BE] {
common-voice  | [BE]   kind: 'DatabaseError',
common-voice  | [BE]   message: 'Error retrieving variant sentences for variant "Адыгэбзэ (Къэбэрдей, Кирил, псоми зэдай) [kbd-Cyrl]"',
common-voice  | [BE]   error: Error: Column 'locale_id' in where clause is ambiguous
common-voice  | [BE]       at PromisePool.query (/code/node_modules/mysql2/promise.js:356:22)
common-voice  | [BE]       at Mysql.query (/code/server/src/lib/model/db/mysql.ts:122:41)
common-voice  | [BE]       at processTicksAndRejections (node:internal/process/task_queues:95:5) {
common-voice  | [BE]     code: 'ER_NON_UNIQ_ERROR',
common-voice  | [BE]     errno: 1052,
common-voice  | [BE]     sql: '\n' +
common-voice  | [BE]       '        SELECT *\n' +
....
common-voice  | [BE]       "            AND locale_id = (SELECT id FROM locales WHERE name = 'kbd')\n" +
...
common-voice  | [BE]       '        LIMIT 1000\n' +
common-voice  | [BE]       '    ',
common-voice  | [BE]     sqlState: '23000',
common-voice  | [BE]     sqlMessage: "Column 'locale_id' in where clause is ambiguous"
common-voice  | [BE]   }
common-voice  | [BE] }
```

Tested / working on local DEV ENV.
