### PR TITLE
1260 - Increase cache duration of variant only clips

### DIFF
--- a/server/src/application/repository/clips-repository.ts
+++ b/server/src/application/repository/clips-repository.ts
@@ -6,7 +6,7 @@ import { DBClip } from '../../lib/model/db/tables/clip-table'
 import { pipe } from 'fp-ts/lib/function'
 import { lazyQueryDb, queryDb } from '../../infrastructure/db/mysql'
 import { createDatabaseError } from '../helper/error-helper'
-import { TimeUnits } from 'common'
+import { TimeUnits } from 'common/types'
 
 const VARIANT_CLIPS_LIMIT = 10000
 
@@ -16,7 +16,7 @@ export type FetchVariantClips = (
 export const fetchVariantClipsFromDB: FetchVariantClips = (variant: Variant) =>
   pipe(
     [variant.id, variant.id, VARIANT_CLIPS_LIMIT],
-    lazyQueryDb(`fetch-variant-clips-${variant.name}`)(TimeUnits.MINUTE)(
+    lazyQueryDb(`fetch-variant-clips-${variant.tag}`)(10 * TimeUnits.MINUTE)(
       `
         SELECT c.id, c.client_id, c.path, c.sentence, c.original_sentence_id
         FROM clips c


### PR DESCRIPTION
The query time was taking longer than caching time. This caused Redis Locking issues - in addition to 503 errors the users get due to long executing per-user pipeline.

This PR increases the variant-only-clips refresh time from 1 min to 10 minutes, keeping the default 3 min lock.
