### PR TITLE
1231 - Workaround for header parameter caching issue

### DIFF
--- a/server/src/lib/clip.ts
+++ b/server/src/lib/clip.ts
@@ -166,23 +166,23 @@ export default class Clip {
     Basket.sync(client_id).catch(e => console.error(e))
     const ret = challengeTokens.includes(challenge)
       ? {
-          glob: glob,
-          showFirstContributionToast: await earnBonus('first_contribution', [
-            challenge,
-            client_id,
-          ]),
-          hasEarnedSessionToast: await hasEarnedBonus(
-            'invite_contribute_same_session',
-            client_id,
-            challenge
-          ),
-          showFirstStreakToast: await earnBonus('three_day_streak', [
-            client_id,
-            client_id,
-            challenge,
-          ]),
-          challengeEnded: await this.model.db.hasChallengeEnded(challenge),
-        }
+        glob: glob,
+        showFirstContributionToast: await earnBonus('first_contribution', [
+          challenge,
+          client_id,
+        ]),
+        hasEarnedSessionToast: await hasEarnedBonus(
+          'invite_contribute_same_session',
+          client_id,
+          challenge
+        ),
+        showFirstStreakToast: await earnBonus('three_day_streak', [
+          client_id,
+          client_id,
+          challenge,
+        ]),
+        challengeEnded: await this.model.db.hasChallengeEnded(challenge),
+      }
       : { glob }
     response.json(ret)
   }
@@ -195,9 +195,9 @@ export default class Clip {
   saveClip = async (request: Request, response: Response) => {
     // default the client_id to null if it is not present in the session.user object
     // so that a 400 is returned below
-    const { headers } = request 
+    const { headers } = request
     const client_id = request?.session?.user?.client_id
-    const sentenceId = headers['sentence-id'] as string
+    const sentenceId = headers['sentence-id'] as string || headers.sentence_id as string // TODO: Remove the second case in August 2025
     const source = headers.source || 'unidentified'
     const format = headers['content-type']
     const size = headers['content-length']
@@ -303,25 +303,25 @@ export default class Clip {
         const challenge = headers.challenge as ChallengeToken
         const ret = challengeTokens.includes(challenge)
           ? {
-              filePrefix: filePrefix,
-              showFirstContributionToast: await earnBonus(
-                'first_contribution',
-                [challenge, client_id]
-              ),
-              hasEarnedSessionToast: await hasEarnedBonus(
-                'invite_contribute_same_session',
-                client_id,
-                challenge
-              ),
-              // can't simply reduce the number of the calls to DB through streak_days in checkGoalsAfterContribution()
-              // since the the streak_days may start before the time when user set custom_goals, check to win bonus for each contribution
-              showFirstStreakToast: await earnBonus('three_day_streak', [
-                client_id,
-                client_id,
-                challenge,
-              ]),
-              challengeEnded: await this.model.db.hasChallengeEnded(challenge),
-            }
+            filePrefix: filePrefix,
+            showFirstContributionToast: await earnBonus(
+              'first_contribution',
+              [challenge, client_id]
+            ),
+            hasEarnedSessionToast: await hasEarnedBonus(
+              'invite_contribute_same_session',
+              client_id,
+              challenge
+            ),
+            // can't simply reduce the number of the calls to DB through streak_days in checkGoalsAfterContribution()
+            // since the the streak_days may start before the time when user set custom_goals, check to win bonus for each contribution
+            showFirstStreakToast: await earnBonus('three_day_streak', [
+              client_id,
+              client_id,
+              challenge,
+            ]),
+            challengeEnded: await this.model.db.hasChallengeEnded(challenge),
+          }
           : { filePrefix }
         response.json(ret)
       })
@@ -351,7 +351,7 @@ export default class Clip {
   serveRandomClips = async (request: Request, response: Response) => {
     const { client_id } = request?.session?.user || {}
     const { locale } = request.params
-    
+
     if (!client_id) {
       return response.sendStatus(StatusCodes.BAD_REQUEST)
     }


### PR DESCRIPTION
After (https://github.com/common-voice/common-voice/pull/4945) is on production:, we saw some small spikes in errors, where some people hit a single time. It seems the `index.html` caching in open tabs in browsers and/or intermediate agents (caching proxies, CDNs) are causing the use of the old form, which are rejected in BE, and when it does the user gets the new files and moves on.

This PR implements a temporary workaround to handle both cases until the cache issues on user end settles.
