### PR TITLE
1174-MCV Fix parameter passing through request.headers

### DIFF
--- a/server/src/lib/clip.ts
+++ b/server/src/lib/clip.ts
@@ -199,7 +199,7 @@ export default class Clip {
       },
       headers,
     } = request
-    const sentenceId = headers.sentence_id as string
+    const sentenceId = headers['sentence-id'] as string
     const source = headers.source || 'unidentified'
     const format = headers['content-type']
     const size = headers['content-length']

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -155,14 +155,13 @@ export default class API {
     showFirstStreakToast?: boolean
     challengeEnded: boolean
   }> {
-    // make sure nginx server has allow_underscore turned on
     return this.fetch(this.getClipPath(), {
       method: 'POST',
       headers: {
         'Content-Type': blob.type,
-        sentence_id: sentenceId,
+        'sentence-id': sentenceId,
         challenge: getChallenge(this.user),
-        from_demo: fromDemo ? 'true' : 'false',
+        'from-demo': fromDemo ? 'true' : 'false',
         source: 'web',
       },
       body: blob,


### PR DESCRIPTION
While sending recorded audio for a sentence, sentence_id was sent through request.headers in a non-standard way, where one should change server parameters (e.g. in nginx underscores should be allowed).

This does not come out in MCV production sites, but for external open-source users (including developers) this creates a problem.

In this fix, we just replace the underscored values to strings on both FE and BE, so that it gets more robust.
