### PR TITLE
1432-Create extra indexes and optimize query for top contributors (leaderboard)

### DIFF
--- a/server/src/lib/model/db/migrations/20251024000000-add-indexes-for-top-contributors.ts
+++ b/server/src/lib/model/db/migrations/20251024000000-add-indexes-for-top-contributors.ts
@@ -14,7 +14,7 @@ export const up = async function (db: any): Promise<any> {
 
 export const down = async function (db: any): Promise<any> {
   return db.runSql(`
-    ALTER TABLE user_clients DROP INDEX idx_visible;
+    ALTER TABLE user_clients DROP INDEX idx_visible_client;
     ALTER TABLE clips DROP INDEX idx_client_id_locale;
   `)
 }


### PR DESCRIPTION
The calculations were taking too long and were causing a lot of unnecessary database hits per locale.
Because every language has different number of contributors, the variance in fetch duration changes dramatically, thus caching parameters (lock duration particularly) becomes impossible to measure. It also depends on the load of the server at that time.

Therefore in this PR:
- We introduce new indexes to directly reach users (small percentage of all) to speed up queries and IO time in DB server
- We use two big queries (which we already have), extended with locale info, and extract requested subsets from it programmatically.

More info is added as comments in the code.

As a result, we plan to reduce the Redis/LazyCache related errors and bad UX in the LeaderBoard area in the Dashboard page, which people use most, especially during campaigns.
