### PR TITLE
1518-Update Dockerfile to use corepack...

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Enable Corepack for Yarn (built into Node.js)
-RUN corepack enable && corepack prepare yarn@stable --activate
+RUN corepack enable && corepack prepare yarn@1.22.22 --activate
 
 # Prepare for nonroot user
 RUN groupadd -g $GID app; \


### PR DESCRIPTION
... instead of deprecated pubkey method for yarn

Starting early today, because GPG keys expired CI does not work on GitHub.
