### PR TITLE
1306-Remove duplicate language code key definitions in SS .ftl

### DIFF
--- a/web/locales/spontaneous-speech/en/pages/common.ftl
+++ b/web/locales/spontaneous-speech/en/pages/common.ftl
@@ -46,22 +46,9 @@ not-found-page-content = The page you are looking for could not be found
 # Privacy and Terms checkbox
 accept-privacy-and-terms = I agree to Common Voice's <termsLink>Terms</termsLink> and <privacyLink>Privacy Notice</privacyLink>
 
-# Locales
-bsy = Sabah Bisaya
-cdo = Fuzhou
-cpx = Heng Hua
-hch = Wixarika
-kzi = Kelabit
-mbf = Baba Malay
+# Locales (not yet fully resolved in Pontoon)
 meh = Southwestern Tlaxiaco Mixtec
 mel = Central Melanau
-mmc = Michoacán Mazahua
-msi = Sabah Malay
-pez = Eastern Penan
-pne = Western Penan
-sdo = Serian Bidayuh
-snv = Sa'ban
-xkl = Kenyah
 
 # Locales-Variants
 ms-MY = Bahasa Malay


### PR DESCRIPTION
Removing language keys in SS, which already exist in Pontoon, thus in CV. Still two to go.

These have already been cross-checked/approved in internal issue 1306.
