### PR TITLE
1513-Update sentence bands of 4 languages

### DIFF
--- a/server/src/lib/model/db/migrations/20260116160000-update-sentence-bands.ts
+++ b/server/src/lib/model/db/migrations/20260116160000-update-sentence-bands.ts
@@ -1,20 +1,12 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 export const up = async function (db: any): Promise<any> {
   // BAND A (750 sentences - <1M speakers)
   await db.runSql(
     `
       UPDATE locales SET target_sentence_count = 750
       WHERE name IN (
-        'aii', 'efk'
+        'aii', 'efk', 'laj', 'tum'
         )
-    `
-  )
-  // BAND B (2000 sentences - 1-10M speakers)
-  await db.runSql(
-    `
-      UPDATE locales SET target_sentence_count = 2000
-      WHERE name IN ( 
-        'laj', 'tum'
-      )
     `
   )
 }


### PR DESCRIPTION
New `aii`, `efk`, `laj`, `tum` languages are set to Band A (750 sentences)