### PR TITLE
Fix multiple issues

### DIFF
--- a/server/src/lib/model/user-client.ts
+++ b/server/src/lib/model/user-client.ts
@@ -547,7 +547,7 @@ const UserClient = {
             'SELECT client_id FROM user_clients WHERE email = ? AND !has_login',
             [email]
           )
-        : [],
+        : [[]], // no email → no anonymous rows to claim; [[]] so [clients] destructures to []
     ])
 
     const clientId = accountClientId || client_id

--- a/server/src/lib/validation/user-client.test.ts
+++ b/server/src/lib/validation/user-client.test.ts
@@ -137,6 +137,20 @@ describe('user-client schema validation', () => {
       expect(next).toBeCalledWith(expect.any(ValidationError))
     })
 
+    it('rejects languages where accents is not an array', () => {
+      mockRequest.body = { languages: [{ locale: 'en', accents: 'not-an-array' }] }
+      run()
+      expect(next).toBeCalledWith(expect.any(ValidationError))
+    })
+
+    it('accepts a non-empty languages array with valid structure', () => {
+      mockRequest.body = {
+        languages: [{ locale: 'en', accents: [{ id: 1, name: 'General American' }] }],
+      }
+      run()
+      expect(next).toBeCalledWith()
+    })
+
     it('accepts full valid profile body', () => {
       mockRequest.body = {
         client_id: VALID_UUID,
@@ -144,7 +158,7 @@ describe('user-client schema validation', () => {
         visible: 0,
         age: 'thirties',
         gender: 'female_feminine',
-        languages: [],
+        languages: [{ locale: 'en', accents: [{ id: 1, name: 'General American' }] }],
         enrollment: { challenge: 'pilot', team: 'mozilla' },
         skip_submission_feedback: false,
       }

--- a/server/src/lib/validation/user-client.test.ts
+++ b/server/src/lib/validation/user-client.test.ts
@@ -50,6 +50,71 @@ describe('user-client schema validation', () => {
       run()
       expect(next).toBeCalledWith(expect.any(ValidationError))
     })
+
+    it('accepts valid gender values', () => {
+      for (const gender of [
+        'female_feminine',
+        'male_masculine',
+        'intersex',
+        'transgender',
+        'non-binary',
+        'do_not_wish_to_say',
+        '',
+      ]) {
+        next.mockClear()
+        mockRequest.body = { gender }
+        run()
+        expect(next).toBeCalledWith()
+      }
+    })
+
+    it('rejects invalid gender (attack pattern)', () => {
+      mockRequest.body = { gender: 'hittsiiqeaqpg.blid.site' }
+      run()
+      expect(next).toBeCalledWith(expect.any(ValidationError))
+    })
+
+    it('rejects arbitrary string gender', () => {
+      mockRequest.body = { gender: 'male' }
+      run()
+      expect(next).toBeCalledWith(expect.any(ValidationError))
+    })
+
+    it('accepts valid age values', () => {
+      for (const age of ['teens', 'twenties', 'thirties', 'nineties', '']) {
+        next.mockClear()
+        mockRequest.body = { age }
+        run()
+        expect(next).toBeCalledWith()
+      }
+    })
+
+    it('rejects invalid age', () => {
+      mockRequest.body = { age: 'old' }
+      run()
+      expect(next).toBeCalledWith(expect.any(ValidationError))
+    })
+
+    it('rejects unknown fields', () => {
+      mockRequest.body = { unknownField: 'value' }
+      run()
+      expect(next).toBeCalledWith(expect.any(ValidationError))
+    })
+
+    it('accepts full valid profile body', () => {
+      mockRequest.body = {
+        client_id: VALID_UUID,
+        username: 'jane',
+        visible: 0,
+        age: 'thirties',
+        gender: 'female_feminine',
+        languages: [],
+        enrollment: { challenge: null, invite: null, team: null },
+        skip_submission_feedback: false,
+      }
+      run()
+      expect(next).toBeCalledWith()
+    })
   })
 
   describe('clientIdParamSchema (claim param stays strict)', () => {

--- a/server/src/lib/validation/user-client.test.ts
+++ b/server/src/lib/validation/user-client.test.ts
@@ -34,13 +34,13 @@ describe('user-client schema validation', () => {
     })
 
     it('accepts null client_id (logged-in profile save)', () => {
-      mockRequest.body = { client_id: null, username: 'jane', visible: true }
+      mockRequest.body = { client_id: null, username: 'jane', visible: 1 }
       run()
       expect(next).toBeCalledWith()
     })
 
     it('accepts an absent client_id', () => {
-      mockRequest.body = { visible: true }
+      mockRequest.body = { visible: 1 }
       run()
       expect(next).toBeCalledWith()
     })
@@ -101,6 +101,42 @@ describe('user-client schema validation', () => {
       expect(next).toBeCalledWith(expect.any(ValidationError))
     })
 
+    it('accepts visible 0, 1, 2', () => {
+      for (const visible of [0, 1, 2]) {
+        next.mockClear()
+        mockRequest.body = { visible }
+        run()
+        expect(next).toBeCalledWith()
+      }
+    })
+
+    it('rejects visible out of range', () => {
+      for (const visible of [-1, 3, 1.5]) {
+        next.mockClear()
+        mockRequest.body = { visible }
+        run()
+        expect(next).toBeCalledWith(expect.any(ValidationError))
+      }
+    })
+
+    it('rejects empty username', () => {
+      mockRequest.body = { username: '' }
+      run()
+      expect(next).toBeCalledWith(expect.any(ValidationError))
+    })
+
+    it('accepts enrollment: null', () => {
+      mockRequest.body = { enrollment: null }
+      run()
+      expect(next).toBeCalledWith()
+    })
+
+    it('rejects languages with non-object items', () => {
+      mockRequest.body = { languages: [1, 'x'] }
+      run()
+      expect(next).toBeCalledWith(expect.any(ValidationError))
+    })
+
     it('accepts full valid profile body', () => {
       mockRequest.body = {
         client_id: VALID_UUID,
@@ -109,7 +145,7 @@ describe('user-client schema validation', () => {
         age: 'thirties',
         gender: 'female_feminine',
         languages: [],
-        enrollment: { challenge: null, invite: null, team: null },
+        enrollment: { challenge: 'pilot', team: 'mozilla' },
         skip_submission_feedback: false,
       }
       run()

--- a/server/src/lib/validation/user-client.ts
+++ b/server/src/lib/validation/user-client.ts
@@ -1,16 +1,50 @@
 import { AllowedSchema } from 'express-json-validator-middleware'
+import { Gender } from 'common'
 
 const clientIdProperty = {
   type: 'string',
   format: 'uuidFormat',
 } as const
 
+// Keys mirror the Gender type in common/user-clients.ts and the genders DB table.
+// AGES has no equivalent type in common yet; keep in sync with web/src/stores/demographics.ts.
+const GENDER_VALUES: Array<keyof Gender | ''> = [
+  'female_feminine',
+  'male_masculine',
+  'intersex',
+  'transgender',
+  'non-binary',
+  'do_not_wish_to_say',
+  '',
+]
+
+const AGE_VALUES = [
+  'teens',
+  'twenties',
+  'thirties',
+  'fourties',
+  'fifties',
+  'sixties',
+  'seventies',
+  'eighties',
+  'nineties',
+  '',
+] as const
+
 export const userClientPatchSchema: AllowedSchema = {
   type: 'object',
+  additionalProperties: false,
   properties: {
     // The profile form sends client_id: user.userId, which the web store sets to null once an
     // account exists; accept null so the save isn't 400'd before the handler resolves identity.
     client_id: { type: ['string', 'null'], format: 'uuidFormat' },
+    username: { type: 'string', maxLength: 255 },
+    visible: { type: ['number', 'boolean', 'integer'] },
+    age: { type: 'string', enum: AGE_VALUES as unknown as string[] },
+    gender: { type: 'string', enum: GENDER_VALUES as unknown as string[] },
+    skip_submission_feedback: { type: 'boolean' },
+    languages: { type: 'array' },
+    enrollment: { type: 'object' },
   },
 }
 

--- a/server/src/lib/validation/user-client.ts
+++ b/server/src/lib/validation/user-client.ts
@@ -38,13 +38,13 @@ export const userClientPatchSchema: AllowedSchema = {
     // The profile form sends client_id: user.userId, which the web store sets to null once an
     // account exists; accept null so the save isn't 400'd before the handler resolves identity.
     client_id: { type: ['string', 'null'], format: 'uuidFormat' },
-    username: { type: 'string', maxLength: 255 },
-    visible: { type: ['number', 'boolean', 'integer'] },
+    username: { type: 'string', minLength: 1, maxLength: 255 },
+    visible: { type: 'integer', minimum: 0, maximum: 2 },
     age: { type: 'string', enum: AGE_VALUES as unknown as string[] },
     gender: { type: 'string', enum: GENDER_VALUES as unknown as string[] },
     skip_submission_feedback: { type: 'boolean' },
-    languages: { type: 'array' },
-    enrollment: { type: 'object' },
+    languages: { type: 'array', items: { type: 'object' } },
+    enrollment: { type: ['object', 'null'] },
   },
 }
 

--- a/server/src/lib/validation/user-client.ts
+++ b/server/src/lib/validation/user-client.ts
@@ -43,7 +43,17 @@ export const userClientPatchSchema: AllowedSchema = {
     age: { type: 'string', enum: AGE_VALUES as unknown as string[] },
     gender: { type: 'string', enum: GENDER_VALUES as unknown as string[] },
     skip_submission_feedback: { type: 'boolean' },
-    languages: { type: 'array', items: { type: 'object' } },
+    languages: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          locale: { type: 'string' },
+          accents: { type: 'array' },
+          variant: { type: 'object' },
+        },
+      },
+    },
     enrollment: { type: ['object', 'null'] },
   },
 }

--- a/web/src/components/app.tsx
+++ b/web/src/components/app.tsx
@@ -66,6 +66,7 @@ Sentry.init({
   ignoreErrors: [
     'AbortError', // User navigated away mid-fetch
     /^Connection error: cancelled$/, // iOS Safari wording for user navigation
+    /^Connection error: Load failed$/, // iOS/WebKit wording for the same class of navigation-cancelled requests
     /Error invoking postMessage: Java object is gone/, // Facebook Android webview bridge GC
     /window\.checkLogin is not a function/, // External bookmarklet / extension, not our code
     /undefined is not an object \(evaluating 'window\.webkit\.messageHandlers'\)/, // Facebook iOS in-app browser probe

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -217,6 +217,11 @@ export default class API {
       throw createGatewayTimeoutError('Request timeout')
     }
 
+    // iOS in-app browsers (Facebook, Instagram) throw for 429 instead of returning a proper Response.
+    if (error.message === 'Too Many Requests') {
+      throw new RateLimitError()
+    }
+
     if (
       error.message.includes('Failed to fetch') ||
       error.message.includes('Network Error')

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -425,10 +425,10 @@ export default class API {
     return this.fetch(API_PATH + '/user_client')
   }
 
-  saveAccount(data: UserClient): Promise<UserClient> {
+  saveAccount({ client_id, username, visible, age, gender, skip_submission_feedback, languages, enrollment }: UserClient): Promise<UserClient> {
     return this.fetch(API_PATH + '/user_client', {
       method: 'PATCH',
-      body: data,
+      body: { client_id, username, visible, age, gender, skip_submission_feedback, languages, enrollment },
     })
   }
 

--- a/web/src/stores/user.ts
+++ b/web/src/stores/user.ts
@@ -114,13 +114,18 @@ export namespace User {
           type: ActionType.UPDATE,
           state: { isFetchingAccount: true },
         })
-        dispatch({
-          type: ActionType.UPDATE,
-          state: {
-            account: await api.saveAccount(data),
-            isFetchingAccount: false,
-          },
-        })
+        try {
+          dispatch({
+            type: ActionType.UPDATE,
+            state: {
+              account: await api.saveAccount(data),
+              isFetchingAccount: false,
+            },
+          })
+        } catch (error) {
+          dispatch({ type: ActionType.UPDATE, state: { isFetchingAccount: false } })
+          throw error
+        }
         await actions.claimLocalUser(dispatch, getState)
       },
 

--- a/web/src/stores/user.ts
+++ b/web/src/stores/user.ts
@@ -1,6 +1,7 @@
 import { Dispatch } from 'redux'
 import { UserClient, UserLanguage } from 'common'
 import { generateGUID, generateToken } from '../utility'
+import { RateLimitError } from '../services/app-error'
 import StateTree from './tree'
 
 export const VISIBLE_FOR_NONE = 0
@@ -148,7 +149,13 @@ export namespace User {
     ) => {
       const { api, user } = getState()
       if (user.account && user.userId) {
-        await api.claimAccount()
+        try {
+          await api.claimAccount()
+        } catch (error) {
+          // Rate-limited: contributions stay in DB; retry on next page load when window resets.
+          if (error instanceof RateLimitError) return
+          throw error
+        }
         dispatch({
           type: ActionType.UPDATE,
           state: {


### PR DESCRIPTION
This PR addresses several reliability issues around user profile updates and account-claiming, improving error handling for rate-limits/network edge cases and tightening the `/user_client` PATCH contract between web and server.

- FE: Ensure `isFetchingAccount` is cleared on `saveAccount` failures; tolerate rate-limited `claimAccount`; reduce Sentry noise for specific iOS/WebKit errors.
- FE: Restrict `saveAccount` PATCH payload to a known allow-list of fields (to match stricter server validation).
- BE: Tighten PATCH validation (age/gender enums, reject unknown fields) and add tests; fix a destructuring bug in account save when `email` is absent.
