### PR TITLE
Fix for listen page regression

### DIFF
--- a/web/src/components/pages/contribution/listen/listen.tsx
+++ b/web/src/components/pages/contribution/listen/listen.tsx
@@ -390,8 +390,10 @@ class ListenPage extends React.Component<Props, State> {
               when={() => {
                 // Only show warning if there are clips loaded AND votes that haven't been submitted yet
                 // After submission (isSubmitted=true), user can safely refresh
+                // Don't warn when clips are exhausted (no more to validate) — user must be able to leave freely
                 const isUnvalidatedClips =
                   !isSubmitted &&
+                  !isMissingClips &&
                   clips.length > 0 &&
                   clips.some(clip => clip.isValid !== null)
 


### PR DESCRIPTION
Add no-more-clips condition to not show warning dialog (regression)