### PR TITLE
1699-Add specific error handling guards at multiple locations and drop Sentry noise

### DIFF
--- a/web/locales/common-voice/en/pages/error.ftl
+++ b/web/locales/common-voice/en/pages/error.ftl
@@ -10,6 +10,14 @@ error-clip-upload-too-large = Your recording file is too large to upload. Please
 error-clip-upload-server-error = Server error processing your clip. Please reload the page or try again later.
 error-title-404 = We couldn’t find that page for you
 error-content-404 = Maybe our <homepageLink>homepage</homepageLink> will help? To ask a question, please join the <matrixLink>Matrix community chat</matrixLink>, monitor site issues via <githubLink>GitHub</githubLink> or visit <discourseLink>our Discourse forums</discourseLink>.
+error-title-429 =
+  { $retryAfter ->
+    [0] You’re going too fast. Please slow down and try again in a moment.
+   *[other] You’re going too fast. Please try again in { NUMBER($retryAfter) } { $retryAfter ->
+      [one] second
+     *[other] seconds
+    }.
+  }
 error-title-500 = Sorry, something went wrong
 error-content-500 = An unexpected error occurred. Please try again later. For help, please join the <matrixLink>Matrix community chat</matrixLink>, monitor site issues via <githubLink>GitHub</githubLink> or visit <discourseLink>our Discourse forums</discourseLink>.
 error-title-502 = Connection interrupted

--- a/web/src/components/app.tsx
+++ b/web/src/components/app.tsx
@@ -63,6 +63,26 @@ Sentry.init({
   integrations: [Sentry.browserTracingIntegration()],
   environment: isProduction() ? 'prod' : 'stage',
   release: process.env.GIT_COMMIT_SHA || null,
+  ignoreErrors: [
+    'AbortError', // User navigated away mid-fetch
+    /^Connection error: cancelled$/, // iOS Safari wording for user navigation
+    /Error invoking postMessage: Java object is gone/, // Facebook Android webview bridge GC
+    /window\.checkLogin is not a function/, // External bookmarklet / extension, not our code
+    /undefined is not an object \(evaluating 'window\.webkit\.messageHandlers'\)/, // Facebook iOS in-app browser probe
+  ],
+  // Replace '<unknown>' rejections with the real reason text so they're triageable
+  beforeSend(event, hint) {
+    const reason = (hint as { originalException?: unknown } | undefined)
+      ?.originalException
+    const first = event.exception?.values?.[0]
+    if (first && (first.value === '<unknown>' || !first.value) && reason != null) {
+      first.value =
+        typeof reason === 'string'
+          ? reason
+          : JSON.stringify(reason).slice(0, 200)
+    }
+    return event
+  },
 })
 
 interface PropsFromState {

--- a/web/src/components/app.tsx
+++ b/web/src/components/app.tsx
@@ -76,10 +76,18 @@ Sentry.init({
       ?.originalException
     const first = event.exception?.values?.[0]
     if (first && (first.value === '<unknown>' || !first.value) && reason != null) {
-      first.value =
-        typeof reason === 'string'
-          ? reason
-          : JSON.stringify(reason).slice(0, 200)
+      let text: string
+      if (typeof reason === 'string') {
+        text = reason
+      } else {
+        try {
+          text = JSON.stringify(reason)
+        } catch {
+          // Circular refs (DOM Event, framework error wrappers) — fall back
+          text = String(reason)
+        }
+      }
+      first.value = text.slice(0, 200)
     }
     return event
   },

--- a/web/src/components/pages/contribution/contribution.tsx
+++ b/web/src/components/pages/contribution/contribution.tsx
@@ -195,7 +195,7 @@ class ContributionPage extends React.Component<ContributionPageProps, State> {
   private handleKeyDown = (event: any) => {
     if (isTyping()) return
 
-    const { getString, isSubmitted, locale, onReset, onSubmit, type } =
+    const { getString, hasErrors, isSubmitted, locale, onReset, onSubmit, type } =
       this.props
 
     if (
@@ -203,6 +203,7 @@ class ContributionPage extends React.Component<ContributionPageProps, State> {
       event.altKey ||
       event.shiftKey ||
       event.metaKey ||
+      hasErrors ||
       this.state.showReportModal ||
       this.props.shouldShowFirstCTA ||
       this.props.showPrivacyModal

--- a/web/src/components/pages/contribution/listen/listen.tsx
+++ b/web/src/components/pages/contribution/listen/listen.tsx
@@ -152,6 +152,10 @@ class ListenPage extends React.Component<Props, State> {
       return
     }
 
+    // Guard: a stray shortcut could otherwise replay the buffered clip after all are validated
+    const clipIndex = this.getClipIndex()
+    if (clipIndex < 0 || !this.state.clips[clipIndex]) return
+
     // No attached audio or failing audio (bad file/codec?)
     const audio = this.audioRef.current
     if (!audio) return
@@ -435,6 +439,7 @@ class ListenPage extends React.Component<Props, State> {
             </NavigationPrompt>
           )}
           <audio
+            key={activeClip?.id ?? 'no-clip'}
             {...(activeClip && { src: activeClip.audioSrc })}
             preload="auto"
             onEnded={this.hasPlayed}

--- a/web/src/components/pages/dashboard/stats/leaderboard-card.tsx
+++ b/web/src/components/pages/dashboard/stats/leaderboard-card.tsx
@@ -132,7 +132,14 @@ class UnconnectedLeaderboard extends React.Component<Props, State> {
 
     const { api, globalLocale, locale, type } = this.props
     trackDashboard('leaderboard-load-more', globalLocale)
-    const newRows = await api.forLocale(locale).fetchLeaderboard(type, cursor)
+    let newRows: any[] // eslint-disable-line @typescript-eslint/no-explicit-any
+    try {
+      newRows = await api.forLocale(locale).fetchLeaderboard(type, cursor)
+    } catch (err) {
+      if (!isProduction()) console.warn('Leaderboard paginate failed', err)
+      return
+    }
+    if (!this._isMounted) return
     this.setState(
       ({ rows }) => {
         const allRows = [

--- a/web/src/components/pages/dashboard/stats/progress-card.tsx
+++ b/web/src/components/pages/dashboard/stats/progress-card.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { DAILY_GOALS } from '../../../../constants';
 import { useAccount, useAPI } from '../../../../hooks/store-hooks';
 import { trackDashboard } from '../../../../services/tracker';
+import { isProduction } from '../../../../utility';
 import URLS from '../../../../urls';
 import {
   LocaleLink,
@@ -47,7 +48,9 @@ export default function ProgressCard({
   }
 
   useEffect(() => {
-    fetchAndSetOverallCount();
+    fetchAndSetOverallCount().catch(err => {
+      if (!isProduction()) console.warn('Daily count fetch failed', err);
+    });
   }, []);
 
   const overallGoal = DAILY_GOALS[type][0];

--- a/web/src/components/use-system-error-handler.ts
+++ b/web/src/components/use-system-error-handler.ts
@@ -1,34 +1,32 @@
 import { useEffect } from 'react'
 import { useDispatch } from 'react-redux'
 import { useLocalization } from '@fluent/react'
-import { SystemError } from '../services/app-error'
+import { ClientHandledError, SystemError } from '../services/app-error'
 import { Notifications } from '../stores/notifications'
 
-/**
- * Catches unhandled SystemError promise rejections (from async Redux thunks)
- * and shows a localized notification pill instead of letting them surface
- * as uncaught errors in Sentry.
- *
- * React Error Boundaries only catch errors during rendering — async errors
- * from API calls in Redux thunks escape entirely. This hook fills that gap.
- * 
- * This will catch & handle most of the communication related errors...
- * 
- */
+/** Catches unhandled SystemError/ClientHandledError rejections and shows a localized pill. */
 export default function useSystemErrorHandler() {
   const dispatch = useDispatch()
   const { l10n } = useLocalization()
 
   useEffect(() => {
     const handler = (event: PromiseRejectionEvent) => {
-      if (!(event.reason instanceof SystemError)) return
+      const reason = event.reason
+      let code: string | null = null
+      let retryAfter = 0
+      if (reason instanceof SystemError) {
+        code = reason.code
+      } else if (reason instanceof ClientHandledError) {
+        code = String(reason.status)
+        retryAfter = parseInt(reason.retryAfter ?? '', 10) || 0
+      }
+      if (!code) return
 
       event.preventDefault()
 
-      const code = event.reason.code
       const message = l10n.getString(
         `error-title-${code}`,
-        null,
+        { retryAfter },
         l10n.getString('error-something-went-wrong')
       )
 

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -16,6 +16,8 @@ import {
   SPSLocalesResponse,
 } from 'common'
 import {
+  ClientHandledError,
+  SystemError,
   createBadGatewayError,
   createServiceUnavailableError,
   createGatewayTimeoutError,
@@ -207,6 +209,10 @@ export default class API {
    * These are treated as system errors and trigger Error Boundary
    */
   private handleNetworkError(error: Error): never {
+    if (error instanceof SystemError || error instanceof ClientHandledError) {
+      throw error
+    }
+
     if (error.name === 'AbortError') {
       throw createGatewayTimeoutError('Request timeout')
     }

--- a/web/src/stores/clips.ts
+++ b/web/src/stores/clips.ts
@@ -204,7 +204,7 @@ export namespace Clips {
             hasEarnedSessionToast,
             showFirstStreakToast,
             challengeEnded,
-          } = await state.api.saveVote(id, isValid)
+          } = (await state.api.saveVote(id, isValid)) || {}
 
           if (!state.user.account) {
             dispatch(User.actions.tallyVerification())

--- a/web/src/stores/sentences.ts
+++ b/web/src/stores/sentences.ts
@@ -249,10 +249,12 @@ export namespace Sentences {
         const pendingSentence =
           currentLocaleState?.pendingSentences?.[sentenceVote.sentenceIndex]
         if (pendingSentence?.localeId) {
-          actions.refillPendingSentences(pendingSentence.localeId)(
-            dispatch,
-            getState
-          )
+          actions
+            .refillPendingSentences(pendingSentence.localeId)(
+              dispatch,
+              getState
+            )
+            .catch(() => undefined)
         }
       },
 
@@ -281,10 +283,12 @@ export namespace Sentences {
           s => s.sentenceId === sentenceId
         )
         if (pendingSentence?.localeId) {
-          actions.refillPendingSentences(pendingSentence.localeId)(
-            dispatch,
-            getState
-          )
+          actions
+            .refillPendingSentences(pendingSentence.localeId)(
+              dispatch,
+              getState
+            )
+            .catch(() => undefined)
         }
       },
 


### PR DESCRIPTION
This PR tightens client-side error handling and reduces Sentry noise. It preserves typed `SystemError`/`ClientHandledError` instances through the API layer, extends the global unhandled-rejection handler to cover client-handled errors (with localized 429 messaging including `Retry-After`), suppresses background refill rejections, and adds defensive guards/catches in dashboard cards, the listen page, and the contribution shortcut handler. It also configures `Sentry.init` with `ignoreErrors` and a `beforeSend` that rewrites `<unknown>` rejection values.

- API/error plumbing: don't rewrap `SystemError`/`ClientHandledError` as network errors; handle both in `useSystemErrorHandler` with `retryAfter` localization and add `error-title-429` Fluent message.
- UI hardening: add defensive `.catch`/guards in `progress-card`, `leaderboard-card` pagination, `listen` play/audio key, `contribution` keyboard shortcut, and sentence refill background calls; tolerate null vote response in `clips` store.
- Sentry config: add `ignoreErrors` patterns and a `beforeSend` that replaces `<unknown>` exception values with stringified reason.