### PR TITLE
enh: self hosting

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,8 @@ services:
       - MYSQL_USER=voicecommons
       - MYSQL_PASSWORD=voicecommons
       - MYSQL_ROOT_PASSWORD=voicewebroot
+    volumes:
+      - ./docker/mysql-data:/var/lib/mysql
     command: mysqld --sql_mode="STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
   redis:
     image: redis:alpine

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,8 +12,6 @@ services:
       - MYSQL_PASSWORD=voicecommons
       - MYSQL_ROOT_PASSWORD=voicewebroot
     command: mysqld --sql_mode="STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
-    ports:
-      - 3306:3306
   redis:
     image: redis:alpine
     container_name: redis
@@ -23,8 +21,6 @@ services:
   storage:
     image: fsouza/fake-gcs-server
     container_name: storage
-    ports:
-      - 8080:8080
     networks:
       - voice-web
     command:
@@ -52,8 +48,6 @@ services:
       - ./bundler:/home/node/code
     networks:
       - voice-web
-    ports:
-      - 9001:9001
     command: bash -c "npm ci && npm run build && npm start"
   web:
     build:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,8 @@
 services:
+  # To enable speaking for a locale: sudo docker exec db mysql -uvoicecommons -pvoicecommons voiceweb -e "UPDATE locales SET is_contributable=1 WHERE name='fr';"
+  # then:
+  # sudo docker exec -it redis redis-cli FLUSHALL
+  # sudo docker restart web
   db:
     image: mysql:8.0.31
     networks:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,7 +45,7 @@ services:
       - redis
       - storage
     volumes:
-      - ./bundler:/home/node/code
+      - ./bundler:/code
     networks:
       - voice-web
     command: bash -c "npm ci && npm run build && npm start"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,6 +27,8 @@ services:
   storage:
     image: fsouza/fake-gcs-server
     container_name: storage
+    volumes:
+      - ./docker/voice-clips:/storage/common-voice-clips
     networks:
       - voice-web
     command:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -256,11 +256,11 @@ yarn lint
 
 ## Authentication
 
-If you want to work with login-related features (Profile, Dashboard, Goals, ...) you'll need to set up authentication:
+Currently, it is necessary to setup authentication via `Auth0` to self host this project because of login-related features (Profile, Dashboard, Goals, ...):
 
 1. Create an [Auth0](https://auth0.com/) account.
-2. Click "Applications" from the dashboard. Create a new one, or use the default application.
-3. On "Applications" still, next to your application, click the "three dots" icon, then Settings.
+2. Click "Applications" from the left sidebar of the dashboard. Create a new one, or use the default application.
+3. On "Applications" still, next to your application, click the "three dots" icon, then "Settings".
 4. Add `http://localhost:9000/callback` to the "Allowed Callback URLs" list.
 5. Copy the Auth0 application settings into your configuration file. These are found in the same Settings tab as the "Allowed Callback URLs".
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -183,6 +183,19 @@ Docker can be a very memory-intensive process. If you notice intermittent failur
 
 ## Troubleshooting
 
+### Language greyed out or "can't contribute to this locale" warning
+
+If a locale appears greyed out or you see a warning that you cannot yet contribute to a given language, you need to enable it in the database. For example, to enable French (`fr`):
+
+```sh
+sudo docker exec db mysql -uvoicecommons -pvoicecommons voiceweb -e "UPDATE locales SET is_contributable=1 WHERE name='fr';"
+sudo docker exec -it redis redis-cli FLUSHALL
+```
+
+Then restart the containers.
+
+Replace `fr` with the appropriate language code for your locale.
+
 ### Couldn't connect to Docker daemon 
 
 If you get an error like the following when running native Docker (not Docker for Desktop),


### PR DESCRIPTION
- **Remove unnecessary host port bindings from db, storage, bundler**
- **Fix bundler volume mount path: /home/node/code -> /code**
- **Use bind mount for MySQL data at docker/mysql-data/**
- **Document how to enable speaking for a locale in db**
- **doc: better doc on self hosting**
- **doc: add troubleshooting tip for greyed-out locale contribution**

## Pull Request Form

<!-- Thanks for making a contribution to Common Voice, to help us review the request please fill out this form -->

### Type of Pull Request

<!-- To help us understand your pull request, choose the checkboxes most relevant to your request by filling out the checkboxes with [x] here -->

- [ ] Bulk sentence upload 

<!--- Please ensure your sentences are licensed under CC0 before making a submission. Learn how you can do this via our Playbook https://common-voice.github.io/community-playbook/sub_pages/cc0waiver_process.html -->

- [ ] Related to a listed issue 

<!--- Please link the issues related to your PR Request -->


- [X] Other

Just contributing a few changes that I had to do to self host it.

FYI:
1. I also noticed that trying to rename the `redis` container to something else (to avoid issues with other containers called redis) it appears that modifying `CV_REDIS_URL` is not enough: there is still some hardcoded call to a redis container I believe. I decided to rename my other redis container instead of trying to fix that though.
2. Removing the "not production" banner at the top does not seem to be documented. I had to hardcore it to /web/src/utility.ts's window.location.origin value.