### PR TITLE
Add missing about-menu-aria-label

### DIFF
--- a/web/locales/common-voice/en/pages/home.ftl
+++ b/web/locales/common-voice/en/pages/home.ftl
@@ -102,13 +102,14 @@ spontaneous-speech = SPONTANEOUS SPEECH
 ## MENU ITEMS TOOLTIPS
 about-menu-tooltip = Partnerships, Press and Stories, Community and Languages
 about-us-menu-item-tooltip = Learn about the mission and team behind Common Voice
-about-us-menu-item-aria-label = About us options menu
 partnerships-menu-item-tooltip = Explore organizations supporting Common Voice around the world
 press-and-stories-menu-item-tooltip = Read stories, updates, and media coverage of Common Voice
 community-and-languages-menu-item-tooltip = Connect with our community and see supported languages
 
 ## MENU ITEM ARIA LABELS
+about-menu-aria-label = Menu to access Partnerships, Press and Stories, Community and Languages
 about-us-menu-aria-label = About options menu
+about-us-menu-item-aria-label = About us options menu
 partnerships-menu-item-aria-label = Learn about partnerships with Common Voice
 press-and-stories-menu-item-aria-label = Access press releases and stories related to Common Voice
 community-and-languages-menu-item-aria-label = Explore the community and languages supported by Common Voice


### PR DESCRIPTION
Add missing accessibility key `about-menu-aria-label` for main menu item "About".
