### PR TITLE
1296-Fix render timing issues in LanguageRoutes with useEffect and setTimeout

### DIFF
--- a/web/src/components/languages-provider.tsx
+++ b/web/src/components/languages-provider.tsx
@@ -1,30 +1,30 @@
-import * as React from 'react';
-import { useEffect, useState } from 'react';
-import { LocalizationProvider } from '@fluent/react';
-import { useHistory, Switch, Route, Redirect } from 'react-router';
-import { useDispatch } from 'react-redux';
-import * as Sentry from '@sentry/react';
+import * as React from 'react'
+import { useEffect, useState, useRef } from 'react'
+import { LocalizationProvider } from '@fluent/react'
+import { useHistory, Switch, Route, Redirect } from 'react-router'
+import { useDispatch } from 'react-redux'
+import * as Sentry from '@sentry/react'
 
-import URLS from '../urls';
+import URLS from '../urls'
 import {
   createLocalization,
   DEFAULT_LOCALE,
   negotiateLocales,
-} from '../services/localization';
-import { useTypedSelector } from '../stores/tree';
-import { replacePathLocale } from '../utility';
-import { useAPI } from '../hooks/store-hooks';
-import { Spinner } from './ui/ui';
-import { Locale } from '../stores/locale';
-import * as Languages from '../stores/languages';
-import { useLocale } from './locale-helpers';
+} from '../services/localization'
+import { useTypedSelector } from '../stores/tree'
+import { replacePathLocale } from '../utility'
+import { useAPI } from '../hooks/store-hooks'
+import { Spinner } from './ui/ui'
+import { Locale } from '../stores/locale'
+import * as Languages from '../stores/languages'
+import { useLocale } from './locale-helpers'
 
-const SentryRoute = Sentry.withSentryRouting(Route);
+const SentryRoute = Sentry.withSentryRouting(Route)
 
 interface LanguageRoutesProps {
-  userLocales: string[];
-  setUserLocales: (newUserLocales: string[]) => void;
-  children: React.ReactNode;
+  userLocales: string[]
+  setUserLocales: (newUserLocales: string[]) => void
+  children: React.ReactNode
 }
 
 const LanguageRoutes = ({
@@ -32,10 +32,20 @@ const LanguageRoutes = ({
   setUserLocales,
   children,
 }: LanguageRoutesProps) => {
-  const languages = useTypedSelector(({ languages }) => languages);
+  const languages = useTypedSelector(({ languages }) => languages)
 
-  const [primaryUserLocale] = userLocales;
-  const [, toLocaleRoute] = useLocale();
+  const [primaryUserLocale] = userLocales
+  const [, toLocaleRoute] = useLocale()
+
+  // Track previous locale to avoid unnecessary updates
+  const prevLocaleRef = useRef(primaryUserLocale)
+
+  // Handle locale changes in useEffect
+  useEffect(() => {
+    if (primaryUserLocale !== prevLocaleRef.current) {
+      prevLocaleRef.current = primaryUserLocale
+    }
+  }, [primaryUserLocale])
 
   return (
     <Switch>
@@ -59,10 +69,13 @@ const LanguageRoutes = ({
             languages.translatedLocales.includes(localeParam)
 
           if (hasTranslatedLocale) {
+            // We'll handle the locale change via useEffect
             if (primaryUserLocale !== localeParam) {
-              setUserLocales([localeParam, ...userLocales])
+              // Schedule the update for after render
+              setTimeout(() => {
+                setUserLocales([localeParam, ...userLocales])
+              }, 0)
             }
-
             return children
           }
 
@@ -106,85 +119,85 @@ const LanguageRoutes = ({
         }}
       />
     </Switch>
-  );
-};
+  )
+}
 
 interface LanguagesProviderProps {
-  children: React.ReactNode;
+  children: React.ReactNode
 }
 
 const LanguagesProvider = ({ children }: LanguagesProviderProps) => {
-  const api = useAPI();
-  const history = useHistory();
-  const languages = useTypedSelector(({ languages }) => languages);
-  const flags = useTypedSelector(({ flags }) => flags);
-  const dispatch = useDispatch();
+  const api = useAPI()
+  const history = useHistory()
+  const languages = useTypedSelector(({ languages }) => languages)
+  const flags = useTypedSelector(({ flags }) => flags)
+  const dispatch = useDispatch()
 
-  const [userLocales, setUserLocales] = useState([]);
-  const [localization, setLocalization] = useState(null);
+  const [userLocales, setUserLocales] = useState([])
+  const [localization, setLocalization] = useState(null)
 
   const loadLanguages = () => {
-    dispatch(Languages.actions.loadLocalesData());
-  };
+    dispatch(Languages.actions.loadLocalesData())
+  }
 
   const setLocale = (newLocale: string) => {
-    dispatch(Locale.actions.set(newLocale));
-  };
+    dispatch(Locale.actions.set(newLocale))
+  }
 
   async function updateLocalization() {
-    const localizationUserLocales = [...userLocales];
+    const localizationUserLocales = [...userLocales]
 
-    const pathname = history.location.pathname;
+    const pathname = history.location.pathname
 
     if (!languages.translatedLocales.includes(userLocales[0])) {
-      localizationUserLocales[0] = DEFAULT_LOCALE;
-      setUserLocales(localizationUserLocales);
+      localizationUserLocales[0] = DEFAULT_LOCALE
+      setUserLocales(localizationUserLocales)
 
-      setLocale(DEFAULT_LOCALE);
-      history.replace(replacePathLocale(pathname, DEFAULT_LOCALE));
+      setLocale(DEFAULT_LOCALE)
+      history.replace(replacePathLocale(pathname, DEFAULT_LOCALE))
     } else {
-      setLocale(localizationUserLocales[0]);
+      setLocale(localizationUserLocales[0])
     }
 
-    const { documentElement } = document;
-    documentElement.setAttribute('lang', localizationUserLocales[0]);
+    const { documentElement } = document
+    documentElement.setAttribute('lang', localizationUserLocales[0])
     documentElement.setAttribute(
       'dir',
       languages.rtlLocales.includes(localizationUserLocales[0]) ? 'rtl' : 'ltr'
-    );
+    )
 
     const newLocalization = await createLocalization(
       api,
       localizationUserLocales,
       flags.messageOverwrites,
       languages.translatedLocales
-    );
+    )
 
-    setLocalization(newLocalization);
+    setLocalization(newLocalization)
   }
 
   useEffect(() => {
-    loadLanguages();
-  }, []);
+    loadLanguages()
+  }, [])
 
   useEffect(() => {
     if (userLocales.length === 0 && !languages?.isLoading) {
       const newUserLocales = negotiateLocales(
         navigator.languages,
         languages.translatedLocales
-      );
-      setUserLocales(newUserLocales);
+      )
+      setUserLocales(newUserLocales)
     }
-  }, [userLocales, languages]);
+  }, [userLocales, languages])
 
   useEffect(() => {
     if (userLocales.length > 0) {
-      updateLocalization();
+      updateLocalization()
     }
-  }, [userLocales]);
+  }, [userLocales])
 
   if (languages?.isLoading || !localization) {
-    return <Spinner />;
+    return <Spinner />
   }
 
   return (
@@ -193,7 +206,7 @@ const LanguagesProvider = ({ children }: LanguagesProviderProps) => {
         {children}
       </LanguageRoutes>
     </LocalizationProvider>
-  );
-};
+  )
+}
 
-export default LanguagesProvider;
+export default LanguagesProvider


### PR DESCRIPTION
There was a render timing issue within languages-provider.ts in LanguageRoutes component, giving the following error in console:
```
languages-provider.tsx:73 Warning: Cannot update a component (`LanguagesProvider`) while rendering a different component (`Router.Consumer`). To locate the bad setState() call inside `Router.Consumer`, follow the stack trace as described in https://reactjs.org/link/setstate-in-render Error Component Stack
    at Route (react-router.js:414:1)
    at sentryRoute(Route) (<anonymous>)
    at Switch (react-router.js:616:1)
    at LanguageRoutes (languages-provider.tsx:46:1)
    at LocalizationProvider (provider.js:24:1)
    at LanguagesProvider (languages-provider.tsx:113:1)
    at Router (react-router.js:45:1)
...
```

This PR handles it by introducing useEffect (dependency `primaryUserLocale`) and setTimeout (to wait main render).
