### PR TITLE
1185-MCV-BE Add migration to retire Catalan sentences from a toponym source

### DIFF
--- a/server/src/lib/model/db/migrations/20250628010000-retire-catalan-toponym-corpus.ts
+++ b/server/src/lib/model/db/migrations/20250628010000-retire-catalan-toponym-corpus.ts
@@ -1,0 +1,71 @@
+// Template to retire sentences from a specific source
+// Does not delete, but disables for further recordings
+
+const LOCALE = 'ca'
+const SOURCE = 'frases_agenda'
+
+//
+// Do not change the code below unless database structure has been changed
+//
+// do it in small batches not to lock the users much or trigger autoscale
+// it will take longer but uses less resources
+const BATCH_SIZE = 10000
+export const up = async function (db: any): Promise<any> {
+  // Find locale id
+  const [result] = await db.runSql(
+    `SELECT id as locale_id FROM locales WHERE name = ?`,
+    [LOCALE]
+  )
+  const locale_id = result?.locale_id
+  if (!locale_id) {
+    throw new Error(`Specified locale does not exist: [${LOCALE}]`)
+  }
+
+  // do it in small batches
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { affectedRows } = await db.runSql(
+      `
+      UPDATE sentences
+      SET is_used = FALSE
+      WHERE locale_id = ?
+        AND source = ?
+        AND is_used = TRUE
+      ORDER BY id
+      LIMIT ?
+      `,
+      [locale_id, SOURCE, BATCH_SIZE]
+    )
+    if (affectedRows < BATCH_SIZE) break
+  }
+}
+
+export const down = async function (db: any): Promise<any> {
+  // Find locale id
+  const [result] = await db.runSql(
+    `SELECT id as locale_id FROM locales WHERE name = ?`,
+    [LOCALE]
+  )
+  const locale_id = result?.locale_id
+  if (!locale_id) {
+    throw new Error(`Specified locale does not exist: [${LOCALE}]`)
+  }
+
+  // do it in small batches
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { affectedRows } = await db.runSql(
+      `
+      UPDATE sentences
+      SET is_used = TRUE
+      WHERE locale_id = ?
+        AND source = ?
+        AND is_used = FALSE
+      ORDER BY id
+      LIMIT ?
+      `,
+      [locale_id, SOURCE, BATCH_SIZE]
+    )
+    if (affectedRows < BATCH_SIZE) break
+  }
+}


### PR DESCRIPTION
This retires Catalan sentences coming from `frases_agenda.txt` file by setting `is_used` field to `FALSE`.

It processes in 10k batches because the actual count is ~143k. Although it takes a bit longer to process, it does not lock out other requests too long, and uses less resources at a time, which also prevents possible auto-scaling of pods.

On local development environment the duration increased from 161 secs to 190 secs when batched.
