### PR TITLE
1157- Backend to retrieve sentences & clips without variant when variant ones run out

### DIFF
--- a/server/src/lib/api.ts
+++ b/server/src/lib/api.ts
@@ -192,6 +192,7 @@ export default class API {
 
     // the validator coerces count into a number but doesn't update the type
     const count: number = (request.query.count as never) || 1
+    const ignoreVariant: boolean = Boolean(request.query.ignoreVariant) || false
 
     const userClientVariant = await pipe(
       client_id,
@@ -211,11 +212,13 @@ export default class API {
       )
     )()
 
-    const clientPrefersVariant = pipe(
-      userClientVariant,
-      O.map(v => v.isPreferredOption),
-      O.getOrElse(() => false)
-    )
+    const clientPrefersVariant =
+      !ignoreVariant &&
+      pipe(
+        userClientVariant,
+        O.map(v => v.isPreferredOption),
+        O.getOrElse(() => false)
+      )
 
     if (clientPrefersVariant) {
       const getVariantSentences = pipe(

--- a/server/src/lib/api.ts
+++ b/server/src/lib/api.ts
@@ -192,7 +192,7 @@ export default class API {
 
     // the validator coerces count into a number but doesn't update the type
     const count: number = (request.query.count as never) || 1
-    const ignoreVariant: boolean = Boolean(request.query.ignoreVariant) || false
+    const ignoreClientVariant: boolean = Boolean(request.query.ignoreClientVariant) || false
 
     const userClientVariant = await pipe(
       client_id,
@@ -213,7 +213,7 @@ export default class API {
     )()
 
     const clientPrefersVariant =
-      !ignoreVariant &&
+      !ignoreClientVariant &&
       pipe(
         userClientVariant,
         O.map(v => v.isPreferredOption),

--- a/server/src/lib/bucket.ts
+++ b/server/src/lib/bucket.ts
@@ -92,14 +92,14 @@ export default class Bucket {
     client_id: string,
     locale: string,
     count: number,
-    ignoreVariant: boolean,
+    ignoreClientVariant: boolean,
   ): Promise<Clip[]> {
     // Get more clip IDs than are required in case some are broken links or clips
     const clips = await this.model.findEligibleClips(
       client_id,
       locale,
       Math.ceil(count * 1.5),
-      ignoreVariant,
+      ignoreClientVariant,
     )
     const clipPromises: Clip[] = []
 

--- a/server/src/lib/bucket.ts
+++ b/server/src/lib/bucket.ts
@@ -91,13 +91,15 @@ export default class Bucket {
   async getRandomClips(
     client_id: string,
     locale: string,
-    count: number
+    count: number,
+    ignoreVariant: boolean,
   ): Promise<Clip[]> {
     // Get more clip IDs than are required in case some are broken links or clips
     const clips = await this.model.findEligibleClips(
       client_id,
       locale,
-      Math.ceil(count * 1.5)
+      Math.ceil(count * 1.5),
+      ignoreVariant,
     )
     const clipPromises: Clip[] = []
 

--- a/server/src/lib/clip.ts
+++ b/server/src/lib/clip.ts
@@ -357,10 +357,10 @@ export default class Clip {
     if (!client_id) {
       return response.sendStatus(StatusCodes.BAD_REQUEST)
     }
-    const ignoreVariant = Boolean(request.query.ignoreVariant) || false
+    const ignoreClientVariant = Boolean(request.query.ignoreClientVariant) || false
     const count = Number(request.query.count) || 1
     const clips = await this.bucket
-      .getRandomClips(client_id, locale, count, ignoreVariant)
+      .getRandomClips(client_id, locale, count, ignoreClientVariant)
       .then(this.appendMetadata)
 
     response.json(clips)

--- a/server/src/lib/clip.ts
+++ b/server/src/lib/clip.ts
@@ -353,14 +353,14 @@ export default class Clip {
   serveRandomClips = async (request: Request, response: Response) => {
     const { client_id } = request?.session?.user || {}
     const { locale } = request.params
-
+    
     if (!client_id) {
       return response.sendStatus(StatusCodes.BAD_REQUEST)
     }
-
+    const ignoreVariant = Boolean(request.query.ignoreVariant) || false
     const count = Number(request.query.count) || 1
     const clips = await this.bucket
-      .getRandomClips(client_id, locale, count)
+      .getRandomClips(client_id, locale, count, ignoreVariant)
       .then(this.appendMetadata)
 
     response.json(clips)

--- a/server/src/lib/model.ts
+++ b/server/src/lib/model.ts
@@ -54,11 +54,12 @@ export default class Model {
   async findEligibleClips(
     client_id: string,
     locale: string,
-    count: number
+    count: number,
+    ignoreVariant: boolean,
   ): Promise<DBClip[]> {
     const localeId = await getLocaleId(locale)
 
-    const clientPrefersVariant = await pipe(
+    const clientPrefersVariant = !ignoreVariant && await pipe(
       client_id,
       fetchUserClientVariants,
       TE.map(ucvs => isVariantPreferredOption(localeId)(ucvs)),

--- a/server/src/lib/model.ts
+++ b/server/src/lib/model.ts
@@ -55,11 +55,11 @@ export default class Model {
     client_id: string,
     locale: string,
     count: number,
-    ignoreVariant: boolean,
+    ignoreClientVariant: boolean,
   ): Promise<DBClip[]> {
     const localeId = await getLocaleId(locale)
 
-    const clientPrefersVariant = !ignoreVariant && await pipe(
+    const clientPrefersVariant = !ignoreClientVariant && await pipe(
       client_id,
       fetchUserClientVariants,
       TE.map(ucvs => isVariantPreferredOption(localeId)(ucvs)),

--- a/server/src/lib/validation/clips.ts
+++ b/server/src/lib/validation/clips.ts
@@ -9,5 +9,8 @@ export const clipsSchema: AllowedSchema = {
       minimum: 1,
       maximum: 50
     },
+    ignoreVariant: {
+      type: 'boolean',
+    },
   },
 };

--- a/server/src/lib/validation/clips.ts
+++ b/server/src/lib/validation/clips.ts
@@ -9,7 +9,7 @@ export const clipsSchema: AllowedSchema = {
       minimum: 1,
       maximum: 50
     },
-    ignoreVariant: {
+    ignoreClientVariant: {
       type: 'boolean',
     },
   },

--- a/server/src/lib/validation/sentences.ts
+++ b/server/src/lib/validation/sentences.ts
@@ -1,4 +1,4 @@
-import { AllowedSchema } from 'express-json-validator-middleware';
+import { AllowedSchema } from 'express-json-validator-middleware'
 
 export const sentenceSchema: AllowedSchema = {
   type: 'object',
@@ -10,5 +10,8 @@ export const sentenceSchema: AllowedSchema = {
       minimum: 1,
       maximum: 50,
     },
+    ignoreVariant: {
+      type: 'boolean',
+    },
   },
-};
+}

--- a/server/src/lib/validation/sentences.ts
+++ b/server/src/lib/validation/sentences.ts
@@ -10,7 +10,7 @@ export const sentenceSchema: AllowedSchema = {
       minimum: 1,
       maximum: 50,
     },
-    ignoreVariant: {
+    ignoreClientVariant: {
       type: 'boolean',
     },
   },

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -126,12 +126,23 @@ export default class API {
     return this.getLocalePath() + '/clips'
   }
 
-  async fetchRandomSentences(count = 1): Promise<Sentence[]> {
-    return this.fetch(`${this.getLocalePath()}/sentences?count=${count}`)
+  async fetchRandomSentences(
+    count = 1,
+    ignoreVariant = false
+  ): Promise<Sentence[]> {
+    return this.fetch(
+      `${this.getLocalePath()}/sentences?count=${count}${
+        ignoreVariant ? '&ignoreVariant=true' : ''
+      }`
+    )
   }
 
-  async fetchRandomClips(count = 1): Promise<Clip[]> {
-    return this.fetch(`${this.getClipPath()}?count=${count}`)
+  async fetchRandomClips(count = 1, ignoreVariant = false): Promise<Clip[]> {
+    return this.fetch(
+      `${this.getClipPath()}?count=${count}${
+        ignoreVariant ? '&ignoreVariant=true' : ''
+      }`
+    )
   }
 
   uploadClip(

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -128,19 +128,19 @@ export default class API {
 
   async fetchRandomSentences(
     count = 1,
-    ignoreVariant = false
+    ignoreClientVariant = false
   ): Promise<Sentence[]> {
     return this.fetch(
       `${this.getLocalePath()}/sentences?count=${count}${
-        ignoreVariant ? '&ignoreVariant=true' : ''
+        ignoreClientVariant ? '&ignoreClientVariant=true' : ''
       }`
     )
   }
 
-  async fetchRandomClips(count = 1, ignoreVariant = false): Promise<Clip[]> {
+  async fetchRandomClips(count = 1, ignoreClientVariant = false): Promise<Clip[]> {
     return this.fetch(
       `${this.getClipPath()}?count=${count}${
-        ignoreVariant ? '&ignoreVariant=true' : ''
+        ignoreClientVariant ? '&ignoreClientVariant=true' : ''
       }`
     )
   }


### PR DESCRIPTION
When a user sets a variant and "show only sentences/clips from my variant", the system shows "you are out of sentences/clips".

We want to give an option to the user to continue with sentences/clips from any variant (including those without any variant).

This PR handles the backend of this with an `ignoreClientVariant=true` query parameter (default false) which should be called from front-end after a button click.
