### PR TITLE
1486-Remove single-recording/sentence limitation from some locales

### DIFF
--- a/server/src/lib/model/db.ts
+++ b/server/src/lib/model/db.ts
@@ -42,7 +42,8 @@ const EXTRA_COUNT_MULTIPLIER = 10
 // Ref JIRA ticket OI-1300 - we want to exclude languages with fewer than 500k active global speakers
 // from the single sentence record limit, because they are unlikely to amass enough unique speakers
 // to benefit from single sentence constraints
-const SINGLE_SENTENCE_LIMIT = ['en', 'de', 'fr', 'kab', 'rw', 'es']
+// const SINGLE_SENTENCE_LIMIT = ['en', 'de', 'fr', 'kab', 'rw', 'es'] // these values are from 5 years ago
+const SINGLE_SENTENCE_LIMIT = ['de', 'fr', 'rw']
 
 const teammate_subquery =
   '(SELECT team_id FROM enroll e LEFT JOIN challenges c ON e.challenge_id = c.id WHERE e.client_id = ? AND c.url_token = ?)'


### PR DESCRIPTION
Remove en, es, kab from single recording per sentence limitation, they are out of sentences.
