### PR TITLE
1325-Increase default LazyCache lock duration as a workaround

### DIFF
--- a/server/src/lib/lazy-cache.ts
+++ b/server/src/lib/lazy-cache.ts
@@ -99,13 +99,13 @@ function redisCache<T, S>(
   }
 }
 
-// TODO: The lock duration of 3 minutes is conservative
-// After measuring per query performance and adding lock durations to calling functions, drop it to 30 sec
+// TODO: The lock duration of 5 minutes is conservative
+// After measuring per query performance & optimizing and adding lock durations to calling functions, drop it
 export default function lazyCache<T, S>(
   cacheKey: string,
   f: Fn<T, S>,
   timeMs: number,
-  lockDurationMs = 3 * TimeUnits.MINUTE // TODO: drop this to 30 sec after finetuning
+  lockDurationMs = 5 * TimeUnits.MINUTE // TODO: Make sure each query calls with parameter, then drop this after finetuning
 ): Fn<T, S> {
   const memCache = memoryCache(f, timeMs)
   return async (...args: S[]) =>


### PR DESCRIPTION
When people are getting variant-only clips, the query takes longer than expected, thus Redis based LazyCache default lock duration of 3 minutes was not enough, causing lock-release issues.
With this workaround, we increase the lock duration to 5 minutes, until the related queries are more optimized.
