### PR TITLE
1295-Workaround for picker not showing all locale names

### DIFF
--- a/web/src/components/localization-select/localization-select-complex.tsx
+++ b/web/src/components/localization-select/localization-select-complex.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { useSelect } from 'downshift'
 import classNames from 'classnames'
+import { useLocalization } from '@fluent/react'
 
 import {
   LocalizedGetAttribute,
@@ -52,6 +53,7 @@ const LocalizationSelectComplex = ({
     }
   }
 
+  const { l10n } = useLocalization()
   const availableLocales = useAvailableLocales()
   const availableLocalesWithNames = getAvailableLocalesWithNames()
   const { abortStatus } = useAbortContributionModal()
@@ -103,34 +105,41 @@ const LocalizationSelectComplex = ({
           </button>
           <div className="list-wrapper">
             <ul {...getMenuProps()}>
-              {items.map((item, index) => (
-                <div
-                  key={item}
-                  className={classNames('list-item-wrapper', {
-                    highlighted: index === highlightedIndex,
-                    selecteduserlanguage:
-                      userLanguages &&
-                      userLanguages.length > 0 &&
-                      index <= userLanguages.length - 1 &&
-                      item === locale,
-                    lastuserlanguage:
-                      userLanguages &&
-                      userLanguages.length > 0 &&
-                      index === userLanguages.length - 1,
-                  })}>
-                  <li {...getItemProps({ item })}>
-                    {getLocaleWithName(item).name}
-                  </li>
-                  {item === locale && (
-                    <img
-                      src={require('../../components/ui/icons/checkmark-green.svg')}
-                      alt=""
-                      width={24}
-                      height={24}
-                    />
-                  )}
-                </div>
-              ))}
+              {items.map((item, index) => {
+                const itemWithName = getLocaleWithName(item)
+                return (
+                  <div
+                    key={item}
+                    className={classNames('list-item-wrapper', {
+                      highlighted: index === highlightedIndex,
+                      selecteduserlanguage:
+                        userLanguages &&
+                        userLanguages.length > 0 &&
+                        index <= userLanguages.length - 1 &&
+                        item === locale,
+                      lastuserlanguage:
+                        userLanguages &&
+                        userLanguages.length > 0 &&
+                        index === userLanguages.length - 1,
+                    })}>
+                    <li {...getItemProps({ item })}>
+                      {itemWithName.code === itemWithName.name
+                        ? `${l10n.getString(itemWithName.code)} (${
+                            itemWithName.name
+                          })`
+                        : itemWithName.name}
+                    </li>
+                    {item === locale && (
+                      <img
+                        src={require('../../components/ui/icons/checkmark-green.svg')}
+                        alt=""
+                        width={24}
+                        height={24}
+                      />
+                    )}
+                  </div>
+                )
+              })}
             </ul>
           </div>
         </div>

--- a/web/src/components/localization-select/localization-select.css
+++ b/web/src/components/localization-select/localization-select.css
@@ -89,7 +89,7 @@
         font-size: var(--font-size);
         text-overflow: ellipsis;
         overflow-x: hidden;
-        text-transform: capitalize;
+        /* text-transform: capitalize; */
         cursor: pointer;
         line-height: 24px;
         letter-spacing: 0.8px;


### PR DESCRIPTION
The language picker shows native language names, but if the translators did not translate the language name in Pontoon (yet), they are shown as language codes.

In this PR, we check if the name = code and show them as localized strings: In the current selected language, if exists - else English name will be fallback. We also show the language code in parenthesis so that native speakers can also locate them from the code.

Example below shows some examples in Turkish interface.

<img width="246" height="324" alt="image" src="https://github.com/user-attachments/assets/41fc408f-1057-413a-84fe-8cba93c2882d" />

Whenever they get translated in respective locales, the new native values will be shown (after a production release).

For more info see item no 5 in internal issue 1292.
