### PR TITLE
1187-MCV Change clip-upload process to handle remaining duplicate-clip errors

### DIFF
--- a/server/src/lib/clip.ts
+++ b/server/src/lib/clip.ts
@@ -237,7 +237,7 @@ export default class Clip {
       this.clipSaveError(
         headers,
         response,
-        204,
+        409,
         `${clipFileName} already exists`,
         ERRORS.ALREADY_EXISTS,
         'clip'

--- a/web/locales/common-voice/en/pages/error.ftl
+++ b/web/locales/common-voice/en/pages/error.ftl
@@ -6,9 +6,18 @@ banner-error-slow-link = Status Page
 error-something-went-wrong = Sorry, something went wrong
 error-clip-upload = Upload of this clip keeps failing, keep retrying?
 error-clip-upload-server = Upload of this clip keeps failing at server. Reload the page or try again later.
-error-duplicate-clips =  Only { $uploaded } of { $total } clips could be uploaded. It looks like you've already recorded others. Let's go ahead and try the next set!
 error-title-404 = We couldn’t find that page for you
 error-content-404 = Maybe our <homepageLink>homepage</homepageLink> will help? To ask a question, please join the <matrixLink>Matrix community chat</matrixLink>, monitor site issues via <githubLink>GitHub</githubLink> or visit <discourseLink>our Discourse forums</discourseLink>.
 error-title-503 = We’re experiencing unexpected downtime
 error-content-503 = The site will be back up as soon as possible. For the latest information, please join the <matrixLink>Matrix community chat</matrixLink> or visit <githubLink>GitHub</githubLink> or <discourseLink>our Discourse forums</discourseLink> to submit and monitor site experience issues.
 error-code = Error { $code }
+
+# Warning message shown when none of the clips could be uploaded
+error-duplicate-clips-all =
+  We could not upload { NUMBER($total) ->
+    [one] your clip. It has already been uploaded before.
+    *[other] { $total } clips. They have already been uploaded before.
+  } Let’s continue with the next batch!
+# Warning message shown when only some of the clips could be uploaded (uploaded count will be <5)
+error-duplicate-clips-some =
+  We uploaded { $uploaded } of your clips — The remainder have already been uploaded. Let’s continue with the next batch!

--- a/web/locales/common-voice/en/pages/error.ftl
+++ b/web/locales/common-voice/en/pages/error.ftl
@@ -6,6 +6,7 @@ banner-error-slow-link = Status Page
 error-something-went-wrong = Sorry, something went wrong
 error-clip-upload = Upload of this clip keeps failing, keep retrying?
 error-clip-upload-server = Upload of this clip keeps failing at server. Reload the page or try again later.
+error-duplicate-clips =  Only { $uploaded } of { $total } clips could be uploaded. It looks like you've already recorded others. Let's go ahead and try the next set!
 error-title-404 = We couldn’t find that page for you
 error-content-404 = Maybe our <homepageLink>homepage</homepageLink> will help? To ask a question, please join the <matrixLink>Matrix community chat</matrixLink>, monitor site issues via <githubLink>GitHub</githubLink> or visit <discourseLink>our Discourse forums</discourseLink>.
 error-title-503 = We’re experiencing unexpected downtime

--- a/web/src/components/pages/contribution/speak/speak.tsx
+++ b/web/src/components/pages/contribution/speak/speak.tsx
@@ -508,7 +508,6 @@ class SpeakPage extends React.Component<Props, State> {
             alert(
               getString('error-duplicate-clips-some', {
                 uploaded: uploaded_count,
-                total: clip_count,
               })
             )
           }

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -104,6 +104,13 @@ export default class API {
       throw error
     }
 
+    if (response.status === 409) {
+      if (response.statusText.includes('ALREADY_EXISTS')) {
+        throw new Error(response.statusText)
+      }
+      throw new Error(await response.text())
+    }
+
     if (response.status >= 400) {
       if (response.statusText.includes('save_clip_error')) {
         throw new Error(response.statusText)


### PR DESCRIPTION
Although we fixed the main reason here (https://github.com/common-voice/common-voice/pull/4944) we still have some remaining errors. This PR changes the upload workflow to handle these, while we can continue to find the real reason:

- Instead of showing retry/cancel after each duplicate-clip problem, the new workflow sends the whole batch (1-5) and reports back at the end with an alert box where the user can only say OK (no retry option, because it will fail again).
- Clip sending will still be retried 3 times internally e.g. temporary for communication errors, but without the Retry button (which you can never pass) there will be 3 errors recorded for duplicate clips.
- This enables a better experience for the user and a better feedback on what is actually happening.
- We will have exactly 3 error record (num/3 actual errors) where we can further research.

Edit: Here are the final errors (JS alerts)...

If none could be uploaded (maybe 1-5)
<img width="448" height="150" alt="image" src="https://github.com/user-attachments/assets/959c65f1-637e-479b-815d-c25ae8231e7c" />

If some could be uploaded (maybe 1-4)
<img width="456" height="159" alt="image" src="https://github.com/user-attachments/assets/98083c02-0740-4e0f-9364-a5cf00f90b3a" />
