### PR TITLE
1403-Update accent-variant migration helper to add optional (do not-)delete parameter

### DIFF
--- a/server/src/lib/model/db/migration-helpers/accents-variants/types.ts
+++ b/server/src/lib/model/db/migration-helpers/accents-variants/types.ts
@@ -1,2 +1,2 @@
 // array of tuples [accent_token, variant_token]
-export type AV_MAPPING_TYPE = [string, string][]
+export type AV_MAPPING_TYPE = [string, string, boolean?][]


### PR DESCRIPTION
Adds doDelete parameter (default true) to control deletion of accents.

- When not specified or true, if the accent is not selected by any user (after migrating to variants) the accent will be deleted
- When false, the accent will not be deleted, not from user record, not totally.

This change was required in French migration, where a large list of accents are defined, variants will be defined continent/sub-continent base, and some of them would be needed to kept, but some should be deleted.

E.g. The `belgium` accent will be moved to `fr-europe` variant, but we would like to keep it as accent.
