### PR TITLE
1276-Irish (ga-IE) accent to variant migration

### DIFF
--- a/server/src/lib/model/db/migration-helpers/accents-variants/accents.ts
+++ b/server/src/lib/model/db/migration-helpers/accents-variants/accents.ts
@@ -1,0 +1,32 @@
+export const findAccentIdFromToken = async (
+  db: any,
+  locale_id: number,
+  accent_token: string
+): Promise<number | null> => {
+  const [result] = await db.runSql(
+    `
+      SELECT id
+      FROM accents
+      WHERE locale_id = ?
+        AND accent_token = ?
+    `,
+    [locale_id, accent_token]
+  )
+  return result?.id ? result.id : null
+}
+
+export const bulkDeleteUserAccents = async (
+  db: any,
+  locale_id: number,
+  accent_id: number,
+  clientIdBatch: string[]
+): Promise<any> => {
+  await db.runSql(
+    `
+      DELETE FROM user_client_accents
+      WHERE locale_id=? AND accent_id=?
+        AND client_id IN (${clientIdBatch.map(() => '?').join(',')})
+    `,
+    [locale_id, accent_id, ...clientIdBatch]
+  )
+}

--- a/server/src/lib/model/db/migration-helpers/accents-variants/index.ts
+++ b/server/src/lib/model/db/migration-helpers/accents-variants/index.ts
@@ -1,0 +1,5 @@
+export * from './types'
+export * from './accents'
+export * from './variants'
+export * from './locales'
+export * from './users'

--- a/server/src/lib/model/db/migration-helpers/accents-variants/locales/default.ts
+++ b/server/src/lib/model/db/migration-helpers/accents-variants/locales/default.ts
@@ -1,0 +1,68 @@
+import {
+  AV_MAPPING_TYPE,
+  findLocaleIdFromLocaleCode,
+  findAccentIdFromToken,
+  findVariantIdFromToken,
+  findEligibleUsersForAccentVariantMigration,
+  bulkDeleteUserAccents,
+  bulkInsertUserVariants,
+} from '../..'
+
+const BATCH_SIZE = 100
+
+export const migrateAccentsToVariants_default = async (
+  db: any,
+  locale_code: string,
+  mapping: AV_MAPPING_TYPE
+): Promise<any> => {
+  // get locale_id
+  const locale_id = await findLocaleIdFromLocaleCode(db, locale_code)
+  if (!locale_id) {
+    console.warn(`Specified locale does not exist: [${locale_code}]`)
+    return null
+  }
+
+  // Loop through the mapping
+  for (const [accent_token, variant_token] of mapping) {
+    // get accent_id and variant_id - fail if not found
+    const accent_id = await findAccentIdFromToken(db, locale_id, accent_token)
+    const variant_id = await findVariantIdFromToken(
+      db,
+      locale_id,
+      variant_token
+    )
+    if (!accent_id) {
+      console.warn(`Specified accent does not exist: [${accent_token}]`)
+      continue
+    }
+    if (!variant_id) {
+      console.warn(`Specified variant does not exist: [${variant_token}]`)
+      continue
+    }
+
+    // Get all client_id's where the user has no variant defined, has a single predefined accent and that accent is accent_id
+    const eligible_users = await findEligibleUsersForAccentVariantMigration(db, locale_id, accent_id)
+    if (!eligible_users || eligible_users.length === 0) continue
+
+    // Batched/Bulk process for large datasets
+    for (let i = 0; i < eligible_users.length; i += BATCH_SIZE) {
+      const batch = eligible_users.slice(i, i + BATCH_SIZE)
+      await bulkInsertUserVariants(db, locale_id, variant_id, batch)
+      await bulkDeleteUserAccents(db, locale_id, accent_id, batch)
+    }
+
+    // Remove the old accent if no one uses it anymore
+    const [{ count }] = await db.runSql(
+      `
+        SELECT COUNT(*) as count
+        FROM user_client_accents
+        WHERE locale_id=? AND accent_id=?
+      `,
+      [locale_id, accent_id]
+    )
+
+    if (Number(count) === 0) {
+      await db.runSql(`DELETE FROM accents WHERE id=? LIMIT 1`, [accent_id])
+    }
+  }
+}

--- a/server/src/lib/model/db/migration-helpers/accents-variants/locales/index.ts
+++ b/server/src/lib/model/db/migration-helpers/accents-variants/locales/index.ts
@@ -1,0 +1,1 @@
+export * from './default'

--- a/server/src/lib/model/db/migration-helpers/accents-variants/types.ts
+++ b/server/src/lib/model/db/migration-helpers/accents-variants/types.ts
@@ -1,0 +1,2 @@
+// array of tuples [accent_token, variant_token]
+export type AV_MAPPING_TYPE = [string, string][]

--- a/server/src/lib/model/db/migration-helpers/accents-variants/users.ts
+++ b/server/src/lib/model/db/migration-helpers/accents-variants/users.ts
@@ -1,0 +1,28 @@
+// Eligibility criteria
+// - users who already have variants set -> skip
+// - users with exactly one predefined accent (excluding default "unspecified") matching the mapping -> migrate
+// - users with multiple predefined accents -> skip
+// - users with only user-submitted accents -> skip
+export const findEligibleUsersForAccentVariantMigration = async (
+  db: any,
+  locale_id: number,
+  accent_id: number,
+): Promise<string[] | null> => {
+  const rows: { client_id: string }[] = await db.runSql(
+    `
+      SELECT DISTINCT uca.client_id
+      FROM user_client_accents uca
+      JOIN accents a ON uca.accent_id = a.id
+      LEFT JOIN user_client_variants ucv
+        ON uca.client_id = ucv.client_id AND ucv.locale_id = ?
+      WHERE uca.locale_id = ?
+      GROUP BY uca.client_id
+      HAVING
+        COUNT(DISTINCT CASE WHEN a.user_submitted=0 AND a.accent_token != 'unspecified' THEN uca.accent_id END) = 1
+        AND SUM(CASE WHEN a.user_submitted=0 AND a.accent_token != 'unspecified' AND uca.accent_id = ? THEN 1 ELSE 0 END) = 1
+        AND COUNT(DISTINCT ucv.id) = 0
+    `,
+    [locale_id, locale_id, accent_id])
+  if (!rows || rows.length === 0) return null
+  return rows.map((row) => row.client_id)
+}

--- a/server/src/lib/model/db/migration-helpers/accents-variants/variants.ts
+++ b/server/src/lib/model/db/migration-helpers/accents-variants/variants.ts
@@ -1,0 +1,46 @@
+export const findVariantIdFromToken = async (
+  db: any,
+  locale_id: number,
+  variant_token: string
+): Promise<number | null> => {
+  const [result] = await db.runSql(
+    `
+      SELECT id
+      FROM variants
+      WHERE locale_id = ?
+        AND variant_token = ?
+    `,
+    [locale_id, variant_token]
+  )
+  return result?.id ? result.id : null
+}
+
+export const createNewUserVariantRecord = async (
+  db: any,
+  client_id: string,
+  locale_id: number,
+  variant_id: number
+) => {
+  await db.runSql(
+    `
+      INSERT INTO user_client_variants (client_id, locale_id, variant_id)
+      VALUES (?, ?, ?)
+    `,
+    [client_id, locale_id, variant_id]
+  )
+}
+
+export const bulkInsertUserVariants = async (
+  db: any,
+  locale_id: number,
+  variant_id: number,
+  clientIdBatch: string[]
+): Promise<any> => {
+  await db.runSql(
+    `
+      INSERT IGNORE INTO user_client_variants (client_id, locale_id, variant_id)
+      VALUES ${clientIdBatch.map(() => '(?, ?, ?)').join(',')}
+    `,
+    clientIdBatch.flatMap(id => [id, locale_id, variant_id])
+  )
+}

--- a/server/src/lib/model/db/migration-helpers/common/index.ts
+++ b/server/src/lib/model/db/migration-helpers/common/index.ts
@@ -1,0 +1,1 @@
+export * from './locales'

--- a/server/src/lib/model/db/migration-helpers/common/locales.ts
+++ b/server/src/lib/model/db/migration-helpers/common/locales.ts
@@ -1,0 +1,9 @@
+export const findLocaleIdFromLocaleCode = async (
+  db: any,
+  locale: string
+): Promise<number | null> => {
+  const [result] = await db.runSql(`SELECT id FROM locales WHERE name = ?`, [
+    locale,
+  ])
+  return result?.id ? result.id : null
+}

--- a/server/src/lib/model/db/migration-helpers/index.ts
+++ b/server/src/lib/model/db/migration-helpers/index.ts
@@ -1,0 +1,2 @@
+export * from './common'
+export * from './accents-variants'

--- a/server/src/lib/model/db/migrations/20250801130000-migrate-accents-variants-ga-ie.ts
+++ b/server/src/lib/model/db/migrations/20250801130000-migrate-accents-variants-ga-ie.ts
@@ -4,23 +4,25 @@
 // - Replicate data in local dev environment
 // - Do extensive testing
 // For special cases, one should duplicate migrateAccentsToVariants_default => migrateAccentsToVariants_language_code and work on it
-import { AV_MAPPING_TYPE, migrateAccentsToVariants_default } from '../migration-helpers'
+import {
+  AV_MAPPING_TYPE,
+  migrateAccentsToVariants_default,
+} from '../migration-helpers'
 
 const LOCALE_CODE = 'ga-IE'
 
 // MAPPING: [accent_token, variant_token]
 // These are 1-to-1 mappings
 const MAPPING: AV_MAPPING_TYPE = [
-  ["connachta", "ga-IE-chonnact"],
-  ["mumhain", "ga-IE-mumhan"],
-  ["ulaidh", "ga-IE-uladh"]
+  ['connachta', 'ga-IE-chonnact'],
+  ['mumhain', 'ga-IE-mumhan'],
+  ['ulaidh', 'ga-IE-uladh'],
 ]
 
 //
 // Do not change the code below unless database structure has been changed
 //
 export const up = async function (db: any): Promise<any> {
-  // Find locale id
   return await migrateAccentsToVariants_default(db, LOCALE_CODE, MAPPING)
 }
 

--- a/server/src/lib/model/db/migrations/20250801130000-migrate-accents-variants-ga-ie.ts
+++ b/server/src/lib/model/db/migrations/20250801130000-migrate-accents-variants-ga-ie.ts
@@ -1,0 +1,30 @@
+// Handles Accent => Variant migrations for `ga-IE`
+// Should not be re-used directly for other locales. Suggested steps:
+// - Get statistics from live data
+// - Replicate data in local dev environment
+// - Do extensive testing
+// For special cases, one should duplicate migrateAccentsToVariants_default => migrateAccentsToVariants_language_code and work on it
+import { AV_MAPPING_TYPE, migrateAccentsToVariants_default } from '../migration-helpers'
+
+const LOCALE_CODE = 'ga-IE'
+
+// MAPPING: [accent_token, variant_token]
+// These are 1-to-1 mappings
+const MAPPING: AV_MAPPING_TYPE = [
+  ["connachta", "ga-IE-chonnact"],
+  ["mumhain", "ga-IE-mumhan"],
+  ["ulaidh", "ga-IE-uladh"]
+]
+
+//
+// Do not change the code below unless database structure has been changed
+//
+export const up = async function (db: any): Promise<any> {
+  // Find locale id
+  return await migrateAccentsToVariants_default(db, LOCALE_CODE, MAPPING)
+}
+
+export const down = async function (): Promise<any> {
+  // We cannot take it back
+  return null
+}


### PR DESCRIPTION
This PR adds generic migration helper code for migrating old accents to new variants, and applies it to Irish `ga-IE` case, to fulfill the request in https://github.com/common-voice/common-voice/issues/4993

The code is generic, but should not be reused without extensive testing in local development environment.
