### PR TITLE
1184-MCV-BE Fix: Scale ms to seconds for expire

### DIFF
--- a/server/src/lib/lazy-cache.ts
+++ b/server/src/lib/lazy-cache.ts
@@ -7,9 +7,9 @@ type Fn<T, S> = (...args: S[]) => Promise<T>;
 //
 
 // Adds a value to a Redis SET with expiry
-export async function redisSetAddWithExpiry(key: string, value: string, ttlSeconds: number) {
+export async function redisSetAddWithExpiry(key: string, value: string, ttlMs: number) {
   await redis.sadd(key, value);
-  await redis.expire(key, ttlSeconds); // resets TTL each time
+  await redis.expire(key, Math.floor(ttlMs / 1000)); // resets TTL each time
 }
 
 // Gets values from a Redis SET (if exists)


### PR DESCRIPTION
Fixes long expire duration for Redis caching (ms => sec conversion was needed)