### PR TITLE
Add ug-Cyrl and ug-Arab variants to partially resolve #4144 - support Cyrillic orthography in Uyghur

### DIFF
--- a/server/src/lib/model/db/language-data/variants.ts
+++ b/server/src/lib/model/db/language-data/variants.ts
@@ -417,6 +417,16 @@ export const VARIANTS: Variant[] = [
     variant_token: 'sva-lentekh',
   },
   {
+    locale_name: 'ug',
+    variant_name: 'ئۇيغۇر تىلى',
+    variant_token: 'ug-Arab',
+  },
+  {
+    locale_name: 'ug',
+    variant_name: 'Уйғур тили',
+    variant_token: 'ug-Cyrl',
+  },
+  {
     locale_name: 'vi',
     variant_name: 'Hà Nội',
     variant_token: 'vi-hanoi',


### PR DESCRIPTION
## Pull Request Form

### Type of Pull Request

- [X] Add a language Variant

<!--- Please link the issues related to your PR Request -->

* #4144 - support Cyrillic orthography in Uyghur

This PR is 1 of 2 required to facilitate support for Cyrillic orthography in Uyghur. Following merge of this PR, a second PR is required to ascribe all _existing_ sentences for `ug` to the `ug-Arab` variant. 

The following checks have been done: 

* Check there are no sentence validation rules for `ug` that affect the addition of Variants => no rules exist for `ug`

* Check _only_ the required files are committed to the PR => yes, only `variants.ts`

* Check addition of Variants is in alphabetical order in `variants.ts` => OK 

* Check that the Variants are correctly applied to the DB => OK 

|name|native_name|variant_name|variant_token|
|----|-----------|------------|-------------|
|ug|Uyghur|Уйғур тили|ug-Cyrl|
|ug|Uyghur|ئۇيغۇر تىلى|ug-Arab|


### Acknowledging contributors

* Thanks to @razmikb for the initial request and @moz-bozden for a lot of guidance. 

