### PR TITLE
Fix: Preserve locale when redirecting to spontaneous speech page

### DIFF
--- a/web/src/components/layout/nav/contribute-menu/menu-item-renderer.tsx
+++ b/web/src/components/layout/nav/contribute-menu/menu-item-renderer.tsx
@@ -1,19 +1,20 @@
-import * as React from 'react'
-import { Localized, WithLocalizationProps } from '@fluent/react'
-import classNames from 'classnames'
-import { Tooltip } from 'react-tooltip'
+import * as React from 'react';
+import { Localized, WithLocalizationProps } from '@fluent/react';
+import classNames from 'classnames';
+import { Tooltip } from 'react-tooltip';
+import { useParams } from 'react-router-dom'; //  ADDED for locale
 
-import { ContributeMenuItem } from '.'
-import { LocaleLink } from '../../../locale-helpers'
-import URLS from '../../../../urls'
+import { ContributeMenuItem } from '.';
+import { LocaleLink } from '../../../locale-helpers';
+import URLS from '../../../../urls';
 
 type Props = {
-  item: ContributeMenuItem
-  toggleMenu?: () => void
-  isLocaleContributable: boolean
-} & WithLocalizationProps
+  item: ContributeMenuItem;
+  toggleMenu?: () => void;
+  isLocaleContributable: boolean;
+} & WithLocalizationProps;
 
-const smallTagRegex = /\s*<small>.*?<\/small>/g
+const smallTagRegex = /\s*<small>.*?<\/small>/g;
 
 export const MenuItemRenderer = ({
   item,
@@ -21,6 +22,8 @@ export const MenuItemRenderer = ({
   getString,
   toggleMenu,
 }: Props) => {
+  const { locale } = useParams(); //  Extract locale from the URL
+
   const {
     internalHref,
     externalHref,
@@ -28,10 +31,11 @@ export const MenuItemRenderer = ({
     icon: Icon,
     menuItemTooltip,
     menuItemAriaLabel,
-  } = item
-  const isComingSoon = !(internalHref || externalHref)
+  } = item;
+
+  const isComingSoon = !(internalHref || externalHref);
   const isSpeakOrListenUrl =
-    internalHref === URLS.SPEAK || internalHref === URLS.LISTEN
+    internalHref === URLS.SPEAK || internalHref === URLS.LISTEN;
 
   const renderContent = () => {
     if (!isLocaleContributable && isSpeakOrListenUrl) {
@@ -40,23 +44,25 @@ export const MenuItemRenderer = ({
           <Icon />
           <Localized
             id={`${localizedId}-coming-soon`}
-            elems={{ small: <span /> }}>
+            elems={{ small: <span /> }}
+          >
             <p className="coming-soon-text" />
           </Localized>
         </>
-      )
+      );
     }
 
     if (internalHref) {
       return (
         <LocaleLink
-          to={internalHref}
+          to={`/${locale}${internalHref}`} //  FIXED: prepend locale
           className="contribute-link"
-          onClick={toggleMenu}>
+          onClick={toggleMenu}
+        >
           <Icon />
           <Localized id={localizedId} />
         </LocaleLink>
-      )
+      );
     }
 
     if (externalHref) {
@@ -66,13 +72,14 @@ export const MenuItemRenderer = ({
           target="_blank"
           rel="noreferrer"
           className="contribute-link"
-          onClick={toggleMenu}>
+          onClick={toggleMenu}
+        >
           <Icon />
           {getString(localizedId).replace(smallTagRegex, '')}
         </a>
-      )
+      );
     }
-  }
+  };
 
   return (
     <React.Fragment key={localizedId}>
@@ -81,7 +88,8 @@ export const MenuItemRenderer = ({
           className={classNames('content', {
             'coming-soon':
               isComingSoon || (!isLocaleContributable && isSpeakOrListenUrl),
-          })}>
+          })}
+        >
           {renderContent()}
         </div>
       </li>
@@ -94,10 +102,11 @@ export const MenuItemRenderer = ({
             maxWidth: '350px',
             position: 'absolute',
           }}
-          openEvents={{ mouseover: true }}>
+          openEvents={{ mouseover: true }}
+        >
           {getString(menuItemTooltip)}
         </Tooltip>
       </div>
     </React.Fragment>
-  )
-}
+  );
+};


### PR DESCRIPTION
## Pull Request Form

<!-- Thanks for making a contribution to Common Voice, to help us review the request please fill out this form -->

### Type of Pull Request

-  Bug fix(x)
-  Bulk sentence upload
-  Related to a listed issue
-  Other: UX improvement in locale persistence(x)

### Description of the Pull Request

This PR ensures that the user's selected locale is preserved when navigating to the Spontaneous Speech contribution page (`/speak` or `/listen`). Previously, the locale context was lost, causing redirection to the default language instead of the selected one (e.g., `en`, `te`, etc.).

- Introduced `useParams()` from `react-router-dom` to dynamically extract locale from the URL.
- Updated `internalHref` routes in `<LocaleLink>` to prepend the extracted locale.
- Verified navigation preserves the correct locale when switching between menu items.

### Acknowledging contributors

This fix was independently researched and implemented by [Naveen Chaitanya](https://github.com/NaveenKancharla28), based on user reports and personal debugging. Thanks to the Common Voice community for the opportunity to contribute!
