### PR TITLE
docker-compose: Expose redis port to localhost

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,6 +20,8 @@ services:
     restart: unless-stopped
     networks:
       - voice-web
+    ports:
+      - 6379:6379
   storage:
     image: fsouza/fake-gcs-server
     container_name: storage


### PR DESCRIPTION
This exposes the Redis port of the docker-compose setup. I have this set to run the occasional `flushdb`.