### PR TITLE
1269-Add Irish (ga-IE) variants

### DIFF
--- a/server/src/lib/model/db/language-data/variants.ts
+++ b/server/src/lib/model/db/language-data/variants.ts
@@ -505,5 +505,25 @@ export const VARIANTS: Variant[] = [
     locale_name: 'gsw',
     variant_name: 'Hochàlemmànnisch (Hìniga, Pfìrt, usw.)',
     variant_token: 'gsw-FR-hochalem',
-  }
+  },
+  {
+    locale_name: 'ga-IE',
+    variant_name: 'Gaeilge Uladh - Ulster Irish',
+    variant_token: 'ga-IE-uladh',
+  },
+  {
+    locale_name: 'ga-IE',
+    variant_name: 'Gaeilge Chonnacht - Connacht Irish',
+    variant_token: 'ga-IE-chonnact',
+  },
+  {
+    locale_name: 'ga-IE',
+    variant_name: 'Gaeilge na Mumhan - Munster Irish',
+    variant_token: 'ga-IE-mumhan',
+  },
+  {
+    locale_name: 'ga-IE',
+    variant_name: 'Gaeilge Chaighdeánach - Standardised Irish',
+    variant_token: 'ga-IE-caighd',
+  },
 ]


### PR DESCRIPTION
This PR only adds Irish (`ga-IE`) variants **for sentence-variant usage ONLY**.
This is the first step of handling the FR https://github.com/common-voice/common-voice/issues/4993
Other steps need examination of existing data, data-mapping, programming, and migrations.

If in the meantime, the community members select their variants in their profiles, any 1-to-1 mapping from existing accents will be ignored and disabled.