### PR TITLE
1173-MCV Fix: Use Redis to keep recorded "sentence_id"s per user

### DIFF
--- a/server/src/lib/lazy-cache.ts
+++ b/server/src/lib/lazy-cache.ts
@@ -2,6 +2,25 @@ import { redis, redlock, useRedis } from './redis';
 
 type Fn<T, S> = (...args: S[]) => Promise<T>;
 
+//
+// Simple redis set manipulation
+//
+
+// Adds a value to a Redis SET with expiry
+export async function redisSetAddWithExpiry(key: string, value: string, ttlSeconds: number) {
+  await redis.sadd(key, value);
+  await redis.expire(key, ttlSeconds); // resets TTL each time
+}
+
+// Gets values from a Redis SET (if exists)
+export async function redisSetMembers(key: string): Promise<string[]> {
+  return await redis.smembers(key) || [];
+}
+
+//
+// lazyCache implementation
+//
+
 function isExpired(at: number, timeMs: number) {
   return Date.now() - at > timeMs;
 }

--- a/server/src/lib/model/db.ts
+++ b/server/src/lib/model/db.ts
@@ -22,14 +22,19 @@ import {
   FindVariantsBySentenceIdsResult,
   findVariantsBySentenceIdsInDb,
 } from '../../application/repository/variant-repository'
+
 const MINUTE = 1000 * 60
 const HOUR = MINUTE * 60
 const DAY = HOUR * 24
-const THREE_WEEKS = DAY * 3 * 7
+const WEEK = DAY * 7
+const THREE_WEEKS = WEEK * 3
 
 // When getting new sentences/clips we need to fetch a larger pool and shuffle it to make it less
 // likely that different users requesting at the same time get the same data
 const SHUFFLE_SIZE = 500
+
+// We select this much extra because some might be removed later
+const EXTRA_COUNT = 5
 
 // Ref JIRA ticket OI-1300 - we want to exclude languages with fewer than 500k active global speakers
 // from the single sentence record limit, because they are unlikely to amass enough unique speakers
@@ -314,7 +319,7 @@ export default class DB {
       taxonomySentences = await this.findSentencesMatchingTaxonomy(
         client_id,
         locale_id,
-        count + 5, // 5 might be removed later
+        count + EXTRA_COUNT,
         prioritySegments
       )
     }
@@ -325,7 +330,7 @@ export default class DB {
         : await this.findSentencesWithFewClips(
             client_id,
             locale_id,
-            count + 5 - taxonomySentences.length, // 5 might be removed later
+            count + EXTRA_COUNT - taxonomySentences.length,
             exemptFromSSRL
           )
 


### PR DESCRIPTION
This fixes a race condition we debugged.

## Explanation
Many new and/or low-resource languages must have seen this: You remember that you already recorded a sentence, you record it again, but when you submit it a pop-up comes out saying it could not be saved with two options: Retry - Cancel.
Even if you retry, you cannot pass it, the only way is to press cancel.
We found out the code is correct, but there is a race condition: The database (DB) updates are slower than selects.  Here is what was happening:
- The front-end (FE) requests 25 sentences for being recorded. The back-end (BE) provides them.
- The user submits 25 sentences 5 by 5. The first 4 batches go without a problem. After the last 5 (or less remaining) are sent, FE requests a new batch (of 25).
- While the database is updating the sentence tables incrementing the recorded counts (slow), it also selects new set - but with not-yet-updated values. This is a race condition. So the user gets a random selection of sentences, where some of them might be from the last set of the previous batch. If the text-corpus is small, or the contributing user count is slow, or small number of users record much (which is very much the case for every new/low-resource language) this happens more.
- The user records that sentence again and it gets rejected - because by rule (to prevent bias) a user can only record a sentence once.

In this fix, we keep the sentence_id's which got recorded - for each user in memory for an hour and filter out from the results, which effectively overcomes the race condition caused by slow DB UPDATE process.

## Related issues to be closed
TBA
