### PR TITLE
Uncomment CV_FXA_* key-value pairs, add comments referring to set up Auth0

### DIFF
--- a/.env-local-docker.example
+++ b/.env-local-docker.example
@@ -21,6 +21,7 @@ CV_PROD="false"
 # These vars specify which sentences to import when the Docker containers are run. 
 # You should set CV_IMPORT_SENTENCES to "true" if you are testing a particular language, 
 # and then specify its language code in CV_IMPORT_LANGUAGES
+# Don't forget to reset it to "false" after the import is complete, otherwise it will try to add again needlessly
 CV_IMPORT_SENTENCES="false"
 # Specify multiple languages comma-delimited, e.g. CV_IMPORT_LANGUAGES="en,de,sw,tr"
 # The code should match the language code used for the language in Common Voice 

--- a/.env-local-docker.example
+++ b/.env-local-docker.example
@@ -22,7 +22,9 @@ CV_PROD="false"
 # You should set CV_IMPORT_SENTENCES to "true" if you are testing a particular language, 
 # and then specify its language code in CV_IMPORT_LANGUAGES
 CV_IMPORT_SENTENCES="true"
-CV_IMPORT_LANGUAGES="en,de,tr"
+# Specify multiple languages comma-delimited, e.g. CV_IMPORT_LANGUAGES="en,de,sw,tr"
+# By default we just import English because importing multiple languages takes much longer
+CV_IMPORT_LANGUAGES="en"
 
 # If you are self-hosting, you should put your email address here
 CV_EMAIL_USERNAME_FROM="commonvoice@mozilla.com"
@@ -36,10 +38,18 @@ CV_REDIS_URL="redis"
 # You don't need to change it
 CV_JWT_KEY=super-secure-key
 
-# If you are using authentication features, 
-# you will need to set up an Auth0 tenant
-# See /docs/DEVELOPMENT.md for more information 
-# These should remain commented out otherwise.
-#CV_FXA_DOMAIN="<domain_here>"
-#CV_FXA_CLIENT_ID="<client_id_here>"
-#CV_FXA_CLIENT_SECRET="<client_secret_here>"
+# You will need to set up authentication
+# in order to bring up the development environment
+# - it will not work without it. 
+# The easiest way to do this is to set up an Auth0 tenant. 
+# This is documented at: 
+# https://github.com/common-voice/common-voice/blob/main/docs/DEVELOPMENT.md#authentication
+CV_FXA_DOMAIN="<domain_here>"
+CV_FXA_CLIENT_ID="<client_id_here>"
+CV_FXA_CLIENT_SECRET="<client_secret_here>"
+
+# Ways to get help: 
+# Discord: https://discord.gg/4TjgEdq25Y
+# Matrix: https://chat.mozilla.org/#/room/#common-voice:mozilla.org
+# Email: commonvoice@mozilla.com 
+# or drop us an Issue on GitHub

--- a/.env-local-docker.example
+++ b/.env-local-docker.example
@@ -21,9 +21,11 @@ CV_PROD="false"
 # These vars specify which sentences to import when the Docker containers are run. 
 # You should set CV_IMPORT_SENTENCES to "true" if you are testing a particular language, 
 # and then specify its language code in CV_IMPORT_LANGUAGES
-CV_IMPORT_SENTENCES="true"
+CV_IMPORT_SENTENCES="false"
 # Specify multiple languages comma-delimited, e.g. CV_IMPORT_LANGUAGES="en,de,sw,tr"
-# By default we just import English because importing multiple languages takes much longer
+# The code should match the language code used for the language in Common Voice 
+# e.g. https://commonvoice.mozilla.org/[language-code]/
+# e.g. https://commonvoice.mozilla.org/sw/ for Kiswahili
 CV_IMPORT_LANGUAGES="en"
 
 # If you are self-hosting, you should put your email address here

--- a/.env-local-docker.example
+++ b/.env-local-docker.example
@@ -40,8 +40,7 @@ CV_REDIS_URL="redis"
 # You don't need to change it
 CV_JWT_KEY=super-secure-key
 
-# You will need to set up authentication
-# in order to bring up the development environment
+# You will need to set up authentication in order to bring up the development environment
 # - it will not work without it. 
 # The easiest way to do this is to set up an Auth0 tenant. 
 # This is documented at: 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -44,6 +44,7 @@ This guide is intended for:
 ## Summary to get up and running 
 
 * Fork and clone the repo 
+* Set up an Auth0 tenant or similar to provide authentication.
 * Copy the `.env-local-docker.example` file to `.env-local-docker`, and edit as required for your context
 * Run `docker` containers with `docker compose up`
 * Flush `redis` cache when sentences from your language are imported 

--- a/server/src/config-helper.ts
+++ b/server/src/config-helper.ts
@@ -10,16 +10,16 @@ if (process.env.DOTENV_CONFIG_PATH) {
       process.env.DOTENV_CONFIG_PATH
     )
   } else {
+    // check to see if the default authentication details have changed, if not issue Warning
+    if (result.parsed.CV_FXA_DOMAIN == '<domain_here>') {
+      console.log(
+        'ERROR loading config: found default Authentication values. Have you updated .env-docker-local with correct Authentication values?'
+      )
+    }
     console.log(
       'Loading config: successfully loaded dotenv file: ',
       process.env.DOTENV_CONFIG_PATH
     )
-    // check to see if the default authentication details have changed, if not issue Warning
-    if (result.parsed.CV_FXA_DOMAIN == '<domain_here>') {
-      console.log(
-        'WARNING loading config: found default Authentication values. Have you updated .env-docker-local with correct Authentication values?'
-      )
-    }
   }
 }
 

--- a/server/src/config-helper.ts
+++ b/server/src/config-helper.ts
@@ -14,6 +14,12 @@ if (process.env.DOTENV_CONFIG_PATH) {
       'Loading config: successfully loaded dotenv file: ',
       process.env.DOTENV_CONFIG_PATH
     )
+    // check to see if the default authentication details have changed, if not issue Warning
+    if (result.parsed.CV_FXA_DOMAIN == '<domain_here>') {
+      console.log(
+        'WARNING loading config: found default Authentication values. Have you updated .env-docker-local with correct Authentication values?'
+      )
+    }
   }
 }
 


### PR DESCRIPTION
## Pull Request Form

### Type of Pull Request

- [X] Change to `.env-docker-local.example`
- [X] Related to a listed issue 

* #4973 
* #4885 

* Minor change to `.env-local-docker.example` to uncomment the `CV_FXA_*` key-value pairs 
* Add comments to guide developers 
* No changes required to `DEVELOPMENT.md`

### Testing undertaken of this PR 

* git checkout 4973-bug-commenting-out-of-cv_fxa_-key-values-in-env-local-docker-causes-halt-at-startup-when-building-dev-environment 
* build fresh docker containers, as a new dev setting up a local dev environment would with 

```
docker image prune --all --force
```

* copy new `.env-local-docker.example` to `.env-local-docker` 

```
cp .env-local-docker.example .env-local-docker
```

* build and run docker containers 

```
docker compose up
```

=> running localhost:9000 OK

### Acknowledging contributors

* @moz-bozden for sense-checking and peer review
