### PR TITLE
Fix IMPORT_LANGUAGES not working as intended when unset

### DIFF
--- a/server/src/lib/model/db/import-sentences.ts
+++ b/server/src/lib/model/db/import-sentences.ts
@@ -145,7 +145,7 @@ async function importLocaleSentences(
   });
 }
 
-export async function importSentences(pool: any, import_languages: string) {
+export async function importSentences(pool: any, import_languages: string[]) {
   // Decide on which locales to import.
   // If no IMPORT_LANGUAGES specified, all from the file system, else the intersection.
   function getImportableLanguages(
@@ -179,10 +179,7 @@ export async function importSentences(pool: any, import_languages: string) {
   )
 
   // filter them with IMPORT_LANGUAGES config value if specified
-  const importable_locales = getImportableLanguages(
-    fsLocales,
-    import_languages.trim().split(',')
-  )
+  const importable_locales = getImportableLanguages(fsLocales, import_languages)
   print(
     `Final import list: ${importable_locales.length} [${importable_locales.join(
       ','

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -249,9 +249,10 @@ export default class Server {
       // directly add sentences on the CV platform. However, it is still
       // valuable to set up a local development environment.
       if ('local' == getConfig().ENVIRONMENT && getConfig().IMPORT_SENTENCES) {
+        const import_languages = getConfig().IMPORT_LANGUAGES;
         await importSentences(
           await this.model.db.mysql.createPool(),
-          getConfig().IMPORT_LANGUAGES
+          import_languages ? import_languages.trim().split(',') : [],
         )
       }
 


### PR DESCRIPTION
## Pull Request Form

<!-- Thanks for making a contribution to Common Voice, to help us review the request please fill out this form -->

### Type of Pull Request

<!-- To help us understand your pull request, choose the checkboxes most relevant to your request by filling out the checkboxes with [x] here -->

- [x] Bugfix

<!--- Please describe the pull request-->

According to the comment on `importSentences()`: `If no IMPORT_LANGUAGES specified, all from the file system, else the intersection.`
This condition is implemented by checking the length of the array from splitting IMPORT_LANGUAGES string.
However, this array is produced by `trim().split(',')`. In Javascript, splitting a string which does not contain the separator yields an array with the original string as only element. This causes `[""]` to be used as set of languages, which fails to import anything.