### PR TITLE
1534-Add prefetching to statistics

### DIFF
--- a/server/src/lib/model/statistics.ts
+++ b/server/src/lib/model/statistics.ts
@@ -277,7 +277,9 @@ export const getStatistics = lazyCache(
     }
   },
   TimeUnits.DAY,
-  5 * TimeUnits.MINUTE
+  12 * TimeUnits.HOUR,
+  false, // no stale data
+  { prefetch: true, prefetchBefore: 2 * TimeUnits.HOUR } // Prefetch 2h before expiry (16% of TTL)
 )
 
 export const formatMetadataStatistics = (
@@ -378,5 +380,7 @@ export const getMetadataQueryHandler = lazyCache(
   'get-stats-metadata',
   getMetadataQueryHandlerImpl,
   TimeUnits.DAY,
-  10 * TimeUnits.MINUTE
+  12 * TimeUnits.HOUR,
+  false, // no stale data
+  { prefetch: true, prefetchBefore: 2 * TimeUnits.HOUR } // Prefetch 2h before expiry (16% of TTL)
 )


### PR DESCRIPTION
These endpoints are cached for 24 hours, but are not used frequently. When a user hits these endpoints, because the calculations take long, a timeout occurs.
This PR adds pre-fetching (2h before) so that the data is live (about 22+ hours).
