### PR TITLE
1385-Add /languagedata endpoint and remove predefined accents endpoint

### DIFF
--- a/common/language.ts
+++ b/common/language.ts
@@ -1,38 +1,38 @@
 // a single accent object
 export type Accent = {
-  id: number;
-  name: string;
-  token?: string;
-  clientId?: string;
-};
+  id: number
+  name: string
+  token?: string
+  clientId?: string
+}
 
 type SentenceCount = {
-  currentCount: number;
-  targetSentenceCount: number;
-};
+  currentCount: number
+  targetSentenceCount: number
+}
 
-// a single accent object
+// a single language object
 export type Language = {
-  id: number;
-  name: string;
-  sentenceCount: SentenceCount;
-  target_sentence_count?: number;
-  is_contributable?: boolean;
-  is_translated?: boolean;
-  native_name: string;
-  text_direction: string;
-};
+  id: number
+  name: string
+  sentenceCount: SentenceCount
+  target_sentence_count?: number
+  is_contributable?: boolean
+  is_translated?: boolean
+  native_name: string
+  text_direction: string
+}
 
 // single variant object
 export type Variant = {
-  id: number;
-  locale: string;
-  name: string;
-  tag: string;
-};
+  id: number
+  locale: string
+  name: string
+  tag: string
+}
 
 export type UserVariant = Variant & {
-  is_preferred_option: boolean;
+  is_preferred_option: boolean
 }
 
 /*
@@ -40,7 +40,33 @@ export type UserVariant = Variant & {
   accent/locale/variant data for a user
 */
 export type UserLanguage = {
-  locale: string;
-  variant?: UserVariant;
-  accents?: Accent[];
-};
+  locale: string
+  variant?: UserVariant
+  accents?: Accent[]
+}
+
+// Combined Language Data
+export type VariantData = {
+  id: number
+  code: string
+  name: string
+  type?: string
+  locale_id: number
+}
+export type AccentData = {
+  id: number
+  code: string
+  name: string
+  locale_id: number
+}
+export type LanguageData = {
+  id: number
+  code: string
+  target_sentence_count?: number
+  native_name: string
+  is_contributable?: number
+  is_translated?: number
+  text_direction: string
+  variants: VariantData[]
+  predefined_accents: AccentData[]
+}

--- a/server/src/lib/api.ts
+++ b/server/src/lib/api.ts
@@ -122,7 +122,6 @@ export default class API {
     router.post('/user_client/takeout/request', this.requestTakeout)
     router.post('/user_client/takeout/:id/links', this.getTakeoutLinks)
 
-    router.get('/language/accents/predefined', this.getAllPredefinedAccents)
     router.get('/language/accents/:locale?', this.getAccents)
     router.get('/language/variants/:locale?', this.getVariants)
     router.post(
@@ -156,6 +155,7 @@ export default class API {
       validate({ query: projectSchema }),
       this.getAvailableLanguages
     )
+    router.get('/languagedata', this.getCombinedLanguageData)
     router.get('/languages', this.getAllLanguages)
     router.use('/languages/:locale', languagesRouter)
     router.get('/stats/languages/', this.getLanguageStats)
@@ -307,6 +307,10 @@ export default class API {
     } = request
     await this.model.db.createSkippedClip(id, client_id)
     response.json({})
+  }
+
+  getCombinedLanguageData = async (_request: Request, response: Response) => {
+    response.json(await this.model.getCombinedLanguageData())
   }
 
   getAllLanguages = async (_request: Request, response: Response) => {
@@ -730,11 +734,6 @@ export default class API {
   getServerDate = (request: Request, response: Response) => {
     // prevents contributors manipulating dates in client
     response.json(new Date())
-  }
-
-  getAllPredefinedAccents = async (req: Request, response: Response) => {
-    console.log('=== getAllPredefinedAccents ===')
-    response.json(await this.model.db.getAllPredefinedAccents())
   }
 
   getAccents = async (req: Request, response: Response) => {


### PR DESCRIPTION
Provides language data with variants and predefined-accents embedded under a language.
This will very much simplify language data handling in Public API and Spontaneous Speech.
Notes:
- Removes previously added /language/accents/predefined
- Specified the caching period to 6 hours to speed up new updates - it is very low cost...
