### PR TITLE
1725-BUNDLER- Upgrade uploader to disable previous versions via CLI

### DIFF
--- a/bundler/uploader/DEVELOPER.md
+++ b/bundler/uploader/DEVELOPER.md
@@ -40,8 +40,10 @@ gcs.py ------------> google-cloud-storage (for gs:// URIs)
 Supporting modules:
 
 - `typedef.py` -- shared type definitions (`UploadStatus`, `MDCTarget`, `LanguageNames`, TypedDicts)
-- `models.py` -- data models (`Modality`, `ReleaseType`, `ReleaseSpec`, `LocaleUploadJob`, `UploadResult`)
+- `models.py` -- data models (`Modality`, `DisableMode`, `ReleaseType`, `ReleaseSpec`, `LocaleUploadJob`, `OrgDataset`, `UploadResult`)
 - `log.py` -- structured logging matching the bundler's `[TIMESTAMP] [LEVEL] [COMPONENT]` format
+- `org_page.py` -- MDC org page scraping: fetch, parse, GCS snapshot save/load, prior map builder
+- `prior.py` -- entry point for loading the prior version map (used by pre and post modes)
 
 ## Environment Variables
 
@@ -64,18 +66,20 @@ Dev and prod use separate MDC accounts. Set the key matching your `-ut` target.
 | -------------- | --------------------------------------------------------------------------------------------- |
 | `cli.py`       | Click CLI entry point, option parsing, `--retry-failed`/`--resume` handling, error formatting |
 | `config.py`    | `UploaderConfig` dataclass, env var + CLI arg resolution                                      |
-| `constants.py` | MDC API URLs, metadata templates, contact info                                                |
+| `constants.py` | MDC API URLs, metadata templates, contact info, disable-prior constants                       |
 | `typedef.py`   | Shared type aliases, Literal types, TypedDicts                                                |
-| `models.py`    | `Modality`, `ReleaseType`, `ReleaseSpec`, `LocaleUploadJob`, `UploadResult`                   |
+| `models.py`    | Data models: `Modality`, `DisableMode`, `OrgDataset`, `UploadResult`, release/job types       |
 | `naming.py`    | Release name parsing, tarball/datasheet path construction                                     |
 | `language.py`  | `LanguageRegistry` class -- fetches locale names from CV API + hardcoded extras               |
-| `mdc.py`       | `MDCClient` -- step-by-step SDK calls, resume, recovery, error/response capture, 429 retry    |
+| `mdc.py`       | `MDCClient` -- step-by-step SDK calls, resume, recovery, 429 retry, disable methods           |
 | `streaming.py` | GCS-to-MDC direct streaming: range reads -> presigned URL PUTs, resume via state file         |
-| `pipeline.py`  | Per-locale orchestration, streaming/non-streaming routing, ThreadPoolExecutor concurrency     |
+| `pipeline.py`  | Per-locale orchestration, streaming/non-streaming routing, concurrency, pre/post disable      |
 | `state.py`     | `BatchState` JSON persistence (thread-safe), orphaned extraction, log-to-storage upload       |
 | `progress.py`  | tqdm batch progress bar, human-readable size formatting                                       |
 | `log.py`       | Structured logging, auto log file, `flush_all`/`get_log_file_path` for storage save           |
 | `gcs.py`       | GCS fallback for `gs://` URIs (uses `google-cloud-storage` runtime dependency)                |
+| `org_page.py`  | MDC org page scraping, GCS snapshot save/load, prior version map builder                      |
+| `prior.py`     | Entry point: loads prior version map for pre and post disable modes                           |
 
 ---
 

--- a/bundler/uploader/README.md
+++ b/bundler/uploader/README.md
@@ -27,6 +27,7 @@ For architecture and development details see [DEVELOPER.md](DEVELOPER.md).
 - Can write all output to a log file via `--log-file` (always captures DEBUG level)
 - Can persist batch state to JSON after each locale for `--retry-failed` support
 - Can save log file and state JSON to `<base-dir>/<release>/upload-logs/` after each batch so they survive pod recycling
+- Can disable prior MDC dataset versions automatically via `--disable-prior pre` (bulk before upload) or `--disable-prior post` (per-locale after success) -- disabled by default (`skip`)
 
 ## Data Pipeline
 

--- a/bundler/uploader/src/mdc_uploader/cli.py
+++ b/bundler/uploader/src/mdc_uploader/cli.py
@@ -27,6 +27,8 @@ Examples:
   mdc-upload --retry-failed upload-state-...-20260313T143000.json
   mdc-upload --resume -r cv-corpus-25.0-2026-03-09 -l fr -ut prod
   mdc-upload -r sps-corpus-3.0-2026-03-09 --base-dir ./test-releases --dry-run
+  mdc-upload -r cv-corpus-26.0-2026-06-15 -ut prod --disable-prior post
+  mdc-upload -r cv-corpus-26.0-2026-06-15 -ut prod --disable-prior pre --force-rescrape
 
 \b
 Environment variables:
@@ -137,6 +139,29 @@ Environment variables:
     help="Disable GCS streaming; download tarballs to temp before uploading. "
     "Streaming is the default for gs:// base dirs.",
 )
+@click.option(
+    "--disable-prior",
+    "disable_mode",
+    type=click.Choice(["skip", "pre", "post"]),
+    default="skip",
+    show_default=True,
+    help=(
+        "Disable prior version(s) of each locale's dataset on MDC. "
+        "'pre': bulk-disable all before uploading. "
+        "'post': disable immediately after each successful upload. "
+        "Both modes use the cached GCS org snapshot, re-scraped only when missing "
+        "or when --force-rescrape is set."
+    ),
+)
+@click.option(
+    "--force-rescrape",
+    is_flag=True,
+    default=False,
+    help=(
+        "Force a fresh scrape of the MDC org page even if a cached snapshot exists in GCS. "
+        "Only relevant when --disable-prior is pre or post."
+    ),
+)
 def cli(
     release: str | None,
     upload_target: str,
@@ -151,6 +176,8 @@ def cli(
     verbose: bool,
     jobs: int,
     no_stream: bool,
+    disable_mode: str,
+    force_rescrape: bool,
 ) -> None:
     """Upload Common Voice release tarballs to Mozilla Data Collective (MDC) via API.
 
@@ -167,6 +194,12 @@ def cli(
 
     setup_logging(verbose, log_file=log_file)
 
+    if force_rescrape and disable_mode == "skip":
+        logger.warning(
+            "UPLOAD",
+            "--force-rescrape has no effect without --disable-prior pre or post",
+        )
+
     try:
         _run(
             release=release,
@@ -181,6 +214,8 @@ def cli(
             verbose=verbose,
             jobs=jobs,
             no_stream=no_stream,
+            disable_mode=disable_mode,
+            force_rescrape=force_rescrape,
         )
     except click.UsageError:
         raise  # let Click format these
@@ -225,6 +260,8 @@ def _run(
     verbose: bool,
     jobs: int,
     no_stream: bool,
+    disable_mode: str = "skip",
+    force_rescrape: bool = False,
 ) -> None:
     """Inner logic separated for clean error handling."""
     mdc_api_url = os.environ.get("MDC_API_URL")
@@ -300,6 +337,8 @@ def _run(
             mdc_api_url=mdc_api_url,
             resume_state_path=os.path.abspath(state_file),
             resume_submission_id=resume_submission_id,
+            disable_mode=disable_mode,
+            force_rescrape=force_rescrape,
         )
         success = run_batch(config)
         sys.exit(0 if success else 1)
@@ -328,6 +367,8 @@ def _run(
             mdc_api_key=mdc_api_key,
             mdc_api_url=mdc_api_url,
             orphaned_submissions=state.get("orphaned_submissions"),
+            disable_mode=disable_mode,
+            force_rescrape=force_rescrape,
         )
         logger.info(
             "RETRY",
@@ -353,6 +394,8 @@ def _run(
             no_stream=no_stream,
             mdc_api_key=mdc_api_key,
             mdc_api_url=mdc_api_url,
+            disable_mode=disable_mode,
+            force_rescrape=force_rescrape,
         )
 
     success = run_batch(config)

--- a/bundler/uploader/src/mdc_uploader/config.py
+++ b/bundler/uploader/src/mdc_uploader/config.py
@@ -6,7 +6,7 @@ import os
 from dataclasses import dataclass
 
 from mdc_uploader.constants import DEFAULT_BASE_DIR, MDC_API_URLS
-from mdc_uploader.models import ReleaseType
+from mdc_uploader.models import DisableMode, ReleaseType
 from mdc_uploader.typedef import MDCTarget, _OrphanedSubmission
 
 
@@ -44,6 +44,9 @@ class UploaderConfig:
     # SDK state file for --resume (resumes partial multipart upload)
     resume_state_path: str | None = None
     resume_submission_id: str | None = None
+    # Disable-prior mode and cache control
+    disable_mode: DisableMode = DisableMode.SKIP
+    force_rescrape: bool = False
 
     def __post_init__(self) -> None:
         """Validate config invariants."""
@@ -78,6 +81,8 @@ class UploaderConfig:
         orphaned_submissions: dict[str, _OrphanedSubmission] | None = None,
         resume_state_path: str | None = None,
         resume_submission_id: str | None = None,
+        disable_mode: str = "skip",
+        force_rescrape: bool = False,
     ) -> UploaderConfig:
         """Build config from CLI args and environment variables."""
         resolved_url = mdc_api_url or MDC_API_URLS[upload_target]
@@ -100,4 +105,6 @@ class UploaderConfig:
             orphaned_submissions=orphaned_submissions,
             resume_state_path=resume_state_path,
             resume_submission_id=resume_submission_id,
+            disable_mode=DisableMode(disable_mode),
+            force_rescrape=force_rescrape,
         )

--- a/bundler/uploader/src/mdc_uploader/constants.py
+++ b/bundler/uploader/src/mdc_uploader/constants.py
@@ -45,3 +45,11 @@ DESCRIPTIONS: dict[str, DescriptionTemplate] = {
 
 # Max Retry-After value (seconds) before giving up on a 429
 MAX_RETRY_AFTER_SECONDS = 3600
+
+# MDC org page (disable-prior feature)
+# Set once MDC team confirms endpoint. E.g. ("DELETE", "/submissions/{id}")
+# or ("PATCH", "/submissions/{id}") with body {"status": "disabled"}.
+# When None: all disable calls are logged no-ops (Q1 guard).
+MDC_DISABLE_ENDPOINT: tuple[str, str] | None = None
+MDC_ORG_ID = "cmfh0j9o10006ns07jq45h7xk"
+MDC_SITE_BASE = "https://mozilladatacollective.com"

--- a/bundler/uploader/src/mdc_uploader/gcs.py
+++ b/bundler/uploader/src/mdc_uploader/gcs.py
@@ -138,3 +138,15 @@ def gcs_read_text(gcs_uri: str, blob_path: str) -> str | None:
 
     text: str = blob.download_as_text()
     return text
+
+
+def gcs_write_text(gcs_uri: str, blob_path: str, content: str) -> None:
+    """Write text content to a GCS blob (UTF-8, plain text)."""
+    bucket_name, base_prefix = parse_gcs_uri(gcs_uri)
+
+    client = gcs_storage.Client()
+    bucket = client.bucket(bucket_name)
+    full_path = f"{base_prefix}/{blob_path}" if base_prefix else blob_path
+    blob = bucket.blob(full_path)
+    blob.upload_from_string(content, content_type="text/plain; charset=utf-8")
+    logger.info("GCS", "Written -> gs://%s/%s", bucket_name, full_path)

--- a/bundler/uploader/src/mdc_uploader/language.py
+++ b/bundler/uploader/src/mdc_uploader/language.py
@@ -138,7 +138,9 @@ class LanguageRegistry:
             code = raw.get("code", "")
             if not code:
                 continue
-            # Store as LanguageData -- the API response matches our TypedDict
+            if not isinstance(raw.get("native_name"), str) or not raw["native_name"]:
+                logger.warning("LANG", "Skipping locale %r: missing native_name", code)
+                continue
             entry: LanguageData = raw  # type: ignore[assignment]
             self._registry[code] = entry
 

--- a/bundler/uploader/src/mdc_uploader/mdc.py
+++ b/bundler/uploader/src/mdc_uploader/mdc.py
@@ -36,11 +36,7 @@ from mdc_uploader.log import logger
 from mdc_uploader.models import ReleaseSpec
 from mdc_uploader.streaming import stream_upload_from_gcs
 
-# -- Override SDK default part size --------------------------------------------
-# The MDC API does not return partSize in the initiate response, so the SDK
-# falls back to DEFAULT_PART_SIZE.  256 MB keeps part count manageable
-# (390 parts for 100 GB vs 20,000 at 5 MB) and completes well within MDC's
-# per-part deadline.  Must target upload_utils (where _initiate_upload lives).
+# 256 MB parts: MDC doesn't return partSize so SDK falls back to this default (must target upload_utils).
 _dc_upload_utils.DEFAULT_PART_SIZE = 256 * 1024 * 1024  # 256 MB
 
 # -- 429 / transient error detection ------------------------------------------
@@ -59,14 +55,7 @@ class TransientError(Exception):
 
 
 def _is_retryable(exc: BaseException) -> bool:
-    """Return True for errors worth retrying.
-
-    Only our custom wrapper types are retryable. All exceptions in retry-decorated
-    methods go through _wrap_exception first, which wraps transient/network errors
-    as TransientError. Raw SDK exceptions (e.g. requests.HTTPError for 401/403)
-    inherit from OSError in Python 3, so we must NOT use isinstance(exc, OSError)
-    here -- that would retry auth failures and create orphaned drafts.
-    """
+    """Return True for RateLimitError/TransientError only (NOT bare OSError — HTTPError inherits it)."""
     if isinstance(exc, RateLimitError):
         return exc.retry_after <= MAX_RETRY_AFTER_SECONDS
     return isinstance(exc, TransientError)
@@ -107,6 +96,22 @@ def _extract_response_detail(exc: Exception) -> tuple[int | None, str | None]:
         return resp.status_code, resp.text
     except (AttributeError, TypeError):  # noqa: BLE001
         return None, None
+
+
+def _extract_retry_after(exc: Exception, default: int = 60) -> int:
+    """Extract Retry-After seconds from response headers or exception text."""
+    resp = getattr(exc, "response", None)
+    if resp is not None:
+        try:
+            header = resp.headers.get("Retry-After", "")
+            if str(header).isdigit():
+                return int(header)
+        except (AttributeError, TypeError):
+            pass
+    match = re.search(r"retry.after[:\s]+(\d+)", str(exc), re.IGNORECASE)
+    if match:
+        return int(match.group(1))
+    return default
 
 
 # -- License mapping ----------------------------------------------------------
@@ -435,6 +440,67 @@ class MDCClient:
         logger.info("MDC", "New version uploaded to %s", submission_id)
         return True
 
+    def disable_submission(self, submission_id: str) -> bool:
+        """Disable one MDC dataset submission.
+
+        Returns False (logged as PENDING) when MDC_DISABLE_ENDPOINT is not yet
+        confirmed. Returns True on success, False on API failure (non-fatal;
+        caller decides whether to abort or continue).
+        """
+        from mdc_uploader.constants import (  # pylint: disable=import-outside-toplevel
+            MDC_DISABLE_ENDPOINT,
+        )
+
+        if MDC_DISABLE_ENDPOINT is None:
+            logger.info(
+                "MDC",
+                "PENDING: would disable %s (endpoint not yet confirmed)",
+                submission_id,
+            )
+            return False
+
+        method, path_template = MDC_DISABLE_ENDPOINT
+        path = path_template.format(id=submission_id)
+        logger.info("MDC", "Disabling %s via %s %s", submission_id, method, path)
+        try:
+            # TODO: implement actual call once endpoint is confirmed.
+            # Example: requests.request(method, f"{self.api_url}{path}")
+            raise NotImplementedError(
+                f"MDC_DISABLE_ENDPOINT is set to {MDC_DISABLE_ENDPOINT!r} "
+                "but the HTTP call is not implemented yet. "
+                "Add the call here once the endpoint is confirmed."
+            )
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.error("MDC", "Failed to disable %s: %s", submission_id, exc)
+            return False
+
+    def disable_submissions(
+        self, submission_ids: list[str]
+    ) -> dict[str, bool]:
+        """Disable multiple MDC dataset submissions.
+
+        Returns {submission_id -> success}. Non-fatal per entry: failures are
+        logged and included in the result map as False.
+        """
+        results: dict[str, bool] = {}
+        for sid in submission_ids:
+            try:
+                results[sid] = self.disable_submission(sid)
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                logger.warning("MDC", "Unhandled error disabling %s: %s", sid, exc)
+                results[sid] = False
+
+        success = sum(1 for v in results.values() if v)
+        pending_or_failed = len(results) - success
+        logger.info(
+            "MDC",
+            "disable_submissions: %d succeeded, %d pending/failed (of %d total)",
+            success,
+            pending_or_failed,
+            len(submission_ids),
+        )
+        return results
+
 
 class OrphanedDraftError(Exception):
     """Raised when a draft was created but the upload/submit failed."""
@@ -484,23 +550,20 @@ def _wrap_exception(exc: Exception) -> Exception:
             body += f"... ({len(response_body)} chars total)"
         logger.error("MDC", "HTTP %s | Response body: %s", status_code, body)
     logger.error("MDC", "SDK exception [%s]: %s", type(exc).__name__, exc)
-    exc_str = str(exc).lower()
-    # Check for 429
-    if "429" in exc_str or "too many requests" in exc_str or "rate limit" in exc_str:
-        # Try to extract Retry-After value
-        retry_after = 60  # default
-        match = re.search(r"retry.after[:\s]+(\d+)", exc_str, re.IGNORECASE)
-        if match:
-            retry_after = int(match.group(1))
-        return RateLimitError(retry_after, str(exc))
-    # Check for transient server errors (by message content)
-    if any(code in exc_str for code in ("500", "502", "503", "504", "timeout", "connection")):
+
+    # Status code is authoritative; string matching is fallback for no-response errors.
+    if status_code == 429:
+        return RateLimitError(_extract_retry_after(exc), str(exc))
+    if status_code is not None and 500 <= status_code < 600:
         return TransientError(str(exc))
-    # Check by exception type for network-level errors whose message may not
-    # contain the keywords above (e.g. bare ConnectionError, TimeoutError).
-    # Note: Python's builtin ConnectionError/TimeoutError are OSError subclasses,
-    # but we must NOT catch OSError broadly -- requests.HTTPError also inherits
-    # from OSError and that would make auth errors (401/403) retryable.
+
+    # String fallback for bare network errors (no response object).
+    exc_str = str(exc).lower()
+    if "too many requests" in exc_str or "rate limit" in exc_str:
+        return RateLimitError(_extract_retry_after(exc), str(exc))
+    if any(kw in exc_str for kw in ("500", "502", "503", "504", "timeout", "connection")):
+        return TransientError(str(exc))
+    # Type check for bare network errors (NOT OSError — requests.HTTPError inherits it).
     if isinstance(exc, (ConnectionError, TimeoutError)):
         return TransientError(str(exc))
     # Non-retryable (includes 401/403 auth errors, 404, etc.)

--- a/bundler/uploader/src/mdc_uploader/models.py
+++ b/bundler/uploader/src/mdc_uploader/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 
 from mdc_uploader.typedef import UploadStatus
@@ -13,6 +13,14 @@ class Modality(StrEnum):
 
     SCS = "scs"
     SPS = "sps"
+
+
+class DisableMode(StrEnum):
+    """Controls whether and when prior MDC dataset versions are disabled."""
+
+    SKIP = "skip"
+    PRE = "pre"
+    POST = "post"
 
 
 class ReleaseType(StrEnum):
@@ -51,6 +59,19 @@ class ReleaseSpec:
 
 
 @dataclass
+class OrgDataset:
+    """A dataset submission scraped from the MDC org page."""
+
+    locale_code: str   # primary — e.g. "en", "rm-vallader" (from page table)
+    modality: str      # "scs" | "sps" (parsed from name)
+    version: str       # e.g. "25.0" (parsed from name)
+    submission_id: str  # e.g. "cmfh0j9o10006ns07jq45h7xk"
+    name: str          # full display name, e.g. "Common Voice Scripted Speech 25.0 - English"
+    locale_name: str   # English locale name extracted from name field
+    href: str          # "/datasets/{submission_id}"
+
+
+@dataclass
 class LocaleUploadJob:
     """A single locale upload job."""
 
@@ -83,3 +104,7 @@ class UploadResult:
     error: str | None = None
     orphaned_draft: bool = False
     attempts: int = 0
+    # Disable-prior results (post-mode: set after successful upload)
+    disabled_ids: list[str] = field(default_factory=list)
+    disable_failed_ids: list[str] = field(default_factory=list)
+    disable_pending_ids: list[str] = field(default_factory=list)

--- a/bundler/uploader/src/mdc_uploader/org_page.py
+++ b/bundler/uploader/src/mdc_uploader/org_page.py
@@ -238,6 +238,7 @@ def save_org_snapshot(datasets: list[OrgDataset], gcs_base: str) -> None:
                 "version": d.version,
                 "id": d.submission_id,
                 "name": d.name,
+                "locale_name": d.locale_name,
             }
             for d in datasets
         ],

--- a/bundler/uploader/src/mdc_uploader/org_page.py
+++ b/bundler/uploader/src/mdc_uploader/org_page.py
@@ -1,0 +1,326 @@
+"""MDC org page scraping: discover all dataset submissions for our organization.
+
+Fetches the server-side-rendered org page and regex-parses locale codes,
+submission IDs, and dataset names. Saves/loads a stable GCS snapshot so
+subsequent runs reuse the cached data without re-scraping.
+
+T0.2: Validate regex patterns against actual MDC org page HTML before activating disable calls.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from datetime import UTC, datetime
+
+import httpx
+
+from mdc_uploader.constants import MDC_ORG_ID, MDC_SITE_BASE
+from mdc_uploader.gcs import gcs_read_text, gcs_write_text, is_gcs_uri
+from mdc_uploader.log import logger
+from mdc_uploader.models import Modality, OrgDataset
+
+# Stable snapshot blob paths relative to base_dir (no timestamp, no release)
+_SNAPSHOT_JSON = ".state/org-snapshot.json"
+_SNAPSHOT_TSV = ".state/org-snapshot.tsv"
+
+# Snapshots older than this are treated as stale and trigger a fresh scrape.
+_SNAPSHOT_MAX_AGE_HOURS = 48
+
+# Strip HTML tags from anchor content
+_TAG_RE = re.compile(r"<[^>]+>")
+
+# Dataset name format: "Common Voice Scripted Speech 25.0 - English"
+_NAME_RE = re.compile(
+    r"^Common Voice (Scripted|Spontaneous) Speech (\d+\.\d+) - (.+)$"
+)
+
+# href="/datasets/{id}" with DOTALL to capture anchor content including inner HTML; caller strips via _TAG_RE.
+_LINK_RE = re.compile(
+    r'href="/datasets/([a-z0-9]{15,})"[^>]*>(.*?)</a>',
+    re.DOTALL | re.IGNORECASE,
+)
+
+# HTML table row
+_ROW_RE = re.compile(r"<tr\b[^>]*>(.*?)</tr>", re.DOTALL | re.IGNORECASE)
+
+# HTML table cell text
+_CELL_RE = re.compile(r"<td[^>]*>\s*([^<\s][^<]*?)\s*</td>", re.IGNORECASE)
+
+# Valid locale code: "en", "rm-vallader", "zh-TW", etc.
+_LOCALE_CODE_RE = re.compile(r"^[a-z]{2,3}(?:-[a-zA-Z0-9]+)*$")
+
+
+def fetch_org_datasets(
+    site_base: str = MDC_SITE_BASE,
+    org_id: str = MDC_ORG_ID,
+    timeout: int = 30,
+) -> list[OrgDataset]:
+    """GET /organization/{org_id} and regex-parse datasets from HTML.
+
+    Returns [] on any HTTP or parse failure — caller decides how to proceed.
+    T0.2: Validate and adjust regex patterns against actual MDC org page HTML.
+    """
+    url = f"{site_base}/organization/{org_id}"
+    try:
+        resp = httpx.get(url, timeout=timeout, follow_redirects=True)
+        resp.raise_for_status()
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.warning("ORG", "Failed to fetch org page %s: %s", url, exc)
+        return []
+
+    datasets = _parse_org_page(resp.text)
+    if not datasets:
+        logger.warning("ORG", "Org page parsed 0 matching datasets from %s", url)
+    else:
+        logger.info("ORG", "Fetched %d datasets from org page", len(datasets))
+    return datasets
+
+
+def _parse_org_page(html: str) -> list[OrgDataset]:
+    """Parse org page HTML into an OrgDataset list.
+
+    Expected HTML structure: a table where each row contains a dataset link
+    (href="/datasets/{id}") and a locale code in an adjacent cell.
+
+    T0.2: Adjust regex patterns after inspecting actual MDC org page HTML.
+    """
+    results: list[OrgDataset] = []
+    seen_ids: set[str] = set()
+
+    for row_m in _ROW_RE.finditer(html):
+        row_html = row_m.group(1)
+
+        # Find dataset link: href + anchor text (dataset name)
+        link_m = _LINK_RE.search(row_html)
+        if not link_m:
+            continue
+        submission_id = link_m.group(1)
+        if submission_id in seen_ids:
+            continue
+        name = _TAG_RE.sub("", link_m.group(2)).strip()
+
+        # Parse name: "Common Voice {Scripted|Spontaneous} Speech {version} - {locale_name}"
+        name_m = _NAME_RE.match(name)
+        if not name_m:
+            continue
+        modality_word, version, locale_name = name_m.groups()
+        modality = "scs" if modality_word == "Scripted" else "sps"
+
+        # Extract locale code: look for a standalone locale-code value in table cells
+        locale_code = _extract_locale_code(row_html)
+        if not locale_code:
+            logger.warning(
+                "ORG",
+                "Could not extract locale code for %s (%s) -- skipping",
+                submission_id,
+                name,
+            )
+            continue
+
+        seen_ids.add(submission_id)
+        results.append(
+            OrgDataset(
+                locale_code=locale_code,
+                modality=modality,
+                version=version,
+                submission_id=submission_id,
+                name=name,
+                locale_name=locale_name,
+                href=f"/datasets/{submission_id}",
+            )
+        )
+
+    return results
+
+
+def _extract_locale_code(row_html: str) -> str:
+    """Extract locale code from a table row's cells or data attributes."""
+    # Primary: look for a <td> containing only a locale-code value
+    for cell_m in _CELL_RE.finditer(row_html):
+        cell_text = cell_m.group(1).strip()
+        if _LOCALE_CODE_RE.match(cell_text):
+            return cell_text
+
+    # Fallback 1: data-locale="..." attribute on any element
+    attr_m = re.search(r'data-locale="([a-z][a-z0-9-]+)"', row_html, re.IGNORECASE)
+    if attr_m:
+        return attr_m.group(1)
+
+    # Fallback 2: strip HTML and scan text tokens for a locale-shaped value.
+    plain = _TAG_RE.sub(" ", row_html)
+    for token in plain.split():
+        if _LOCALE_CODE_RE.match(token):
+            return token
+
+    return ""
+
+
+def load_org_snapshot(gcs_base: str) -> list[OrgDataset] | None:
+    """Load org-snapshot.json from GCS or local .state/.
+
+    Returns None on cache miss or parse error — caller should scrape fresh.
+    """
+    raw: str | None
+    if is_gcs_uri(gcs_base):
+        raw = gcs_read_text(gcs_base, _SNAPSHOT_JSON)
+    else:
+        local_path = os.path.join(gcs_base, _SNAPSHOT_JSON)
+        try:
+            with open(local_path, encoding="utf-8") as f:
+                raw = f.read()
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            logger.warning("ORG", "Failed to read local snapshot: %s", exc)
+            return None
+
+    if raw is None:
+        return None
+
+    try:
+        data = json.loads(raw)
+        scraped_at_str = data.get("scraped_at", "")
+        if scraped_at_str:
+            try:
+                age_hours = (
+                    datetime.now(UTC) - datetime.fromisoformat(scraped_at_str)
+                ).total_seconds() / 3600
+                if age_hours > _SNAPSHOT_MAX_AGE_HOURS:
+                    logger.warning(
+                        "ORG",
+                        "Org snapshot is %.0fh old (max %dh) -- will re-scrape",
+                        age_hours,
+                        _SNAPSHOT_MAX_AGE_HOURS,
+                    )
+                    return None
+            except ValueError:
+                pass  # malformed scraped_at — treat snapshot as fresh
+        datasets = [
+            OrgDataset(
+                locale_code=entry["locale"],
+                modality=entry["modality"],
+                version=entry["version"],
+                submission_id=entry["id"],
+                name=entry["name"],
+                locale_name=entry.get("locale_name", ""),
+                href=f'/datasets/{entry["id"]}',
+            )
+            for entry in data.get("datasets", [])
+        ]
+        logger.info(
+            "ORG",
+            "Loaded %d datasets from snapshot (scraped_at=%s)",
+            len(datasets),
+            scraped_at_str or "?",
+        )
+        return datasets
+    except (KeyError, ValueError, TypeError) as exc:
+        logger.warning("ORG", "Failed to parse org snapshot: %s", exc)
+        return None
+
+
+def save_org_snapshot(datasets: list[OrgDataset], gcs_base: str) -> None:
+    """Write org-snapshot.json + org-snapshot.tsv to GCS or local .state/.
+
+    Best-effort: logs on failure, never raises.
+    """
+    scraped_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    data = {
+        "scraped_at": scraped_at,
+        "org_id": MDC_ORG_ID,
+        "total": len(datasets),
+        "datasets": [
+            {
+                "locale": d.locale_code,
+                "modality": d.modality,
+                "version": d.version,
+                "id": d.submission_id,
+                "name": d.name,
+            }
+            for d in datasets
+        ],
+    }
+    json_content = json.dumps(data, indent=2, ensure_ascii=False)
+
+    tsv_lines = ["locale\tmodality\tversion\tid\tname"]
+    tsv_lines.extend(
+        f"{d.locale_code}\t{d.modality}\t{d.version}\t{d.submission_id}\t{d.name}"
+        for d in datasets
+    )
+    tsv_content = "\n".join(tsv_lines) + "\n"
+
+    try:
+        if is_gcs_uri(gcs_base):
+            gcs_write_text(gcs_base, _SNAPSHOT_JSON, json_content)
+            gcs_write_text(gcs_base, _SNAPSHOT_TSV, tsv_content)
+        else:
+            state_dir = os.path.join(gcs_base, ".state")
+            os.makedirs(state_dir, exist_ok=True)
+            for fname, content in (
+                (os.path.join(state_dir, "org-snapshot.json"), json_content),
+                (os.path.join(state_dir, "org-snapshot.tsv"), tsv_content),
+            ):
+                with open(fname, "w", encoding="utf-8") as f:
+                    f.write(content)
+            logger.info("ORG", "Saved org snapshot to %s", state_dir)
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.warning("ORG", "Failed to save org snapshot: %s", exc)
+
+
+def load_or_fetch(
+    site_base: str = MDC_SITE_BASE,
+    org_id: str = MDC_ORG_ID,
+    gcs_base: str = "",
+    force_rescrape: bool = False,
+) -> list[OrgDataset]:
+    """Return datasets from GCS cache, or scrape + save if missing or force_rescrape.
+
+    Returns [] on total failure (all errors are logged).
+    """
+    if not force_rescrape and gcs_base:
+        cached = load_org_snapshot(gcs_base)
+        if cached is not None:
+            return cached
+
+    datasets = fetch_org_datasets(site_base=site_base, org_id=org_id)
+    if datasets and gcs_base:
+        save_org_snapshot(datasets, gcs_base)
+    return datasets
+
+
+def build_prior_map(
+    datasets: list[OrgDataset],
+    modality: Modality,
+    current_version: str,
+    current_submission_ids: set[str] | None = None,
+) -> dict[str, list[str]]:
+    """Return {locale_code -> [prior_submission_ids]} for the given modality.
+
+    A "prior" entry matches on modality, has a version != current_version,
+    and is not in current_submission_ids. Entries with a different modality
+    are left untouched (one-time uploads preserved).
+    """
+    modality_val = modality.value
+    exclude = current_submission_ids or set()
+    prior_map: dict[str, list[str]] = {}
+
+    for d in datasets:
+        if d.modality != modality_val:
+            continue
+        if d.version == current_version:
+            continue
+        if d.submission_id in exclude:
+            continue
+        prior_map.setdefault(d.locale_code, []).append(d.submission_id)
+
+    if prior_map:
+        total_ids = sum(len(ids) for ids in prior_map.values())
+        logger.info(
+            "ORG",
+            "Prior map: %d locale(s), %d submission(s) to potentially disable",
+            len(prior_map),
+            total_ids,
+        )
+    return prior_map

--- a/bundler/uploader/src/mdc_uploader/pipeline.py
+++ b/bundler/uploader/src/mdc_uploader/pipeline.py
@@ -8,7 +8,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from mdc_uploader import language
+from mdc_uploader import language, prior as prior_module
 from mdc_uploader.config import UploaderConfig
 from mdc_uploader.gcs import (
     parse_gcs_uri,
@@ -19,6 +19,7 @@ from mdc_uploader.gcs import (
 from mdc_uploader.log import logger
 from mdc_uploader.mdc import MDCClient, OrphanedDraftError
 from mdc_uploader.models import (
+    DisableMode,
     LocaleUploadJob,
     ReleaseSpec,
     ReleaseType,
@@ -284,18 +285,11 @@ def _cleanup_gcs_temp(
     release_name: str = "",
     release_type: str = "",
 ) -> None:
-    """Clean up GCS-downloaded temp files after a locale upload.
-
-    Always removes the tarball to prevent disk exhaustion during batches.
-    SDK state files (.mdc-upload.json) are always copied to STATE_DIR using
-    the canonical _sdk_state_fname so --resume can discover them. The copy
-    destination is logged only on failure to avoid noise on the happy path.
-    """
+    """Remove GCS temp tarball and copy SDK state files (.mdc-upload.json) to STATE_DIR for --resume."""
     try:
         tmp_dir = os.path.dirname(tmp_file)
 
-        # Preserve state files to STATE_DIR BEFORE touching the tarball so they
-        # survive even if the tarball removal fails.
+        # Copy state files before touching tarball so they survive on tarball removal failure.
         if tmp_dir and tmp_dir != os.getcwd():
             import shutil  # pylint: disable=import-outside-toplevel
 
@@ -357,16 +351,41 @@ def _sdk_state_path(
     return os.path.join(upload_logs, fname)
 
 
+def _disable_prior_version(
+    locale: str,
+    prior_ids: list[str],
+    client: MDCClient,
+) -> tuple[list[str], list[str], list[str]]:
+    """Disable prior MDC submissions for one locale.
+
+    Returns (disabled_ids, failed_ids, pending_ids).
+    Never raises -- all exceptions are caught and logged.
+    """
+    from mdc_uploader.constants import (  # pylint: disable=import-outside-toplevel
+        MDC_DISABLE_ENDPOINT,
+    )
+
+    if MDC_DISABLE_ENDPOINT is None:
+        for sid in prior_ids:
+            logger.info("MDC", "[%s] PENDING: would disable %s", locale, sid)
+        return [], [], list(prior_ids)
+
+    disabled: list[str] = []
+    failed: list[str] = []
+    for sid in prior_ids:
+        try:
+            ok = client.disable_submission(sid)
+            (disabled if ok else failed).append(sid)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.warning("MDC", "[%s] Failed to disable %s: %s", locale, sid, exc)
+            failed.append(sid)
+    return disabled, failed, []
+
+
 def _preserve_sdk_state_local(
     tarball_path: str, locale: str, release_name: str, release_type: str,
 ) -> None:
-    """Copy SDK state file to .state/ for --resume support (fallback).
-
-    Only needed when state_path was NOT passed to upload_dataset_file
-    (e.g. upload_new_version). The default SDK location is
-    <tarball>.mdc-upload.json next to the tarball.
-    No-op when the SDK state file does not exist.
-    """
+    """Copy <tarball>.mdc-upload.json to .state/ for --resume (fallback for upload_new_version)."""
     sdk_state = f"{tarball_path}.mdc-upload.json"
     if not os.path.exists(sdk_state):
         return
@@ -379,6 +398,104 @@ def _preserve_sdk_state_local(
         logger.info("UPLOAD", "[%s] SDK upload state saved to: %s", locale, dest)
     except OSError as exc:
         logger.warning("UPLOAD", "[%s] Failed to preserve SDK state (non-fatal): %s", locale, exc)
+
+
+def _process_orphan_recovery(
+    job: LocaleUploadJob,
+    client: MDCClient,
+    english_name: str,
+    native_name: str,
+    base_dir: str,
+    start: float,
+) -> UploadResult:
+    """Steps 3-4 only: recover an orphaned draft without re-downloading the tarball."""
+    datasheet_text = ""
+    if job.datasheet_path:
+        if is_gcs_uri(base_dir):
+            datasheet_text = gcs_read_text(base_dir, job.datasheet_path) or ""
+        elif os.path.exists(job.datasheet_path):
+            with open(job.datasheet_path, encoding="utf-8") as f:
+                datasheet_text = f.read()
+    submission = client.build_submission(
+        release_spec=job.release_spec,
+        english_name=english_name,
+        native_name=native_name,
+        locale=job.locale,
+        license_name=job.license_type,
+        datasheet_text=datasheet_text,
+    )
+    logger.info(
+        "UPLOAD",
+        "[%s] RETRYING orphaned draft %s (steps 3-4 only)",
+        job.locale,
+        job.orphaned_submission_id,
+    )
+    submission_id, _ = client.recover_submission(
+        submission_id=job.orphaned_submission_id,  # type: ignore[arg-type]
+        file_upload_id=job.orphaned_file_upload_id,  # type: ignore[arg-type]
+        submission=submission,
+    )
+    return UploadResult(
+        locale=job.locale,
+        status="success",
+        submission_id=submission_id,
+        size_bytes=job.file_size,
+        duration_seconds=time.monotonic() - start,
+        attempts=1,
+    )
+
+
+def _process_resume(
+    job: LocaleUploadJob,
+    client: MDCClient,
+    english_name: str,
+    native_name: str,
+    base_dir: str,
+    start: float,
+) -> tuple[UploadResult, str | None]:
+    """Resume a partial upload from SDK state. Returns (result, tmp_file); caller owns cleanup."""
+    tarball_local, datasheet_text, resolve_error = _resolve_file_and_datasheet(job, base_dir)
+    if tarball_local is None:
+        return UploadResult(
+            locale=job.locale,
+            status="failed",
+            size_bytes=job.file_size,
+            duration_seconds=time.monotonic() - start,
+            error=resolve_error or f"Tarball not found: {job.tarball_path}",
+            attempts=0,
+        ), None
+
+    tmp_file: str | None = tarball_local if is_gcs_uri(base_dir) else None
+    _try_fadvise(tarball_local, getattr(os, "POSIX_FADV_SEQUENTIAL", 0))
+
+    submission = client.build_submission(
+        release_spec=job.release_spec,
+        english_name=english_name,
+        native_name=native_name,
+        locale=job.locale,
+        license_name=job.license_type,
+        datasheet_text=datasheet_text,
+    )
+    logger.info(
+        "UPLOAD",
+        "[%s] RESUMING partial upload for draft %s",
+        job.locale,
+        job.resume_submission_id,
+    )
+    submission_id, _ = client.resume_and_upload(
+        file_path=tarball_local,
+        submission=submission,
+        resume_state_path=job.resume_state_path,  # type: ignore[arg-type]
+        submission_id=job.resume_submission_id,  # type: ignore[arg-type]
+    )
+    return UploadResult(
+        locale=job.locale,
+        status="success",
+        submission_id=submission_id,
+        size_bytes=job.file_size,
+        duration_seconds=time.monotonic() - start,
+        attempts=1,
+    ), tmp_file
 
 
 def process_locale(  # pylint: disable=too-many-return-statements,too-many-branches,too-many-locals
@@ -405,99 +522,25 @@ def process_locale(  # pylint: disable=too-many-return-statements,too-many-branc
         english_name = lang_entry.get("english_name", lang_entry["code"])
         native_name = lang_entry["native_name"]
 
-        # Recovery mode: skip tarball download, go straight to steps 3+4.
-        # Only needs language data + submission metadata, not the tarball.
+        # Recovery mode: steps 3-4 only, no tarball needed.
         if job.orphaned_submission_id and job.orphaned_file_upload_id:
             if client is None:
                 raise RuntimeError("MDC client required for recovery (not dry-run)")
-            # Read datasheet without downloading the tarball
-            datasheet_text = ""
-            if job.datasheet_path:
-                if is_gcs_uri(base_dir):
-                    datasheet_text = gcs_read_text(base_dir, job.datasheet_path) or ""
-                elif os.path.exists(job.datasheet_path):
-                    with open(job.datasheet_path, encoding="utf-8") as f:
-                        datasheet_text = f.read()
-            submission = client.build_submission(
-                release_spec=job.release_spec,
-                english_name=english_name,
-                native_name=native_name,
-                locale=locale,
-                license_name=job.license_type,
-                datasheet_text=datasheet_text,
+            result = _process_orphan_recovery(
+                job, client, english_name, native_name, base_dir, start
             )
-            logger.info(
-                "UPLOAD",
-                "[%s] RETRYING orphaned draft %s (steps 3-4 only)",
-                locale,
-                job.orphaned_submission_id,
-            )
-            submission_id, _ = client.recover_submission(
-                submission_id=job.orphaned_submission_id,
-                file_upload_id=job.orphaned_file_upload_id,
-                submission=submission,
-            )
-            upload_succeeded = True
-            return UploadResult(
-                locale=locale,
-                status="success",
-                submission_id=submission_id,
-                size_bytes=job.file_size,
-                duration_seconds=time.monotonic() - start,
-                attempts=1,
-            )
+            upload_succeeded = result.status == "success"
+            return result
 
         # Resume mode: reuse existing draft, resume partial multipart upload.
         if job.resume_state_path and job.resume_submission_id:
             if client is None:
                 raise RuntimeError("MDC client required for resume (not dry-run)")
-
-            tarball_local, datasheet_text, resolve_error = _resolve_file_and_datasheet(
-                job, base_dir
+            result, tmp_file = _process_resume(
+                job, client, english_name, native_name, base_dir, start
             )
-            if tarball_local is None:
-                return UploadResult(
-                    locale=locale,
-                    status="failed",
-                    size_bytes=job.file_size,
-                    duration_seconds=time.monotonic() - start,
-                    error=resolve_error or f"Tarball not found: {job.tarball_path}",
-                    attempts=0,
-                )
-            if is_gcs_uri(base_dir):
-                tmp_file = tarball_local
-
-            _try_fadvise(tarball_local, getattr(os, "POSIX_FADV_SEQUENTIAL", 0))
-
-            submission = client.build_submission(
-                release_spec=job.release_spec,
-                english_name=english_name,
-                native_name=native_name,
-                locale=locale,
-                license_name=job.license_type,
-                datasheet_text=datasheet_text,
-            )
-            logger.info(
-                "UPLOAD",
-                "[%s] RESUMING partial upload for draft %s",
-                locale,
-                job.resume_submission_id,
-            )
-            submission_id, _ = client.resume_and_upload(
-                file_path=tarball_local,
-                submission=submission,
-                resume_state_path=job.resume_state_path,
-                submission_id=job.resume_submission_id,
-            )
-            upload_succeeded = True
-            return UploadResult(
-                locale=locale,
-                status="success",
-                submission_id=submission_id,
-                size_bytes=job.file_size,
-                duration_seconds=time.monotonic() - start,
-                attempts=1,
-            )
+            upload_succeeded = result.status == "success"
+            return result
 
         # -- Streaming path: skip download, read datasheet from GCS directly --
         if use_streaming and is_gcs_uri(base_dir):
@@ -587,8 +630,7 @@ def process_locale(  # pylint: disable=too-many-return-statements,too-many-branc
             _try_fadvise(tarball_local, getattr(os, "POSIX_FADV_SEQUENTIAL", 0))
 
         if job.submission_id:
-            # Version update mode -- requires a local file (SDK API).
-            # If streaming left tarball_local=None, download now.
+            # Version update: needs local file; download now if streaming left tarball_local=None.
             if tarball_local is None and is_gcs_uri(base_dir):
                 tarball_local, _, resolve_error = _resolve_file_and_datasheet(
                     job, base_dir
@@ -635,8 +677,7 @@ def process_locale(  # pylint: disable=too-many-return-statements,too-many-branc
         os.makedirs(os.path.dirname(state_path), exist_ok=True)
 
         if use_streaming and is_gcs_uri(base_dir):
-            # Streaming mode: GCS range reads -> MDC presigned URLs.
-            # No temp file, no download phase.
+            # Streaming: GCS range reads -> MDC presigned URLs, no temp file.
             bucket_name, base_prefix = parse_gcs_uri(base_dir)
             blob_path = (
                 f"{base_prefix}/{job.tarball_path}"
@@ -753,6 +794,31 @@ def print_summary(state: BatchState) -> None:
     if log_path:
         logger.info("UPLOAD", "Log file: %s", log_path)
 
+    # Disable-prior footer (only shown when mode is not skip)
+    if state.disable_mode != DisableMode.SKIP:
+        logger.info("UPLOAD", "")
+        if state.disable_mode == DisableMode.PRE:
+            logger.info("UPLOAD", "Pre-disabled prior versions: %d", state.disabled_total)
+        else:
+            logger.info(
+                "UPLOAD",
+                "Post-disabled prior versions: %d / %d",
+                state.disabled_total,
+                state.locales_with_prior,
+            )
+        if state.disable_pending_total > 0:
+            logger.info(
+                "UPLOAD",
+                "Pending (endpoint TBD): %d",
+                state.disable_pending_total,
+            )
+        if state.disable_failed_ids:
+            logger.info(
+                "UPLOAD",
+                "Failed to disable: %s",
+                state.disable_failed_ids,
+            )
+
     if failed > 0:
         logger.info("UPLOAD", "")
         logger.info(
@@ -765,8 +831,7 @@ def print_summary(state: BatchState) -> None:
             "To retry failed: mdc-upload --retry-failed %s",
             state.state_path,
         )
-        # Check for SDK state files that support --resume (partial uploads).
-        # State may be in upload-logs/ (GCS-persistent) or .state/ (local).
+        # SDK state files support --resume; may be in upload-logs/ (GCS) or .state/ (local).
         from mdc_uploader.constants import (
             DEFAULT_BASE_DIR,  # pylint: disable=import-outside-toplevel
         )
@@ -818,13 +883,13 @@ def run_batch(config: UploaderConfig) -> bool:
     if config.dry_run:
         logger.info("UPLOAD", "** DRY RUN MODE **")
 
-    # Initialize batch state early so save_logs_to_storage can persist
-    # the log file even if build_jobs or language.init() fails.
+    # BatchState early so logs are persisted even when build_jobs or language.init() fails.
     state = BatchState(
         release=config.release_name,
         upload_target=config.upload_target,
         release_type=config.release_type.value,
         base_dir=config.base_dir,
+        disable_mode=config.disable_mode.value,
     )
 
     try:
@@ -863,14 +928,56 @@ def run_batch(config: UploaderConfig) -> bool:
             else None
         )
 
+        # Prior version map: loaded once for both pre and post modes.
+        # Empty for skip mode or when org page is unavailable.
+        prior_map: dict[str, list[str]] = {}
+        if config.disable_mode != DisableMode.SKIP:
+            prior_map = prior_module.load_prior_map(
+                disable_mode=config.disable_mode,
+                base_dir=config.base_dir,
+                release_spec=release_spec,
+                force_rescrape=config.force_rescrape,
+            )
+            state.locales_with_prior = len(prior_map)
+
+        # Pre-mode: bulk disable all prior versions before starting uploads.
+        if config.disable_mode == DisableMode.PRE and prior_map:
+            all_prior = [sid for ids in prior_map.values() for sid in ids]
+            logger.info(
+                "UPLOAD",
+                "Pre-disabling %d submission(s) across %d locale(s)...",
+                len(all_prior),
+                len(prior_map),
+            )
+            if config.dry_run:
+                logger.info(
+                    "UPLOAD",
+                    "DRY RUN -- would pre-disable %d submission(s): %s",
+                    len(all_prior),
+                    all_prior,
+                )
+                state.disable_pending_total += len(all_prior)
+            elif client is not None:
+                for locale_code, ids in prior_map.items():
+                    dis, fail, pend = _disable_prior_version(locale_code, ids, client)
+                    state.disabled_total += len(dis)
+                    state.disable_failed_ids.extend(fail)
+                    state.disable_pending_total += len(pend)
+                logger.info(
+                    "UPLOAD",
+                    "Pre-disable complete: %d disabled, %d pending, %d failed",
+                    state.disabled_total,
+                    state.disable_pending_total,
+                    len(state.disable_failed_ids),
+                )
+                state.flush()  # persist before batch starts — survives pod recycle
+
         # Streaming is default for gs:// URIs; --no-stream disables it.
         use_streaming = is_gcs_uri(config.base_dir) and not config.no_stream
         if use_streaming:
             logger.info("UPLOAD", "Streaming mode: GCS range-read -> MDC (no temp files)")
 
-        # Concurrency and retry settings.
-        # Parallel only with streaming -- non-streaming downloads to temp
-        # and concurrent downloads would exhaust ephemeral disk.
+        # Parallel only with streaming — concurrent temp downloads would exhaust disk.
         max_workers = config.jobs if use_streaming else 1
         max_retries = 3
 
@@ -896,9 +1003,7 @@ def run_batch(config: UploaderConfig) -> bool:
                 )
                 if result.status != "failed":
                     break
-                # Orphaned drafts should not be retried -- each retry
-                # would create a new draft, wasting API quota.
-                # Use --retry-failed to recover from step 3 instead.
+                # Orphaned drafts: don't retry — each retry creates a new draft; use --retry-failed.
                 if result.orphaned_draft:
                     break
                 if attempt < max_retries:
@@ -911,23 +1016,57 @@ def run_batch(config: UploaderConfig) -> bool:
                         result.error,
                     )
             assert result is not None
-            result.attempts = max(result.attempts, attempt)
+            result.attempts = attempt
             return result
 
         def _log_result(result: UploadResult) -> None:
             nonlocal completed_count
+
+            # Post-mode: disable prior version immediately after a successful upload.
+            if (
+                config.disable_mode == DisableMode.POST
+                and result.status == "success"
+                and result.locale in prior_map
+            ):
+                prior_ids = prior_map[result.locale]
+                if config.dry_run:
+                    logger.info(
+                        "UPLOAD",
+                        "[%s] DRY RUN -- would disable %d prior: %s",
+                        result.locale,
+                        len(prior_ids),
+                        prior_ids,
+                    )
+                    result.disable_pending_ids = list(prior_ids)
+                elif client is not None:
+                    dis, fail, pend = _disable_prior_version(result.locale, prior_ids, client)
+                    result.disabled_ids = dis
+                    result.disable_failed_ids = fail
+                    result.disable_pending_ids = pend
+
             state.record(result)
             with completed_lock:
                 completed_count += 1
                 idx = completed_count
             total = len(jobs)
+
+            # Build optional disable suffix for the log line
+            disable_suffix = ""
+            if result.disabled_ids:
+                disable_suffix = f"  [disabled {len(result.disabled_ids)} prior]"
+            elif result.disable_pending_ids:
+                disable_suffix = f"  [disable pending: {len(result.disable_pending_ids)}]"
+            elif result.disable_failed_ids:
+                disable_suffix = f"  [disable failed: {result.disable_failed_ids}]"
+
             if result.status == "success":
                 logger.info(
                     "UPLOAD",
-                    "[%d/%d] %s -- SUCCESS (%s in %.1fs)",
+                    "[%d/%d] %s -- SUCCESS (%s in %.1fs)%s",
                     idx, total, result.locale,
                     format_size(result.size_bytes),
                     result.duration_seconds,
+                    disable_suffix,
                 )
             elif result.status == "failed":
                 logger.error(
@@ -938,8 +1077,8 @@ def run_batch(config: UploaderConfig) -> bool:
             elif result.status == "skipped":
                 logger.info(
                     "UPLOAD",
-                    "[%d/%d] %s -- SKIPPED (dry run)",
-                    idx, total, result.locale,
+                    "[%d/%d] %s -- SKIPPED (dry run)%s",
+                    idx, total, result.locale, disable_suffix,
                 )
             progress.update(1)
 
@@ -975,6 +1114,5 @@ def run_batch(config: UploaderConfig) -> bool:
         _, failed, _ = state.summary()
         return failed == 0
     finally:
-        # Persist logs to GCS so they survive pod recycling.
-        # Runs on all exit paths including early errors.
+        # Persist logs to GCS on all exit paths (pod recycle safety).
         save_logs_to_storage(config.base_dir, config.release_name, state)

--- a/bundler/uploader/src/mdc_uploader/pipeline.py
+++ b/bundler/uploader/src/mdc_uploader/pipeline.py
@@ -802,7 +802,7 @@ def print_summary(state: BatchState) -> None:
         else:
             logger.info(
                 "UPLOAD",
-                "Post-disabled prior versions: %d / %d",
+                "Post-disabled prior versions: %d submission(s) in %d locale(s)",
                 state.disabled_total,
                 state.locales_with_prior,
             )
@@ -938,6 +938,13 @@ def run_batch(config: UploaderConfig) -> bool:
                 release_spec=release_spec,
                 force_rescrape=config.force_rescrape,
             )
+            # Exclude the target submission when --submission-id is used with --disable-prior.
+            if config.submission_id:
+                prior_map = {
+                    loc: [s for s in ids if s != config.submission_id]
+                    for loc, ids in prior_map.items()
+                    if any(s != config.submission_id for s in ids)
+                }
             state.locales_with_prior = len(prior_map)
 
         # Pre-mode: bulk disable all prior versions before starting uploads.

--- a/bundler/uploader/src/mdc_uploader/pipeline.py
+++ b/bundler/uploader/src/mdc_uploader/pipeline.py
@@ -804,7 +804,7 @@ def print_summary(state: BatchState) -> None:
                 "UPLOAD",
                 "Post-disabled prior versions: %d submission(s) in %d locale(s)",
                 state.disabled_total,
-                state.locales_with_prior,
+                state.locales_disabled_count,
             )
         if state.disable_pending_total > 0:
             logger.info(

--- a/bundler/uploader/src/mdc_uploader/prior.py
+++ b/bundler/uploader/src/mdc_uploader/prior.py
@@ -1,0 +1,46 @@
+"""Prior version map for the disable-prior feature.
+
+Single entry point used by both pre-mode (bulk disable before batch)
+and post-mode (per-locale disable after success).
+"""
+
+from __future__ import annotations
+
+from mdc_uploader import org_page
+from mdc_uploader.constants import MDC_ORG_ID, MDC_SITE_BASE
+from mdc_uploader.log import logger
+from mdc_uploader.models import DisableMode, ReleaseSpec
+
+
+def load_prior_map(
+    disable_mode: DisableMode,
+    base_dir: str,
+    release_spec: ReleaseSpec,
+    force_rescrape: bool = False,
+) -> dict[str, list[str]]:
+    """Return {locale_code -> [prior_submission_ids]}.
+
+    Returns {} when disable_mode is SKIP or the org page cannot be loaded.
+    Calls org_page.load_or_fetch() for both pre and post modes.
+
+    Note: version filter in build_prior_map already excludes current-version entries.
+    """
+    if disable_mode == DisableMode.SKIP:
+        return {}
+
+    datasets = org_page.load_or_fetch(
+        site_base=MDC_SITE_BASE,
+        org_id=MDC_ORG_ID,
+        gcs_base=base_dir,
+        force_rescrape=force_rescrape,
+    )
+
+    if not datasets:
+        logger.warning("ORG", "No datasets loaded from org page -- skipping disable")
+        return {}
+
+    return org_page.build_prior_map(
+        datasets=datasets,
+        modality=release_spec.modality,
+        current_version=release_spec.version,
+    )

--- a/bundler/uploader/src/mdc_uploader/state.py
+++ b/bundler/uploader/src/mdc_uploader/state.py
@@ -41,7 +41,8 @@ class BatchState:
         self.disabled_total: int = 0
         self.disable_failed_ids: list[str] = []
         self.disable_pending_total: int = 0
-        self.locales_with_prior: int = 0  # for post-mode M count
+        self.locales_with_prior: int = 0  # eligible locale count (set after prior_map load)
+        self.locales_disabled_count: int = 0  # locales where at least one disable succeeded
         resolved_dir = output_dir if output_dir is not None else STATE_DIR
         os.makedirs(resolved_dir, exist_ok=True)
         self._state_path = self._build_path(release, resolved_dir)
@@ -82,6 +83,7 @@ class BatchState:
             # Accumulate disable-prior stats
             if result.disabled_ids:
                 self.disabled_total += len(result.disabled_ids)
+                self.locales_disabled_count += 1
             if result.disable_failed_ids:
                 self.disable_failed_ids.extend(result.disable_failed_ids)
             if result.disable_pending_ids:
@@ -104,6 +106,7 @@ class BatchState:
             "locales": self.locales,
             "disable_mode": self.disable_mode,
             "locales_with_prior": self.locales_with_prior,
+            "locales_disabled_count": self.locales_disabled_count,
             "disabled_total": self.disabled_total,
             "disable_failed_ids": self.disable_failed_ids,
             "disable_pending_total": self.disable_pending_total,

--- a/bundler/uploader/src/mdc_uploader/state.py
+++ b/bundler/uploader/src/mdc_uploader/state.py
@@ -102,6 +102,8 @@ class BatchState:
             "base_dir": self.base_dir,
             "started_at": self.started_at,
             "locales": self.locales,
+            "disable_mode": self.disable_mode,
+            "locales_with_prior": self.locales_with_prior,
             "disabled_total": self.disabled_total,
             "disable_failed_ids": self.disable_failed_ids,
             "disable_pending_total": self.disable_pending_total,

--- a/bundler/uploader/src/mdc_uploader/state.py
+++ b/bundler/uploader/src/mdc_uploader/state.py
@@ -27,14 +27,21 @@ class BatchState:
         release_type: str,
         base_dir: str,
         output_dir: str | None = None,
+        disable_mode: str = "skip",
     ) -> None:
         self.release = release
         self.upload_target = upload_target
         self.release_type = release_type
         self.base_dir = base_dir
+        self.disable_mode = disable_mode
         self.started_at = datetime.now(UTC).isoformat()
         self.locales: dict[str, LocaleStateEntry] = {}
         self._lock = threading.Lock()
+        # Disable-prior accumulators (updated under lock in record())
+        self.disabled_total: int = 0
+        self.disable_failed_ids: list[str] = []
+        self.disable_pending_total: int = 0
+        self.locales_with_prior: int = 0  # for post-mode M count
         resolved_dir = output_dir if output_dir is not None else STATE_DIR
         os.makedirs(resolved_dir, exist_ok=True)
         self._state_path = self._build_path(release, resolved_dir)
@@ -72,6 +79,18 @@ class BatchState:
 
         with self._lock:
             self.locales[result.locale] = entry
+            # Accumulate disable-prior stats
+            if result.disabled_ids:
+                self.disabled_total += len(result.disabled_ids)
+            if result.disable_failed_ids:
+                self.disable_failed_ids.extend(result.disable_failed_ids)
+            if result.disable_pending_ids:
+                self.disable_pending_total += len(result.disable_pending_ids)
+            self._flush()
+
+    def flush(self) -> None:
+        """Force-flush state to disk (thread-safe). Call after bulk operations."""
+        with self._lock:
             self._flush()
 
     def _flush(self) -> None:
@@ -83,6 +102,9 @@ class BatchState:
             "base_dir": self.base_dir,
             "started_at": self.started_at,
             "locales": self.locales,
+            "disabled_total": self.disabled_total,
+            "disable_failed_ids": self.disable_failed_ids,
+            "disable_pending_total": self.disable_pending_total,
         }
         with open(self._state_path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)

--- a/bundler/uploader/tests/test_config.py
+++ b/bundler/uploader/tests/test_config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from mdc_uploader.config import UploaderConfig
-from mdc_uploader.models import ReleaseType
+from mdc_uploader.models import DisableMode, ReleaseType
 
 
 class TestResumeValidation:
@@ -284,3 +284,86 @@ class TestUploaderConfigFromCli:
             mdc_api_url=None,
         )
         assert config.no_stream is True
+
+    def test_disable_mode_default_skip(self) -> None:
+        """disable_mode defaults to skip."""
+        config = UploaderConfig.from_cli(
+            release="cv-corpus-25.0-2026-03-09",
+            upload_target="dev",
+            base_dir=None,
+            release_type="full",
+            locales=None,
+            submission_id=None,
+            dry_run=False,
+            verbose=False,
+            mdc_api_key="test",
+            mdc_api_url=None,
+        )
+        assert config.disable_mode == DisableMode.SKIP
+
+    def test_disable_mode_pre(self) -> None:
+        """disable_mode='pre' is parsed to DisableMode.PRE."""
+        config = UploaderConfig.from_cli(
+            release="cv-corpus-25.0-2026-03-09",
+            upload_target="dev",
+            base_dir=None,
+            release_type="full",
+            locales=None,
+            submission_id=None,
+            dry_run=False,
+            verbose=False,
+            mdc_api_key="test",
+            mdc_api_url=None,
+            disable_mode="pre",
+        )
+        assert config.disable_mode == DisableMode.PRE
+
+    def test_disable_mode_post(self) -> None:
+        """disable_mode='post' is parsed to DisableMode.POST."""
+        config = UploaderConfig.from_cli(
+            release="cv-corpus-25.0-2026-03-09",
+            upload_target="dev",
+            base_dir=None,
+            release_type="full",
+            locales=None,
+            submission_id=None,
+            dry_run=False,
+            verbose=False,
+            mdc_api_key="test",
+            mdc_api_url=None,
+            disable_mode="post",
+        )
+        assert config.disable_mode == DisableMode.POST
+
+    def test_force_rescrape_default_false(self) -> None:
+        """force_rescrape defaults to False."""
+        config = UploaderConfig.from_cli(
+            release="cv-corpus-25.0-2026-03-09",
+            upload_target="dev",
+            base_dir=None,
+            release_type="full",
+            locales=None,
+            submission_id=None,
+            dry_run=False,
+            verbose=False,
+            mdc_api_key="test",
+            mdc_api_url=None,
+        )
+        assert config.force_rescrape is False
+
+    def test_force_rescrape_true(self) -> None:
+        """force_rescrape=True is passed through."""
+        config = UploaderConfig.from_cli(
+            release="cv-corpus-25.0-2026-03-09",
+            upload_target="dev",
+            base_dir=None,
+            release_type="full",
+            locales=None,
+            submission_id=None,
+            dry_run=False,
+            verbose=False,
+            mdc_api_key="test",
+            mdc_api_url=None,
+            force_rescrape=True,
+        )
+        assert config.force_rescrape is True

--- a/bundler/uploader/tests/test_mdc.py
+++ b/bundler/uploader/tests/test_mdc.py
@@ -527,6 +527,55 @@ class TestStreamAndUpload:
             )
 
 
+class TestDisableSubmission:
+    """Tests for disable_submission and disable_submissions."""
+
+    def _client(self) -> MDCClient:
+        return MDCClient(api_key="test", api_url="http://test")
+
+    def test_disable_submission_pending_when_endpoint_none(self) -> None:
+        """When MDC_DISABLE_ENDPOINT is None, returns False and logs PENDING."""
+        import mdc_uploader.constants as consts
+        original = consts.MDC_DISABLE_ENDPOINT
+        try:
+            consts.MDC_DISABLE_ENDPOINT = None
+            result = self._client().disable_submission("sub-123")
+        finally:
+            consts.MDC_DISABLE_ENDPOINT = original
+        assert result is False
+
+    def test_disable_submissions_returns_map(self) -> None:
+        """disable_submissions returns {id -> result} map."""
+        import mdc_uploader.constants as consts
+        original = consts.MDC_DISABLE_ENDPOINT
+        try:
+            consts.MDC_DISABLE_ENDPOINT = None
+            result = self._client().disable_submissions(["sub-a", "sub-b"])
+        finally:
+            consts.MDC_DISABLE_ENDPOINT = original
+        assert set(result.keys()) == {"sub-a", "sub-b"}
+        assert result["sub-a"] is False
+        assert result["sub-b"] is False
+
+    def test_disable_submissions_empty_list(self) -> None:
+        """disable_submissions on empty list returns empty dict."""
+        result = self._client().disable_submissions([])
+        assert result == {}
+
+    def test_disable_submissions_nonfatal_on_exception(self) -> None:
+        """Unhandled exception in disable_submission is caught; result is False."""
+        client = self._client()
+        import mdc_uploader.constants as consts
+        original = consts.MDC_DISABLE_ENDPOINT
+        try:
+            consts.MDC_DISABLE_ENDPOINT = ("DELETE", "/submissions/{id}")
+            result = client.disable_submissions(["sub-fail"])
+        finally:
+            consts.MDC_DISABLE_ENDPOINT = original
+        # NotImplementedError is caught as broad exception, result = False
+        assert result["sub-fail"] is False
+
+
 class TestVerbosePassthrough:
     """Tests for verbose flag passthrough to SDK."""
 

--- a/bundler/uploader/tests/test_org_page.py
+++ b/bundler/uploader/tests/test_org_page.py
@@ -1,0 +1,330 @@
+"""Tests for org_page.py -- scraping, snapshot I/O, and prior map."""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mdc_uploader.models import Modality, OrgDataset
+from mdc_uploader.org_page import (
+    _parse_org_page,
+    build_prior_map,
+    fetch_org_datasets,
+    load_or_fetch,
+    load_org_snapshot,
+    save_org_snapshot,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_dataset(
+    locale: str = "en",
+    modality: str = "scs",
+    version: str = "25.0",
+    sid: str = "cmndapwry02jnmh07dyo46mot",
+    name: str | None = None,
+) -> OrgDataset:
+    if name is None:
+        mod_word = "Scripted" if modality == "scs" else "Spontaneous"
+        locale_name = {"en": "English", "fr": "French", "de": "German"}.get(locale, locale)
+        name = f"Common Voice {mod_word} Speech {version} - {locale_name}"
+    return OrgDataset(
+        locale_code=locale,
+        modality=modality,
+        version=version,
+        submission_id=sid,
+        name=name,
+        locale_name=name.rsplit(" - ", 1)[-1],
+        href=f"/datasets/{sid}",
+    )
+
+
+def _make_html(entries: list[tuple[str, str, str]]) -> str:
+    """Build minimal org page HTML from (locale, sid, name) tuples."""
+    rows = []
+    for locale, sid, name in entries:
+        rows.append(
+            f"<tr>"
+            f'<td>{locale}</td>'
+            f'<td><a href="/datasets/{sid}">{name}</a></td>'
+            f"</tr>"
+        )
+    return "<table>" + "".join(rows) + "</table>"
+
+
+# ---------------------------------------------------------------------------
+# _parse_org_page
+# ---------------------------------------------------------------------------
+
+
+class TestParseOrgPage:
+    def test_parses_scs_entry(self) -> None:
+        html = _make_html([
+            ("en", "cmndapwry02jnmh07dyo46mot", "Common Voice Scripted Speech 25.0 - English"),
+        ])
+        result = _parse_org_page(html)
+        assert len(result) == 1
+        d = result[0]
+        assert d.locale_code == "en"
+        assert d.modality == "scs"
+        assert d.version == "25.0"
+        assert d.submission_id == "cmndapwry02jnmh07dyo46mot"
+        assert d.locale_name == "English"
+        assert d.href == "/datasets/cmndapwry02jnmh07dyo46mot"
+
+    def test_parses_sps_entry(self) -> None:
+        html = _make_html([
+            ("fr", "cmn1pv5hi00uto1072y1074y7", "Common Voice Spontaneous Speech 3.0 - French"),
+        ])
+        result = _parse_org_page(html)
+        assert len(result) == 1
+        assert result[0].modality == "sps"
+        assert result[0].locale_code == "fr"
+        assert result[0].version == "3.0"
+
+    def test_parses_multiple_entries(self) -> None:
+        html = _make_html([
+            ("en", "cmndapwry02jnmh07dyo46mot", "Common Voice Scripted Speech 25.0 - English"),
+            ("fr", "cmn2abc123def456ghi789jkl", "Common Voice Scripted Speech 25.0 - French"),
+        ])
+        result = _parse_org_page(html)
+        assert len(result) == 2
+        locales = {d.locale_code for d in result}
+        assert locales == {"en", "fr"}
+
+    def test_skips_non_cv_names(self) -> None:
+        html = _make_html([
+            ("en", "cmndapwry02jnmh07dyo46mot", "Common Voice Scripted Speech 25.0 - English"),
+            ("xx", "cmn0000000000000000000001", "Some Other Dataset - Unknown"),
+        ])
+        result = _parse_org_page(html)
+        assert len(result) == 1
+        assert result[0].locale_code == "en"
+
+    def test_deduplicates_same_id(self) -> None:
+        row = '<tr><td>en</td><td><a href="/datasets/cmndapwry02jnmh07dyo46mot">Common Voice Scripted Speech 25.0 - English</a></td></tr>'
+        html = "<table>" + row + row + "</table>"
+        result = _parse_org_page(html)
+        assert len(result) == 1
+
+    def test_skips_row_without_locale(self) -> None:
+        # Row has no cell that looks like a locale code
+        html = (
+            '<table>'
+            '<tr><td>NOT-A-LOCALE-CODE-TOO-LONG</td>'
+            '<td><a href="/datasets/cmndapwry02jnmh07dyo46mot">Common Voice Scripted Speech 25.0 - English</a></td></tr>'
+            '</table>'
+        )
+        result = _parse_org_page(html)
+        assert len(result) == 0
+
+    def test_empty_html_returns_empty(self) -> None:
+        assert _parse_org_page("") == []
+
+    def test_hyphenated_locale_code(self) -> None:
+        html = _make_html([
+            ("rm-vallader", "cmn1aaaaaaaaaaaaaaaaaaaaa", "Common Voice Scripted Speech 25.0 - Romansh Vallader"),
+        ])
+        result = _parse_org_page(html)
+        assert len(result) == 1
+        assert result[0].locale_code == "rm-vallader"
+
+
+# ---------------------------------------------------------------------------
+# fetch_org_datasets
+# ---------------------------------------------------------------------------
+
+
+class TestFetchOrgDatasets:
+    def test_returns_datasets_on_success(self) -> None:
+        html = _make_html([
+            ("en", "cmndapwry02jnmh07dyo46mot", "Common Voice Scripted Speech 25.0 - English"),
+        ])
+        mock_resp = MagicMock()
+        mock_resp.text = html
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch("mdc_uploader.org_page.httpx.get", return_value=mock_resp):
+            result = fetch_org_datasets("https://example.com", "orgid123")
+
+        assert len(result) == 1
+        assert result[0].locale_code == "en"
+
+    def test_returns_empty_on_http_error(self) -> None:
+        with patch("mdc_uploader.org_page.httpx.get", side_effect=Exception("connection refused")):
+            result = fetch_org_datasets("https://example.com", "orgid123")
+        assert result == []
+
+    def test_returns_empty_on_non_200(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = Exception("404")
+        with patch("mdc_uploader.org_page.httpx.get", return_value=mock_resp):
+            result = fetch_org_datasets("https://example.com", "orgid123")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# load_org_snapshot / save_org_snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestOrgSnapshot:
+    def test_round_trip_local(self, tmp_path: object) -> None:
+        """Save to local path and load back."""
+        base = str(tmp_path)
+        datasets = [_make_dataset("en"), _make_dataset("fr", sid="cmn2abc123def456ghi789jkl")]
+        save_org_snapshot(datasets, base)
+
+        loaded = load_org_snapshot(base)
+        assert loaded is not None
+        assert len(loaded) == 2
+        locales = {d.locale_code for d in loaded}
+        assert locales == {"en", "fr"}
+
+    def test_load_returns_none_on_miss(self, tmp_path: object) -> None:
+        result = load_org_snapshot(str(tmp_path))
+        assert result is None
+
+    def test_load_returns_none_on_malformed_json(self, tmp_path: object) -> None:
+        state_dir = os.path.join(str(tmp_path), ".state")
+        os.makedirs(state_dir)
+        with open(os.path.join(state_dir, "org-snapshot.json"), "w") as f:
+            f.write("not json {{{")
+        result = load_org_snapshot(str(tmp_path))
+        assert result is None
+
+    def test_load_returns_none_on_missing_key(self, tmp_path: object) -> None:
+        state_dir = os.path.join(str(tmp_path), ".state")
+        os.makedirs(state_dir)
+        with open(os.path.join(state_dir, "org-snapshot.json"), "w") as f:
+            json.dump({"scraped_at": "2026-06-06T00:00:00Z", "datasets": [{"no_locale": "x"}]}, f)
+        result = load_org_snapshot(str(tmp_path))
+        assert result is None
+
+    def test_tsv_written_with_correct_columns(self, tmp_path: object) -> None:
+        base = str(tmp_path)
+        datasets = [_make_dataset("en")]
+        save_org_snapshot(datasets, base)
+
+        tsv_path = os.path.join(base, ".state", "org-snapshot.tsv")
+        with open(tsv_path, encoding="utf-8") as f:
+            lines = f.read().splitlines()
+        assert lines[0] == "locale\tmodality\tversion\tid\tname"
+        assert lines[1].startswith("en\tscs\t25.0\t")
+
+    def test_save_failure_is_nonfatal(self, tmp_path: object) -> None:
+        # Make .state a file (not a dir) to trigger failure
+        bad_state = os.path.join(str(tmp_path), ".state")
+        with open(bad_state, "w") as f:
+            f.write("block")
+        datasets = [_make_dataset("en")]
+        save_org_snapshot(datasets, str(tmp_path))  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# load_or_fetch
+# ---------------------------------------------------------------------------
+
+
+class TestLoadOrFetch:
+    def test_uses_cache_when_available(self, tmp_path: object) -> None:
+        base = str(tmp_path)
+        datasets = [_make_dataset("en")]
+        save_org_snapshot(datasets, base)
+
+        with patch("mdc_uploader.org_page.fetch_org_datasets") as mock_fetch:
+            result = load_or_fetch(gcs_base=base)
+
+        mock_fetch.assert_not_called()
+        assert len(result) == 1
+
+    def test_force_rescrape_bypasses_cache(self, tmp_path: object) -> None:
+        base = str(tmp_path)
+        # Pre-populate cache
+        save_org_snapshot([_make_dataset("en")], base)
+
+        fresh = [_make_dataset("fr", sid="cmn2abc123def456ghi789jkl")]
+        with patch("mdc_uploader.org_page.fetch_org_datasets", return_value=fresh):
+            result = load_or_fetch(gcs_base=base, force_rescrape=True)
+
+        assert len(result) == 1
+        assert result[0].locale_code == "fr"
+
+    def test_scrapes_when_no_cache(self, tmp_path: object) -> None:
+        base = str(tmp_path)
+        fresh = [_make_dataset("de", sid="cmn3abc123def456ghi789jkl")]
+        with patch("mdc_uploader.org_page.fetch_org_datasets", return_value=fresh):
+            result = load_or_fetch(gcs_base=base)
+
+        assert len(result) == 1
+        assert result[0].locale_code == "de"
+        # Snapshot was saved
+        assert os.path.exists(os.path.join(base, ".state", "org-snapshot.json"))
+
+    def test_returns_empty_on_total_failure(self) -> None:
+        with patch("mdc_uploader.org_page.fetch_org_datasets", return_value=[]):
+            result = load_or_fetch()
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# build_prior_map
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPriorMap:
+    def test_filters_by_modality(self) -> None:
+        datasets = [
+            _make_dataset("en", "scs", "24.0", "cmn1aaaaaaaaaaaaaaaaaaaaa"),
+            _make_dataset("en", "sps", "2.0", "cmn2bbbbbbbbbbbbbbbbbbbb"),
+        ]
+        result = build_prior_map(datasets, Modality.SCS, "25.0")
+        assert "en" in result
+        assert "cmn1aaaaaaaaaaaaaaaaaaaaa" in result["en"]
+        assert "cmn2bbbbbbbbbbbbbbbbbbbb" not in result.get("en", [])
+
+    def test_excludes_current_version(self) -> None:
+        datasets = [
+            _make_dataset("en", "scs", "25.0", "cmn1aaaaaaaaaaaaaaaaaaaaa"),
+            _make_dataset("fr", "scs", "24.0", "cmn2bbbbbbbbbbbbbbbbbbbb"),
+        ]
+        result = build_prior_map(datasets, Modality.SCS, "25.0")
+        assert "en" not in result
+        assert "fr" in result
+
+    def test_excludes_current_submission_ids(self) -> None:
+        datasets = [
+            _make_dataset("en", "scs", "24.0", "cmn1aaaaaaaaaaaaaaaaaaaaa"),
+        ]
+        result = build_prior_map(
+            datasets, Modality.SCS, "25.0", current_submission_ids={"cmn1aaaaaaaaaaaaaaaaaaaaa"}
+        )
+        assert result == {}
+
+    def test_returns_empty_for_no_prior(self) -> None:
+        datasets = [_make_dataset("en", "scs", "25.0")]
+        result = build_prior_map(datasets, Modality.SCS, "25.0")
+        assert result == {}
+
+    def test_preserves_one_time_uploads(self) -> None:
+        datasets = [
+            _make_dataset("en", "scs", "24.0", "cmn1aaaaaaaaaaaaaaaaaaaaa"),
+            _make_dataset("xx", "sps", "1.0", "cmn2bbbbbbbbbbbbbbbbbbbb"),  # SPS -- different modality
+        ]
+        result = build_prior_map(datasets, Modality.SCS, "25.0")
+        assert "xx" not in result
+        assert "en" in result
+
+    def test_multiple_prior_versions_per_locale(self) -> None:
+        datasets = [
+            _make_dataset("en", "scs", "23.0", "cmn1aaaaaaaaaaaaaaaaaaaaa"),
+            _make_dataset("en", "scs", "24.0", "cmn2bbbbbbbbbbbbbbbbbbbb"),
+        ]
+        result = build_prior_map(datasets, Modality.SCS, "25.0")
+        assert len(result["en"]) == 2

--- a/bundler/uploader/tests/test_org_page.py
+++ b/bundler/uploader/tests/test_org_page.py
@@ -6,8 +6,6 @@ import json
 import os
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from mdc_uploader.models import Modality, OrgDataset
 from mdc_uploader.org_page import (
     _parse_org_page,
@@ -17,7 +15,6 @@ from mdc_uploader.org_page import (
     load_org_snapshot,
     save_org_snapshot,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -108,7 +105,11 @@ class TestParseOrgPage:
         assert result[0].locale_code == "en"
 
     def test_deduplicates_same_id(self) -> None:
-        row = '<tr><td>en</td><td><a href="/datasets/cmndapwry02jnmh07dyo46mot">Common Voice Scripted Speech 25.0 - English</a></td></tr>'
+        row = (
+            '<tr><td>en</td>'
+            '<td><a href="/datasets/cmndapwry02jnmh07dyo46mot">'
+            "Common Voice Scripted Speech 25.0 - English</a></td></tr>"
+        )
         html = "<table>" + row + row + "</table>"
         result = _parse_org_page(html)
         assert len(result) == 1
@@ -116,10 +117,11 @@ class TestParseOrgPage:
     def test_skips_row_without_locale(self) -> None:
         # Row has no cell that looks like a locale code
         html = (
-            '<table>'
-            '<tr><td>NOT-A-LOCALE-CODE-TOO-LONG</td>'
-            '<td><a href="/datasets/cmndapwry02jnmh07dyo46mot">Common Voice Scripted Speech 25.0 - English</a></td></tr>'
-            '</table>'
+            "<table>"
+            "<tr><td>NOT-A-LOCALE-CODE-TOO-LONG</td>"
+            '<td><a href="/datasets/cmndapwry02jnmh07dyo46mot">'
+            "Common Voice Scripted Speech 25.0 - English</a></td></tr>"
+            "</table>"
         )
         result = _parse_org_page(html)
         assert len(result) == 0
@@ -129,7 +131,8 @@ class TestParseOrgPage:
 
     def test_hyphenated_locale_code(self) -> None:
         html = _make_html([
-            ("rm-vallader", "cmn1aaaaaaaaaaaaaaaaaaaaa", "Common Voice Scripted Speech 25.0 - Romansh Vallader"),
+            ("rm-vallader", "cmn1aaaaaaaaaaaaaaaaaaaaa",
+             "Common Voice Scripted Speech 25.0 - Romansh Vallader"),
         ])
         result = _parse_org_page(html)
         assert len(result) == 1
@@ -315,7 +318,7 @@ class TestBuildPriorMap:
     def test_preserves_one_time_uploads(self) -> None:
         datasets = [
             _make_dataset("en", "scs", "24.0", "cmn1aaaaaaaaaaaaaaaaaaaaa"),
-            _make_dataset("xx", "sps", "1.0", "cmn2bbbbbbbbbbbbbbbbbbbb"),  # SPS -- different modality
+            _make_dataset("xx", "sps", "1.0", "cmn2bbbbbbbbbbbbbbbbbbbb"),  # SPS
         ]
         result = build_prior_map(datasets, Modality.SCS, "25.0")
         assert "xx" not in result

--- a/bundler/uploader/tests/test_prior.py
+++ b/bundler/uploader/tests/test_prior.py
@@ -1,0 +1,93 @@
+"""Tests for prior.py -- load_prior_map."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from mdc_uploader.models import DisableMode, Modality, OrgDataset
+from mdc_uploader.naming import parse_release_name
+from mdc_uploader.prior import load_prior_map
+
+
+def _scs_release() -> object:
+    return parse_release_name("cv-corpus-25.0-2026-03-09")
+
+
+def _make_dataset(locale: str, version: str, sid: str, modality: str = "scs") -> OrgDataset:
+    mod_word = "Scripted" if modality == "scs" else "Spontaneous"
+    name = f"Common Voice {mod_word} Speech {version} - English"
+    return OrgDataset(
+        locale_code=locale,
+        modality=modality,
+        version=version,
+        submission_id=sid,
+        name=name,
+        locale_name="English",
+        href=f"/datasets/{sid}",
+    )
+
+
+class TestLoadPriorMap:
+    def test_returns_empty_for_skip_mode(self) -> None:
+        with patch("mdc_uploader.prior.org_page.load_or_fetch") as mock_fetch:
+            result = load_prior_map(
+                disable_mode=DisableMode.SKIP,
+                base_dir="/gcs",
+                release_spec=_scs_release(),
+            )
+        mock_fetch.assert_not_called()
+        assert result == {}
+
+    def test_returns_empty_when_fetch_fails(self) -> None:
+        with patch("mdc_uploader.prior.org_page.load_or_fetch", return_value=[]):
+            result = load_prior_map(
+                disable_mode=DisableMode.PRE,
+                base_dir="/gcs",
+                release_spec=_scs_release(),
+            )
+        assert result == {}
+
+    def test_pre_mode_calls_load_or_fetch(self) -> None:
+        datasets = [_make_dataset("en", "24.0", "cmn1aaaaaaaaaaaaaaaaaaaaa")]
+        with patch("mdc_uploader.prior.org_page.load_or_fetch", return_value=datasets) as mock_f:
+            result = load_prior_map(
+                disable_mode=DisableMode.PRE,
+                base_dir="/gcs",
+                release_spec=_scs_release(),
+            )
+        mock_f.assert_called_once()
+        assert "en" in result
+        assert "cmn1aaaaaaaaaaaaaaaaaaaaa" in result["en"]
+
+    def test_post_mode_calls_load_or_fetch(self) -> None:
+        datasets = [_make_dataset("fr", "24.0", "cmn2bbbbbbbbbbbbbbbbbbbb")]
+        with patch("mdc_uploader.prior.org_page.load_or_fetch", return_value=datasets) as mock_f:
+            result = load_prior_map(
+                disable_mode=DisableMode.POST,
+                base_dir="/gcs",
+                release_spec=_scs_release(),
+            )
+        mock_f.assert_called_once()
+        assert "fr" in result
+
+    def test_passes_force_rescrape(self) -> None:
+        with patch("mdc_uploader.prior.org_page.load_or_fetch", return_value=[]) as mock_f:
+            load_prior_map(
+                disable_mode=DisableMode.PRE,
+                base_dir="/gcs",
+                release_spec=_scs_release(),
+                force_rescrape=True,
+            )
+        _, kwargs = mock_f.call_args
+        assert kwargs.get("force_rescrape") is True
+
+    def test_version_filter_excludes_current_version(self) -> None:
+        # Same-version entries are excluded by build_prior_map — current_ids not needed.
+        datasets = [_make_dataset("en", "25.0", "cmn1aaaaaaaaaaaaaaaaaaaaa")]
+        with patch("mdc_uploader.prior.org_page.load_or_fetch", return_value=datasets):
+            result = load_prior_map(
+                disable_mode=DisableMode.PRE,
+                base_dir="/gcs",
+                release_spec=_scs_release(),
+            )
+        assert result == {}

--- a/bundler/uploader/tests/test_prior.py
+++ b/bundler/uploader/tests/test_prior.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from mdc_uploader.models import DisableMode, Modality, OrgDataset
+from mdc_uploader.models import DisableMode, OrgDataset
 from mdc_uploader.naming import parse_release_name
 from mdc_uploader.prior import load_prior_map
 


### PR DESCRIPTION
NOTE: This feature is gated! It currently runs like dry-mode, pending tests.

This PR adds a new “disable prior versions” feature to the `mdc-uploader` bundler uploader, allowing operators to automatically disable older MDC dataset submissions either before uploading (bulk) or after each successful locale upload (per-locale), driven by a new CLI flag and backed by an org-page scraping/snapshot cache.

- Add `--disable-prior {skip,pre,post}` and `--force-rescrape` CLI/config plumbing, plus state/reporting for disable outcomes.
- Implement MDC org-page scraping with GCS/local snapshot caching and prior-version map construction.
- Integrate pre/post disable flows into the upload pipeline and expand test coverage for the new components.
