### PR TITLE
Update config-helper to ignore non-existent config.json

### DIFF
--- a/server/src/config-helper.ts
+++ b/server/src/config-helper.ts
@@ -6,7 +6,15 @@ if (process.env.DOTENV_CONFIG_PATH) {
   const result = config({ path: process.env.DOTENV_CONFIG_PATH })
   if (result.error) {
     console.log(result.error)
-    console.log('Failed loading dotenv file, using defaults')
+    console.log(
+      'ERROR loading config: Failed loading dotenv file. Expected file: ',
+      process.env.DOTENV_CONFIG_PATH
+    )
+  } else {
+    console.log(
+      'Loading config: successfully loaded dotenv file: ',
+      process.env.DOTENV_CONFIG_PATH
+    )
   }
 }
 
@@ -122,32 +130,25 @@ const BASE_CONFIG: CommonVoiceConfig = {
 }
 
 let injectedConfig: CommonVoiceConfig
-let loadedConfig: CommonVoiceConfig
 
 export function injectConfig(config: Partial<CommonVoiceConfig>) {
   injectedConfig = { ...BASE_CONFIG, ...config }
 }
 
 export function getConfig(): CommonVoiceConfig {
-  if (injectedConfig) {
-    return injectedConfig
-  }
-
-  if (loadedConfig) {
-    return loadedConfig
-  }
-
-  let fileConfig = null
-
   try {
-    const config_path = process.env.SERVER_CONFIG_PATH || './config.json'
-    fileConfig = JSON.parse(fs.readFileSync(config_path, 'utf-8'))
+    if (injectedConfig) {
+      console.log('Loading config: reading injectedConfig ...')
+      return injectedConfig
+    }
+
+    if (BASE_CONFIG) {
+      console.log('Loading config: reading BASE_CONFIG ...')
+      return BASE_CONFIG
+    }
   } catch (err) {
     console.error(
-      `Could not load config.json, using defaults (error message: ${err.message})`
+      `ERROR: Could not load any available configuration (error message: ${err.message})`
     )
   }
-  loadedConfig = { ...BASE_CONFIG, ...fileConfig }
-
-  return loadedConfig
 }

--- a/server/src/config-helper.ts
+++ b/server/src/config-helper.ts
@@ -142,10 +142,8 @@ export function getConfig(): CommonVoiceConfig {
       return injectedConfig
     }
 
-    if (BASE_CONFIG) {
-      console.log('Loading config: reading BASE_CONFIG ...')
-      return BASE_CONFIG
-    }
+    console.log('Loading config: reading BASE_CONFIG ...')
+    return BASE_CONFIG
   } catch (err) {
     console.error(
       `ERROR: Could not load any available configuration (error message: ${err.message})`


### PR DESCRIPTION
## Pull Request Form

### Type of Pull Request

- [X] Amendment to logic which loads configuration

* #4845
* #4708 
* #4389 
* #4003

This PR: 

* Changes the logic in the `configuration-helper.ts` and no longer checks for a `config.json` file, which was causing confusion with people setting up their own development environment, as it threw an error if it wasn't found, _even though_ it wasn't required. 
* Removes references to `loadedConfig` which no longer serves a purpose AFAICT
* Adds better semantic logging of what's happening through `console.log`
* Provides better failure message if dotenv file not found 

I do have some questions about things that I don't understand in this file: 

* I don't understand how `injectedConfig` works, or what purpose it serves? 
* With the logging I added, I can see that the config gets loaded _a lot_. I couldn't see an easy way to log _what_ was being loaded from the config at a particular stage via `getConfig()`, but that would be helpful here. 