### PR TITLE
1698-Remove extra messages in Sentry and server logs

### DIFF
--- a/server/src/lib/middleware/rate-limiter-middleware.ts
+++ b/server/src/lib/middleware/rate-limiter-middleware.ts
@@ -6,6 +6,10 @@ import {
 } from 'rate-limiter-flexible'
 import { redis as redisClient } from '../redis-cache'
 
+// Feature flag: log every 429 to the server console
+// Set to true to track rate-limited requests for debugging
+const ENABLE_RATELIMIT_LOG = false
+
 function createRateLimiter(
   keyPrefix: string,
   rateLimiterOptions?: Partial<IRateLimiterStoreOptions>
@@ -59,16 +63,19 @@ function rateLimiterMiddleware(
       }
 
       const rlRes = exception as RateLimiterRes
-      console.warn(
-        '[ratelimit] 429',
-        request.method,
-        request.originalUrl,
-        JSON.stringify({
-          keyPrefix,
-          authUserId: request.session?.user?.client_id ?? null,
-          targetClientId: request.params?.client_id ?? null,
-        })
-      )
+      if (ENABLE_RATELIMIT_LOG) {
+        console.warn(
+          '[ratelimit] 429',
+          request.method,
+          request.originalUrl,
+          JSON.stringify({
+            keyPrefix,
+            locale: request.params?.locale ?? null,
+            authUserId: request.session?.user?.client_id ?? null,
+            targetClientId: request.params?.client_id ?? null,
+          })
+        )
+      }
       rateLimitResponse(response, rlRes?.msBeforeNext)
       return
     }

--- a/web/src/stores/clips.ts
+++ b/web/src/stores/clips.ts
@@ -5,8 +5,8 @@ import { User } from './user'
 import { Clip } from 'common'
 
 // Feature flag: Enable detailed error telemetry in Sentry
-// Set to false to reduce Sentry costs (only critical errors will be tracked)
-const ENABLE_ERROR_TELEMETRY = true
+// Set to true to track handled clip-load and clip-vote failures in Sentry
+const ENABLE_ERROR_TELEMETRY = false
 
 function extractErrorDetails(err: unknown): {
   errMessage: string


### PR DESCRIPTION
We were using these to debug issues, no longer needed.