### PR TITLE
1230-Fix: Non existing locale in migration should not throw

### DIFF
--- a/server/src/lib/model/db/migrations/20250628010000-retire-catalan-toponym-corpus.ts
+++ b/server/src/lib/model/db/migrations/20250628010000-retire-catalan-toponym-corpus.ts
@@ -18,7 +18,9 @@ export const up = async function (db: any): Promise<any> {
   )
   const locale_id = result?.locale_id
   if (!locale_id) {
-    throw new Error(`Specified locale does not exist: [${LOCALE}]`)
+    // for local env do not throw/fail but continue with next
+    console.warn(`Specified locale does not exist: [${LOCALE}]`)
+    return
   }
 
   // do it in small batches


### PR DESCRIPTION
`Throw`ing an `Error` in migrations cause disruption for local development environments.

With this change, we silently ignore non-existing locales, and only warn...

Thank you @akrabat for discovering this.
