### PR TITLE
Add additional tests for public API credentials

### DIFF
--- a/server/src/test/api/profile/handler/create-api-credentials-handler.test.ts
+++ b/server/src/test/api/profile/handler/create-api-credentials-handler.test.ts
@@ -12,13 +12,8 @@ jest.mock(
   '../../../../application/profile/command-handler/createClientCredentialsCommandHandler'
 )
 
-const mockGetClientCredentialsQueryHandler = jest.mocked(
-  getClientCredentialsQueryHandler
-)
-
-const mockCreateClientCredentialsCommandHandler = jest.mocked(
-  createClientCredentialsCommandHandler
-)
+const mockGetClientCredentialsQueryHandler = jest.mocked(getClientCredentialsQueryHandler)
+const mockCreateClientCredentialsCommandHandler = jest.mocked(createClientCredentialsCommandHandler)
 
 interface MockRequest {
   session: {

--- a/server/src/test/api/profile/handler/delete-api-credentials-handler.test.ts
+++ b/server/src/test/api/profile/handler/delete-api-credentials-handler.test.ts
@@ -8,12 +8,8 @@ import { deleteClientCredentialsCommandHandler } from '../../../../application/p
 jest.mock('../../../../application/profile/query-handler/getClientCredentialsQueryHandler')
 jest.mock('../../../../application/profile/command-handler/deleteClientCredentialsCommandHandler')
 
-const mockGetClientCredentialsQueryHandler = getClientCredentialsQueryHandler as jest.MockedFunction<
-  typeof getClientCredentialsQueryHandler
->
-const mockDeleteClientCredentialsCommandHandler = deleteClientCredentialsCommandHandler as jest.MockedFunction<
-  typeof deleteClientCredentialsCommandHandler
->
+const mockGetClientCredentialsQueryHandler = jest.mocked(getClientCredentialsQueryHandler)
+const mockDeleteClientCredentialsCommandHandler = jest.mocked(deleteClientCredentialsCommandHandler)
 
 interface MockRequest {
   session: {

--- a/server/src/test/api/profile/handler/get-api-credentials-handler.test.ts
+++ b/server/src/test/api/profile/handler/get-api-credentials-handler.test.ts
@@ -1,0 +1,103 @@
+import { StatusCodes } from 'http-status-codes'
+import { Request, Response } from 'express'
+import { getApiCredentialsHandler } from '../../../../api/profile/handler/get-api-credentials-handler'
+import { getClientCredentialsQueryHandler } from '../../../../application/profile/query-handler/getClientCredentialsQueryHandler'
+
+// Mock the dependencies
+jest.mock('../../../../application/profile/query-handler/getClientCredentialsQueryHandler')
+
+const mockGetClientCredentialsQueryHandler = getClientCredentialsQueryHandler as jest.MockedFunction<
+  typeof getClientCredentialsQueryHandler
+>
+
+interface MockRequest {
+  session: {
+    user: {
+      client_id?: string
+    }
+  }
+}
+
+interface MockResponse {
+  status: jest.MockedFunction<(code: number) => MockResponse>
+  json: jest.MockedFunction<(obj: object) => MockResponse>
+}
+
+describe('getApiCredentialsHandler', () => {
+  const createMockRequest = (clientId?: string): MockRequest => ({
+    session: {
+      user: {
+        client_id: clientId,
+      },
+    },
+  })
+
+  const createMockResponse = (): MockResponse => {
+    const res = {} as MockResponse
+    res.status = jest.fn().mockReturnValue(res)
+    res.json = jest.fn().mockReturnValue(res)
+    return res
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should return 400 when user client_id is missing', async () => {
+    const req = createMockRequest(undefined)
+    const res = createMockResponse()
+
+    await getApiCredentialsHandler(req as unknown as Request, res as unknown as Response)
+
+    expect(res.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+    expect(res.json).toHaveBeenCalledWith({ message: 'no client id' })
+    expect(mockGetClientCredentialsQueryHandler).not.toHaveBeenCalled()
+  })
+
+  it('should return credentials when user client_id exists', async () => {
+    const req = createMockRequest('user-123')
+    const res = createMockResponse()
+
+    const mockCredentials = [
+      { clientId: 'client-123', name: 'Test App 1' },
+      { clientId: 'client-456', name: 'Test App 2' },
+    ]
+
+    mockGetClientCredentialsQueryHandler.mockResolvedValue(mockCredentials)
+
+    await getApiCredentialsHandler(req as unknown as Request, res as unknown as Response)
+
+    expect(mockGetClientCredentialsQueryHandler).toHaveBeenCalledWith({
+      userId: 'user-123',
+    })
+    expect(res.json).toHaveBeenCalledWith(mockCredentials)
+    expect(res.status).not.toHaveBeenCalled()
+  })
+
+  it('should return empty array when user has no credentials', async () => {
+    const req = createMockRequest('user-123')
+    const res = createMockResponse()
+
+    mockGetClientCredentialsQueryHandler.mockResolvedValue([])
+
+    await getApiCredentialsHandler(req as unknown as Request, res as unknown as Response)
+
+    expect(mockGetClientCredentialsQueryHandler).toHaveBeenCalledWith({
+      userId: 'user-123',
+    })
+    expect(res.json).toHaveBeenCalledWith([])
+    expect(res.status).not.toHaveBeenCalled()
+  })
+
+  it('should handle errors from getClientCredentialsQueryHandler', async () => {
+    const req = createMockRequest('user-123')
+    const res = createMockResponse()
+
+    mockGetClientCredentialsQueryHandler.mockRejectedValue(new Error('Failed to retrieve client credentials: 500'))
+
+    await expect(getApiCredentialsHandler(req as unknown as Request, res as unknown as Response)).rejects.toThrow('Failed to retrieve client credentials: 500')
+    expect(mockGetClientCredentialsQueryHandler).toHaveBeenCalledWith({
+      userId: 'user-123',
+    })
+  })
+})

--- a/server/src/test/api/profile/handler/get-api-credentials-handler.test.ts
+++ b/server/src/test/api/profile/handler/get-api-credentials-handler.test.ts
@@ -6,9 +6,7 @@ import { getClientCredentialsQueryHandler } from '../../../../application/profil
 // Mock the dependencies
 jest.mock('../../../../application/profile/query-handler/getClientCredentialsQueryHandler')
 
-const mockGetClientCredentialsQueryHandler = getClientCredentialsQueryHandler as jest.MockedFunction<
-  typeof getClientCredentialsQueryHandler
->
+const mockGetClientCredentialsQueryHandler = jest.mocked(getClientCredentialsQueryHandler)
 
 interface MockRequest {
   session: {

--- a/server/src/test/application/profile/command-handler/createClientCredentialsCommandHandler.test.ts
+++ b/server/src/test/application/profile/command-handler/createClientCredentialsCommandHandler.test.ts
@@ -1,0 +1,94 @@
+import { createClientCredentialsCommandHandler } from '../../../../application/profile/command-handler/createClientCredentialsCommandHandler'
+import { createClientCredentials } from '../../../../infrastructure/authentication/authentication'
+import { CreateClientCredentialsCommand } from '../../../../application/profile/command-handler/command/createClientCredentialsCommand'
+
+// Mock the dependencies
+jest.mock('../../../../infrastructure/authentication/authentication')
+
+const mockCreateClientCredentials = createClientCredentials as jest.MockedFunction<
+  typeof createClientCredentials
+>
+
+describe('createClientCredentialsCommandHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should create client credentials', async () => {
+    const command: CreateClientCredentialsCommand = {
+      userId: 'user-123',
+      description: 'Test application',
+    }
+
+    const mockResponse = {
+      userId: 'user-123',
+      clientId: 'client-456',
+      clientSecret: 'secret-789',
+      description: 'Test application',
+      permissions: [
+        { permission_id: 1, name: 'audio:recording:create', description: 'Create audio recordings' },
+        { permission_id: 2, name: 'audio:recording:upload', description: 'Upload audio recordings' },
+        { permission_id: 3, name: 'audio:recording:read', description: 'Read audio recordings' },
+        { permission_id: 4, name: 'audio:recording:list', description: 'List audio recordings' },
+        { permission_id: 5, name: 'text:submission:read', description: 'Read text submissions' },
+        { permission_id: 6, name: 'text:submission:list', description: 'List text submissions' },
+      ],
+    }
+
+    mockCreateClientCredentials.mockResolvedValue(mockResponse)
+
+    const result = await createClientCredentialsCommandHandler(command)
+
+    expect(mockCreateClientCredentials).toHaveBeenCalledWith({
+      userId: 'user-123',
+      description: 'Test application',
+      permissions: [
+        'audio:recording:create',
+        'audio:recording:upload',
+        'audio:recording:read',
+        'audio:recording:list',
+        'text:submission:read',
+        'text:submission:list',
+      ],
+    })
+
+    expect(result).toEqual({
+      userId: 'user-123',
+      clientId: 'client-456',
+      clientSecret: 'secret-789',
+      description: 'Test application',
+      permissions: [
+        'audio:recording:create',
+        'audio:recording:upload',
+        'audio:recording:read',
+        'audio:recording:list',
+        'text:submission:read',
+        'text:submission:list',
+      ],
+    })
+  })
+
+  it('should handle errors from createClientCredentials', async () => {
+    const command: CreateClientCredentialsCommand = {
+      userId: 'user-123',
+      description: 'Test application',
+    }
+
+    mockCreateClientCredentials.mockRejectedValue(new Error('Failed to create client credentials: 500'))
+
+    await expect(createClientCredentialsCommandHandler(command)).rejects.toThrow('Failed to create client credentials: 500')
+
+    expect(mockCreateClientCredentials).toHaveBeenCalledWith({
+      userId: 'user-123',
+      description: 'Test application',
+      permissions: [
+        'audio:recording:create',
+        'audio:recording:upload',
+        'audio:recording:read',
+        'audio:recording:list',
+        'text:submission:read',
+        'text:submission:list',
+      ],
+    })
+  })
+})

--- a/server/src/test/application/profile/command-handler/createClientCredentialsCommandHandler.test.ts
+++ b/server/src/test/application/profile/command-handler/createClientCredentialsCommandHandler.test.ts
@@ -5,9 +5,7 @@ import { CreateClientCredentialsCommand } from '../../../../application/profile/
 // Mock the dependencies
 jest.mock('../../../../infrastructure/authentication/authentication')
 
-const mockCreateClientCredentials = createClientCredentials as jest.MockedFunction<
-  typeof createClientCredentials
->
+const mockCreateClientCredentials = jest.mocked(createClientCredentials)
 
 describe('createClientCredentialsCommandHandler', () => {
   beforeEach(() => {

--- a/server/src/test/application/profile/command-handler/deleteClientCredentialsCommandHandler.test.ts
+++ b/server/src/test/application/profile/command-handler/deleteClientCredentialsCommandHandler.test.ts
@@ -5,9 +5,7 @@ import { DeleteClientCredentialsCommand } from '../../../../application/profile/
 // Mock the dependencies
 jest.mock('../../../../infrastructure/authentication/authentication')
 
-const mockDeleteClientCredentials = deleteClientCredentials as jest.MockedFunction<
-  typeof deleteClientCredentials
->
+const mockDeleteClientCredentials = jest.mocked(deleteClientCredentials)
 
 describe('deleteClientCredentialsCommandHandler', () => {
   beforeEach(() => {

--- a/server/src/test/application/profile/query-handler/getClientCredentialsQueryHandler.test.ts
+++ b/server/src/test/application/profile/query-handler/getClientCredentialsQueryHandler.test.ts
@@ -5,9 +5,7 @@ import { GetClientCredentialsQuery } from '../../../../application/profile/query
 // Mock the infrastructure dependency
 jest.mock('../../../../infrastructure/authentication/authentication')
 
-const mockGetClientCredentials = getClientCredentials as jest.MockedFunction<
-  typeof getClientCredentials
->
+const mockGetClientCredentials = jest.mocked(getClientCredentials)
 
 describe('getClientCredentialsQueryHandler', () => {
   beforeEach(() => {

--- a/server/src/test/application/profile/query-handler/getClientCredentialsQueryHandler.test.ts
+++ b/server/src/test/application/profile/query-handler/getClientCredentialsQueryHandler.test.ts
@@ -1,0 +1,60 @@
+import { getClientCredentialsQueryHandler } from '../../../../application/profile/query-handler/getClientCredentialsQueryHandler'
+import { getClientCredentials } from '../../../../infrastructure/authentication/authentication'
+import { GetClientCredentialsQuery } from '../../../../application/profile/query-handler/query/getClientCredentialsQuery'
+
+// Mock the infrastructure dependency
+jest.mock('../../../../infrastructure/authentication/authentication')
+
+const mockGetClientCredentials = getClientCredentials as jest.MockedFunction<
+  typeof getClientCredentials
+>
+
+describe('getClientCredentialsQueryHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should retrieve client credentials for a user', async () => {
+    const query: GetClientCredentialsQuery = {
+      userId: 'user-123',
+    }
+
+    const mockCredentials = [
+      {
+        userId: 'user-123',
+        clientId: 'client-456',
+        description: 'Test application 1',
+        permissions: ['audio:recording:create', 'audio:recording:upload'],
+      },
+      {
+        userId: 'user-123',
+        clientId: 'client-789',
+        description: 'Test application 2',
+        permissions: ['text:submission:read', 'text:submission:list'],
+      },
+    ]
+
+    mockGetClientCredentials.mockResolvedValue(mockCredentials)
+
+    const result = await getClientCredentialsQueryHandler(query)
+
+    expect(mockGetClientCredentials).toHaveBeenCalledWith({
+      userId: 'user-123',
+    })
+    expect(result).toEqual(mockCredentials)
+  })
+
+  it('should handle errors from getClientCredentials', async () => {
+    const query: GetClientCredentialsQuery = {
+      userId: 'user-123',
+    }
+
+    mockGetClientCredentials.mockRejectedValue(new Error('Failed to retrieve client credentials: 500'))
+
+    await expect(getClientCredentialsQueryHandler(query)).rejects.toThrow('Failed to retrieve client credentials: 500')
+
+    expect(mockGetClientCredentials).toHaveBeenCalledWith({
+      userId: 'user-123',
+    })
+  })
+})

--- a/server/src/test/infrastructure/authentication/authentication.test.ts
+++ b/server/src/test/infrastructure/authentication/authentication.test.ts
@@ -1,4 +1,8 @@
-import { deleteClientCredentials } from '../../../infrastructure/authentication/authentication'
+import { 
+  deleteClientCredentials, 
+  createClientCredentials, 
+  getClientCredentials 
+} from '../../../infrastructure/authentication/authentication'
 import { getConfig, CommonVoiceConfig } from '../../../config-helper'
 
 // Mock the config helper
@@ -10,7 +14,7 @@ global.fetch = jest.fn()
 const mockGetConfig = getConfig as jest.MockedFunction<typeof getConfig>
 const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>
 
-describe('deleteClientCredentials', () => {
+describe('authentication', () => {
   const mockConfig: Partial<CommonVoiceConfig> = {
     AUTH_SERVICE_URL: 'https://auth.example.com'
   }
@@ -24,35 +28,158 @@ describe('deleteClientCredentials', () => {
     jest.resetAllMocks()
   })
 
-  it('should successfully delete client credentials', async () => {
-    const clientInfo = { clientId: 'client-123' }
+  describe('deleteClientCredentials', () => {
+    it('should successfully delete client credentials', async () => {
+      const clientInfo = { clientId: 'client-123' }
 
-    mockFetch.mockResolvedValue({
-      ok: true,
-      status: 204
-    } as Response)
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 204
+      } as Response)
 
-    await deleteClientCredentials(clientInfo)
+      await deleteClientCredentials(clientInfo)
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      'https://auth.example.com/internal/auth/clients/client-123',
-      {
-        method: 'DELETE'
-      }
-    )
-    expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://auth.example.com/internal/auth/clients/client-123',
+        {
+          method: 'DELETE'
+        }
+      )
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('should throw an error when response is not ok', async () => {
+      const clientInfo = { clientId: 'client-123' }
+
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500
+      } as Response)
+
+      await expect(deleteClientCredentials(clientInfo)).rejects.toThrow(
+        'Failed to delete client credentials: 500'
+      )
+    })
   })
 
-  it('should throw an error when response is not ok', async () => {
-    const clientInfo = { clientId: 'client-123' }
+  describe('createClientCredentials', () => {
+    it('should successfully create client credentials', async () => {
+      const clientInfo = {
+        userId: 'user-123',
+        description: 'Test application',
+        permissions: ['audio:recording:create', 'audio:recording:upload']
+      }
 
-    mockFetch.mockResolvedValue({
-      ok: false,
-      status: 500
-    } as Response)
+      const mockResponse = {
+        userId: 'user-123',
+        clientId: 'client-456',
+        clientSecret: 'secret-789',
+        description: 'Test application',
+        permissions: [
+          { permission_id: 1, name: 'audio:recording:create', description: 'Create audio recordings' },
+          { permission_id: 2, name: 'audio:recording:upload', description: 'Upload audio recordings' }
+        ]
+      }
 
-    await expect(deleteClientCredentials(clientInfo)).rejects.toThrow(
-      'Failed to delete client credentials: 500'
-    )
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 201,
+        json: jest.fn().mockResolvedValue(mockResponse)
+      } as any)
+
+      const result = await createClientCredentials(clientInfo)
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://auth.example.com/internal/auth/clients',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify(clientInfo)
+        }
+      )
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('should throw an error when response is not ok', async () => {
+      const clientInfo = {
+        userId: 'user-123',
+        description: 'Test application',
+        permissions: ['audio:recording:create']
+      }
+
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 400
+      } as Response)
+
+      await expect(createClientCredentials(clientInfo)).rejects.toThrow(
+        'Failed to create client credentials: 400'
+      )
+    })
+  })
+
+  describe('getClientCredentials', () => {
+    it('should successfully get client credentials', async () => {
+      const clientInfo = { userId: 'user-123' }
+
+      const mockResponse = [
+        {
+          userId: 'user-123',
+          clientId: 'client-456',
+          description: 'Test application 1',
+          permissions: ['audio:recording:create', 'audio:recording:upload']
+        },
+        {
+          userId: 'user-123',
+          clientId: 'client-789',
+          description: 'Test application 2',
+          permissions: ['text:submission:read', 'text:submission:list']
+        }
+      ]
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValue(mockResponse)
+      } as any)
+
+      const result = await getClientCredentials(clientInfo)
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://auth.example.com/internal/auth/clients?userId=user-123'
+      )
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('should handle URL encoding for userId', async () => {
+      const clientInfo = { userId: 'user@example.com' }
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValue([])
+      } as any)
+
+      await getClientCredentials(clientInfo)
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://auth.example.com/internal/auth/clients?userId=user%40example.com'
+      )
+    })
+
+    it('should throw an error when response is not ok', async () => {
+      const clientInfo = { userId: 'user-123' }
+
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500
+      } as Response)
+
+      await expect(getClientCredentials(clientInfo)).rejects.toThrow(
+        'Failed to retrieve client credentials: 500'
+      )
+    })
   })
 })


### PR DESCRIPTION
On the server-side, add the remaining tests for all operations on the public API for credentials including the command and query handlers and the methods in authentication.
