### PR TITLE
1311-Fix nested translation caused by getstring+withLocalization

### DIFF
--- a/web/src/components/pages/profile/api-credentials/components/api-credential-display.tsx
+++ b/web/src/components/pages/profile/api-credentials/components/api-credential-display.tsx
@@ -28,7 +28,7 @@ const ApiCredentialDisplay = ({
 
   return (
     <div className="api-key-display-wrapper">
-      <span className="api-key-label">{getString(label)}</span>
+      <span className="api-key-label">{label}</span>
 
       <div
         className={classNames('api-key-container', {


### PR DESCRIPTION
This is in Profile page API tab, when you create your API credentials.
In ApiCredentialDisplay sub-component, getString is used but the component is also wrapped in withLocalization...