### PR TITLE
1405-Add migration to change sentence bands of 21 locales (20251030)

### DIFF
--- a/server/src/lib/model/db/migrations/20251030010000-update-sentence-bands.ts
+++ b/server/src/lib/model/db/migrations/20251030010000-update-sentence-bands.ts
@@ -1,0 +1,26 @@
+export const up = async function (db: any): Promise<any> {
+  // BAND A (750 sentences - <1M speakers)
+  await db.runSql(
+    `
+      UPDATE locales SET target_sentence_count = 750
+      WHERE name IN (
+        'abq', 'bsy', 'gaa', 'kzi', 'mbf', 'mel', 'mfe',
+        'pau', 'pcd', 'pez', 'pne', 'qxq', 'sdo', 'snv',
+        'xdq', 'xkl', 'xsm'
+        )
+    `
+  )
+  // BAND B (2000 sentences - 1-10M speakers)
+  await db.runSql(
+    `
+      UPDATE locales SET target_sentence_count = 2000
+      WHERE name IN ( 
+        'cpx', 'glk', 'msi', 'seh'
+      )
+    `
+  )
+}
+
+export const down = async function (): Promise<any> {
+  return null
+}


### PR DESCRIPTION
This will immediately effect the Abaza (`abq`) language, because it is already translated and enabled for sentence entry as of today.
More info in internal No. 1405
