### PR TITLE
Update SS ftl with no-<resource>-continue-skipped-message

### DIFF
--- a/web/locales/spontaneous-speech/en/pages/common.ftl
+++ b/web/locales/spontaneous-speech/en/pages/common.ftl
@@ -24,6 +24,8 @@ skip-button = Skip
 submit-button = Submit
 contribute = Contribute
 request-new-language = Request New Language
+# Button text which appears when there are no more resources
+continue-with-skipped = Continue with Skipped
 
 ## Navbar
 

--- a/web/locales/spontaneous-speech/en/pages/contribution/check-transcript.ftl
+++ b/web/locales/spontaneous-speech/en/pages/contribution/check-transcript.ftl
@@ -4,7 +4,8 @@
 transcription-page-instruction = { $actionType } <playIcon></playIcon> Listen to the audio clip, and check the transcription. Does it match? If not, edit it to match perfectly.
 # Header of the textbox that contains a transcription of an audio
 check-editbox-header = Check
-no-transcriptions-message = There are currently no transcriptions to check for this language. Please refresh the page or try again later.
+# Message which appears when there are no more resources on this page
+no-transcriptions-continue-skipped-message = There are currently no transcriptions to check for this language. Continue to see your skipped content or go to transcribe audio and try again later.
 vote-transcript-success = Transcript voted successfully
 vote-transcript-error = An error occurred while voting the transcript
 transcript-edited-success = Transcript edited successfully

--- a/web/locales/spontaneous-speech/en/pages/contribution/check-transcript.ftl
+++ b/web/locales/spontaneous-speech/en/pages/contribution/check-transcript.ftl
@@ -5,7 +5,7 @@ transcription-page-instruction = { $actionType } <playIcon></playIcon> Listen to
 # Header of the textbox that contains a transcription of an audio
 check-editbox-header = Check
 # Message which appears when there are no more resources on this page
-no-transcriptions-continue-skipped-message = There are currently no transcriptions to check for this language. Continue to see your skipped content or go to transcribe audio and try again later.
+no-transcriptions-continue-skipped-message = There are currently no transcriptions to check for this language. If you have skipped any, you can continue with skipped content or go to transcribe audio and try again later.
 vote-transcript-success = Transcript voted successfully
 vote-transcript-error = An error occurred while voting the transcript
 transcript-edited-success = Transcript edited successfully

--- a/web/locales/spontaneous-speech/en/pages/contribution/prompts.ftl
+++ b/web/locales/spontaneous-speech/en/pages/contribution/prompts.ftl
@@ -5,7 +5,7 @@ mic-access-error = You must allow microphone access.
 # actionType will be Click (for desktop devices) or Tap (for mobile devices)
 prompt-page-instruction = { $actionType } <micIcon></micIcon> and respond as naturally as you can
 # Message which appears when there are no more resources on this page
-no-prompts-continue-skipped-message = There are no more questions for this language. Continue to see your skipped content or go to transcribe audio and try again later.
+no-prompts-continue-skipped-message = There are no more questions for this language. If you have skipped any, you can continue with skipped content or go to transcribe audio and try again later.
 error-skipping = An error occurred while skipping this prompt
 error-recording = An error occurred while recording
 error-fetching-prompts = Something went wrong while fetching prompts. Please try again later.

--- a/web/locales/spontaneous-speech/en/pages/contribution/prompts.ftl
+++ b/web/locales/spontaneous-speech/en/pages/contribution/prompts.ftl
@@ -4,7 +4,8 @@ record-player-header = Record your response
 mic-access-error = You must allow microphone access.
 # actionType will be Click (for desktop devices) or Tap (for mobile devices)
 prompt-page-instruction = { $actionType } <micIcon></micIcon> and respond as naturally as you can
-no-prompts-message = There are currently no prompts for this language. Please refresh the page or try again later.
+# Message which appears when there are no more resources on this page
+no-prompts-continue-skipped-message = There are no more questions for this language. Continue to see your skipped content or go to transcribe audio and try again later.
 error-skipping = An error occurred while skipping this prompt
 error-recording = An error occurred while recording
 error-fetching-prompts = Something went wrong while fetching prompts. Please try again later.

--- a/web/locales/spontaneous-speech/en/pages/contribution/transcribe.ftl
+++ b/web/locales/spontaneous-speech/en/pages/contribution/transcribe.ftl
@@ -5,7 +5,7 @@ audio-page-instruction = { $actionType } <playIcon></playIcon> and write down wh
 editbox-header = Transcribe
 editbox-placeholder = Write down what you hear the person saying here
 # Message which appears when there are no more resources on this page
-no-audio-continue-skipped-message = There is currently no audio to transcribe for this language. Continue to see your skipped content or go to review transcriptions and try again later.
+no-audio-continue-skipped-message = There is currently no audio to transcribe for this language. If you have skipped any, you can continue with skipped content or go to review transcriptions and try again later.
 create-transcript-success = Transcript submitted successfully
 create-transcript-error = An error occurred while creating this transcript
 error-playing-audio = Error while playing audio file.

--- a/web/locales/spontaneous-speech/en/pages/contribution/transcribe.ftl
+++ b/web/locales/spontaneous-speech/en/pages/contribution/transcribe.ftl
@@ -4,7 +4,8 @@
 audio-page-instruction = { $actionType } <playIcon></playIcon> and write down what you hear the person saying
 editbox-header = Transcribe
 editbox-placeholder = Write down what you hear the person saying here
-no-audio-message = There is currently no audio to transcribe for this language. Please refresh the page or try again later.
+# Message which appears when there are no more resources on this page
+no-audio-continue-skipped-message = There is currently no audio to transcribe for this language. Continue to see your skipped content or go to review transcriptions and try again later.
 create-transcript-success = Transcript submitted successfully
 create-transcript-error = An error occurred while creating this transcript
 error-playing-audio = Error while playing audio file.

--- a/web/locales/spontaneous-speech/en/pages/contribution/validate.ftl
+++ b/web/locales/spontaneous-speech/en/pages/contribution/validate.ftl
@@ -4,7 +4,8 @@ dataset-label = Dataset
 accept-vote-toast-message = Successfully accepted question
 reject-vote-toast-message = Successfully rejected question
 add-vote-error-message = An error occurred while voting the prompt
-no-questions-message = There are currently no prompts to validate for this language. Please refresh the page or try again later.
+# Message which appears when there are no more resources on this page
+no-questions-continue-skipped-message = There are no more questions for this language. Continue to see your skipped content or go to transcribe audio and try again later.
 validate-page-yes-button-shortcut = Y
 validate-page-no-button-shortcut = N
 validate-page-skip-button-shortcut = S

--- a/web/locales/spontaneous-speech/en/pages/contribution/validate.ftl
+++ b/web/locales/spontaneous-speech/en/pages/contribution/validate.ftl
@@ -5,7 +5,7 @@ accept-vote-toast-message = Successfully accepted question
 reject-vote-toast-message = Successfully rejected question
 add-vote-error-message = An error occurred while voting the prompt
 # Message which appears when there are no more resources on this page
-no-questions-continue-skipped-message = There are no more questions for this language. Continue to see your skipped content or go to transcribe audio and try again later.
+no-questions-continue-skipped-message = There are no more questions for this language. If you have skipped any, you can continue with skipped content or go to transcribe audio and try again later.
 validate-page-yes-button-shortcut = Y
 validate-page-no-button-shortcut = N
 validate-page-skip-button-shortcut = S


### PR DESCRIPTION
Fixes "Pontoon keys not changed" issue for changed "continue-with-skipped" workflow in Spontaneous Speech, which prevents translations.