### PR TITLE
Install CorporaCreator v1.3.0

### DIFF
--- a/bundler/Dockerfile
+++ b/bundler/Dockerfile
@@ -17,9 +17,9 @@ WORKDIR /home/node
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 RUN git clone --depth 1 -b release-v1.0.0 https://github.com/common-voice/mp3-duration-reporter.git
 RUN cd mp3-duration-reporter && /home/node/.cargo/bin/cargo install --path .
-RUN git clone --depth 1 -b release-v1.2.1 https://github.com/common-voice/CorporaCreator.git
-RUN pip3 install numpy
-RUN cd CorporaCreator && python3 setup.py install --user
+RUN git clone --depth 1 -b release-v1.3.0 https://github.com/common-voice/CorporaCreator.git
+RUN pip3 install --upgrade pip setuptools wheel
+RUN cd CorporaCreator && pip3 install --user .
 
 ENV PATH "$PATH:/home/node/.local/bin/:/home/node/.cargo/bin"
 ENV npm_config_cache "/home/node/"


### PR DESCRIPTION
Version 1.3.0 of CorporaCreator fixes its dependency definitions so that it builds with pandas 2.x.

We also install via the new `pip install` command as `pip install setup.py` is deprecated as per PEP517/518.
