### PR TITLE
1155-MCV Re-implement fix for eu accent typo

### DIFF
--- a/server/src/lib/model/db/migrations/20250607160000-fix-for-basque-accent-typo.ts
+++ b/server/src/lib/model/db/migrations/20250607160000-fix-for-basque-accent-typo.ts
@@ -1,0 +1,38 @@
+// Template for "Fix Accent Naming"
+// Update the Basque language accent to fix the typo
+const LOCALE = 'eu'
+const ACCENT_TOKEN = 'mendebalekoa'
+const OLD_NAME =
+  'Mendebalekoa (Araka, Bizkaia, Gipuzkoako mendebaleko herri batzuk)'
+const NEW_NAME =
+  'Mendebalekoa (Araba, Bizkaia, Gipuzkoako mendebaleko herri batzuk)'
+
+//
+// Do not change the code below unless database structure has been changed
+//
+export const up = async function (db: any): Promise<any> {
+  console.log(NEW_NAME, LOCALE, ACCENT_TOKEN)
+  await db.runSql(
+    `
+    UPDATE accents
+    SET accent_name = ?
+    WHERE
+      locale_id = (SELECT id FROM locales WHERE name = ? )
+      AND accent_token = ?
+  `,
+    [NEW_NAME, LOCALE, ACCENT_TOKEN]
+  )
+}
+
+export const down = async function (db: any): Promise<any> {
+  await db.runSql(
+    `
+    UPDATE accents
+    SET accent_name = ?
+    WHERE
+      locale_id = (SELECT id FROM locales WHERE name = ? )
+      AND accent_token = ?
+  `,
+    [OLD_NAME, LOCALE, ACCENT_TOKEN]
+  )
+}


### PR DESCRIPTION
This is simply a re-implementation of PR #4323 as a fix for the issue #4287 
This is done as a template because the PR became stale due to inactivity.

All acknowledgement goes to the people in that issue and PR.
