### PR TITLE
Add Alsatian variants

### DIFF
--- a/server/src/lib/model/db/language-data/variants.ts
+++ b/server/src/lib/model/db/language-data/variants.ts
@@ -481,4 +481,29 @@ export const VARIANTS: Variant[] = [
     variant_name: 'Xopuri',
     variant_token: 'lzz-xopuri',
   },
+  {
+    locale_name: 'gsw',
+    variant_name: 'Südrheinfränkisch (Weissebuisch, Màdere, usw.)',
+    variant_token: 'gsw-FR-sudrfran',
+  },
+  {
+    locale_name: 'gsw',
+    variant_name: 'Rhinfränkisch (Bùckenùmm, Lìtzelstän, usw.)',
+    variant_token: 'gsw-FR-rhinfran',
+  },
+  {
+    locale_name: 'gsw',
+    variant_name: 'Nordniederàlemmànisch (Rishoffe, Zàwere, Bùsswìller, Hawenau, Brüemt, Stroossbùri, Molse, Dàmbàch, Schlettstàtt, usw.)',
+    variant_token: 'gsw-FR-nordalem',
+  },
+  {
+    locale_name: 'gsw',
+    variant_name: 'Südniederàlemmànisch (Kolmer, Gawìller, Mìlhüüsa, Àltkìrich, usw.)',
+    variant_token: 'gsw-FR-sudnalem',
+  },
+  {
+    locale_name: 'gsw',
+    variant_name: 'Hochàlemmànnisch (Hìniga, Pfìrt, usw.)',
+    variant_token: 'gsw-FR-hochalem',
+  }
 ]


### PR DESCRIPTION
Add variants for Alsatian `gsw`.

```
gsw-FR-sudrfran:  Südrheinfränkisch (Weissebuisch, Màdere, usw.) "
gsw-FR-rhinfran: Rhinfränkisch (Bùckenùmm, Lìtzelstän, usw.)"
gsw-FR-nordalem: Nordniederàlemmànisch (Rishoffe, Zàwere, Bùsswìller, Hawenau, Brüemt, Stroossbùri, Molse, Dàmbàch, Schlettstàtt, usw.)"
gsw-FR-sudnalem: Südniederàlemmànisch (Kolmer, Gawìller, Mìlhüüsa, Àltkìrich, usw.)"
gsw-FR-hochalem: Hochàlemmànnisch (Hìniga, Pfìrt, usw.) "
```