### PR TITLE
1406-Add migration to add english_name to locale table

### DIFF
--- a/server/src/lib/model/db/migrations/20251011163000-add-english-name-to-locale-table.ts
+++ b/server/src/lib/model/db/migrations/20251011163000-add-english-name-to-locale-table.ts
@@ -1,0 +1,11 @@
+export const up = async function (db: any): Promise<any> {
+  await db.runSql(`
+    ALTER TABLE locales
+    ADD english_name VARCHAR(255) DEFAULT NULL
+    AFTER target_sentence_count
+  `)
+}
+
+export const down = async function (db: any): Promise<any> {
+  await db.runSql(`ALTER TABLE locales DROP COLUMN english_name`)
+}


### PR DESCRIPTION
This will serve external clients and front-ends providing a fallback language where the native name is not yet translated (where language code is shown in native_name field).
