### PR TITLE
Rework rate limiting

### DIFF
--- a/server/src/api/bulk-submissions/routes.ts
+++ b/server/src/api/bulk-submissions/routes.ts
@@ -1,11 +1,11 @@
 import PromiseRouter from 'express-promise-router'
-import rateLimiter from '../../lib/middleware/rate-limiter-middleware'
+import rateLimiter, { byClientId } from '../../lib/middleware/rate-limiter-middleware'
 import { RequireFeatureMiddleware } from '../../lib/middleware/requireFeatureMiddleware'
 import { addBulkSubmissionHandler } from './handler/add-bulk-submission-handler'
 
 export const bulkSubmissionsRouter = PromiseRouter({ mergeParams: true }).post(
   '/',
   RequireFeatureMiddleware.handle('bulk-upload'),
-  rateLimiter('api/v1/:locale/bulk-submissions/', { points: 1, duration: 600 }),
+  rateLimiter('api/v1/:locale/bulk-submissions/', { points: 1, duration: 600 }, byClientId),
   addBulkSubmissionHandler
 )

--- a/server/src/api/profile/routes.ts
+++ b/server/src/api/profile/routes.ts
@@ -1,5 +1,5 @@
 import PromiseRouter from 'express-promise-router'
-import rateLimiter from '../../lib/middleware/rate-limiter-middleware'
+import rateLimiter, { byClientId } from '../../lib/middleware/rate-limiter-middleware'
 import { validateStrict } from '../../lib/validation'
 import { CreateApiCredentialsRequest } from './validation/create-api-credentials-request'
 import { createApiCredentialsHandler } from './handler/create-api-credentials-handler'
@@ -16,10 +16,14 @@ const requireFeatureMiddleware =
 export const profilesRouter = PromiseRouter({ mergeParams: true })
   .post(
     '/api-credentials',
-    rateLimiter('api/v1/profiles/api-credentials', {
-      points: 1,
-      duration: 60,
-    }),
+    rateLimiter(
+      'api/v1/profiles/api-credentials',
+      {
+        points: 1,
+        duration: 60,
+      },
+      byClientId
+    ),
     validateStrict({ body: CreateApiCredentialsRequest }),
     requireUserMiddleware.handle,
     requireFeatureMiddleware,

--- a/server/src/api/sentences/routes.ts
+++ b/server/src/api/sentences/routes.ts
@@ -1,6 +1,6 @@
 import addSentenceHandler from './handler/add-sentence-handler'
 import PromiseRouter from 'express-promise-router'
-import rateLimiter from '../../lib/middleware/rate-limiter-middleware'
+import rateLimiter, { byClientId } from '../../lib/middleware/rate-limiter-middleware'
 import {
   AddSentenceRequest,
   AddSentenceVoteRequest,
@@ -15,19 +15,19 @@ import addSmallSentenceBatchHandler from './handler/add-small-sentence-batch-han
 export default PromiseRouter({ mergeParams: true })
   .post(
     '/',
-    rateLimiter('api/v1/sentences/', { points: 10, duration: 60 }),
+    rateLimiter('api/v1/sentences/', { points: 10, duration: 60 }, byClientId),
     validateStrict({ body: AddSentenceRequest }),
     addSentenceHandler
   )
   .post(
     '/batch',
-    rateLimiter('api/v1/sentences/batch', { points: 1, duration: 180 }),
+    rateLimiter('api/v1/sentences/batch', { points: 1, duration: 180 }, byClientId),
     validateStrict({ body: AddSmallSentenceBatchRequest }),
     addSmallSentenceBatchHandler
   )
   .post(
     '/vote',
-    rateLimiter('api/v1/sentences/vote', { points: 30, duration: 60 }),
+    rateLimiter('api/v1/sentences/vote', { points: 40, duration: 60 }, byClientId),
     validateStrict({ body: AddSentenceVoteRequest }),
     addSentenceVoteHandler
   )

--- a/server/src/lib/api.ts
+++ b/server/src/lib/api.ts
@@ -13,7 +13,7 @@ import {
 } from './ffmpeg-transcoder'
 
 import { FEATURES_COOKIE, Sentence, UserClient as UserClientType } from 'common'
-import rateLimiter from './middleware/rate-limiter-middleware'
+import rateLimiter, { byClientId } from './middleware/rate-limiter-middleware'
 import { authMiddleware } from '../auth-router'
 import { RequireUserMiddleware } from './middleware/requireUserMiddleware'
 import { HandleFeatureMiddleware } from './middleware/handleFeatureMiddleware'
@@ -173,7 +173,9 @@ export default class API {
     router.patch(
       '/anonymous_user',
       validate({ body: anonUserMetadataSchema }),
-      rateLimiter('/anonymous_user', { points: 1, duration: 60 }),
+      // Per-IP ceiling + per-person limiter (client_id is mintable).
+      rateLimiter('/anonymous_user:byIp', { points: 10, duration: 60 }),
+      rateLimiter('/anonymous_user', { points: 3, duration: 60 }, byClientId),
       this.saveAnonymousAccountLanguages
     )
 
@@ -190,7 +192,9 @@ export default class API {
     // Body: email, name (optional), message
     router.post(
       '/contact',
-      rateLimiter('/contact', { points: 5, duration: 60 }),
+      // Per-IP ceiling + per-person limiter (client_id is mintable; sends email).
+      rateLimiter('/contact:byIp', { points: 20, duration: 60 }),
+      rateLimiter('/contact', { points: 5, duration: 60 }, byClientId),
       validate({ body: sendContactRequestSchema }),
       this.sendContactRequest
     )
@@ -199,7 +203,9 @@ export default class API {
     // Body: email, languageInfo, languageLocale, platforms
     router.post(
       '/language/request',
-      rateLimiter('/language/request', { points: 10, duration: 60 }),
+      // Per-IP ceiling + per-person limiter (client_id is mintable).
+      rateLimiter('/language/request:byIp', { points: 30, duration: 60 }),
+      rateLimiter('/language/request', { points: 10, duration: 60 }, byClientId),
       validate({ body: sendLanguageRequestSchema }),
       this.sendLanguageRequest
     )

--- a/server/src/lib/clip.ts
+++ b/server/src/lib/clip.ts
@@ -5,7 +5,7 @@ import { getConfig } from '../config-helper'
 import Model from './model'
 import getLeaderboard from './model/leaderboard'
 import { earnBonus, hasEarnedBonus } from './model/achievements'
-import rateLimiter from './middleware/rate-limiter-middleware'
+import rateLimiter, { byClientId } from './middleware/rate-limiter-middleware'
 // Basket import removed: currently bulk-mail facility is not supported
 // import * as Basket from './basket'
 import * as Sentry from '@sentry/node'
@@ -87,38 +87,33 @@ export default class Clip {
       }
     )
 
-    // Voting is fast (listen + click)
-    // Fast voter: ~10 votes/minute = 600/hour
-    // But if audio is bad, they may vote faster to get a new clip
-    // => Rate limiting for clip voting: ~900 votes/hour
-    // => Relax for shared IPs => 200 votes per 10 minutes (1200/hour max)
-    // + block for 1 minutes if limit exceeded
+    // Clip voting: 300 per 10 min per person, keyed by client_id.
     router.post(
       '/:clipId/votes',
-      rateLimiter('clips/vote', {
-        points: 200, // 200 votes
-        duration: 600, // per 10 minutes (1200/hour max)
-        blockDuration: 60, // Block for 1 minute
-      }),
+      rateLimiter(
+        'clips/vote',
+        {
+          points: 300, // 300 votes
+          duration: 600, // per 10 minutes
+          blockDuration: 60, // pause for 1 minute if exceeded
+        },
+        byClientId
+      ),
       this.saveClipVote
     )
 
-    // Rate limiting for clip recording: Account for retries (bad NW)/headroom and batch submissions
-    // Usual scripter sends 1 per second, so we must set it below that.
-    // Flow: 25 sentences loaded => record 5 => submit 5
-    // Recording: 1-15 sec/clip (avg 5sec) + UI time => 10sec/clip
-    // Batch of 5 clips: ~50 seconds
-    // 5 batches (25 clips): ~4+ minutes
-    // => Allow 70 uploads per 10 minutes (7 uploads/minute, 420 uploads/hour < 600))
-    // => Relax for shared IPs => 150 uploads per 10 minutes (900/hour max)
-    // + block for 1 minutes if limit exceeded
+    // Clip recording: 200 per 10 min per person (short clips record fast).
     router.post(
       '*',
-      rateLimiter('clips/record', {
-        points: 150, // 150 uploads
-        duration: 600, // per 10 minutes
-        blockDuration: 60, // Block for 1 minute
-      }),
+      rateLimiter(
+        'clips/record',
+        {
+          points: 200, // 200 uploads
+          duration: 600, // per 10 minutes
+          blockDuration: 60, // Block for 1 minute
+        },
+        byClientId
+      ),
       this.saveClip
     )
 

--- a/server/src/lib/middleware/rate-limiter-middleware.ts
+++ b/server/src/lib/middleware/rate-limiter-middleware.ts
@@ -29,6 +29,10 @@ function createRateLimiter(
   }
 }
 
+// Rate-limit key: per-user client_id, falling back to IP.
+export const byClientId = (request: Request): string =>
+  request.session?.user?.client_id ?? request.ip ?? 'unknown'
+
 function rateLimitResponse(response: Response, msBeforeNext: number) {
   const nextRequestSeconds = Math.round(msBeforeNext / 1000) || 1
   response.set('Retry-After', nextRequestSeconds.toString())

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -87,7 +87,8 @@ export default class Server {
         )
       },
     }
-    app.set('trust proxy', 1)
+    // 'true' = trust left-most X-Forwarded-For. TODO: set precise value once proxy chain confirmed.
+    app.set('trust proxy', true)
     app.use(express.json())
 
     app.use(compression())

--- a/web/src/components/pages/contribution/contribution.tsx
+++ b/web/src/components/pages/contribution/contribution.tsx
@@ -194,6 +194,8 @@ class ContributionPage extends React.Component<ContributionPageProps, State> {
 
   private handleKeyDown = (event: any) => {
     if (isTyping()) return
+    // Ignore key auto-repeat to avoid duplicate submissions.
+    if (event.repeat) return
 
     const { getString, hasErrors, isSubmitted, locale, onReset, onSubmit, type } =
       this.props

--- a/web/src/components/pages/contribution/listen/listen.tsx
+++ b/web/src/components/pages/contribution/listen/listen.tsx
@@ -111,6 +111,8 @@ class ListenPage extends React.Component<Props, State> {
   // try to disable double clicks/taps
   private playLockDurationMs = 600 // mobile devices already introduce ~300 ms lag
   private isPlayLocked = false
+  // Block double-submit of the same clip before setState commits.
+  private isVotingInProgress = false
 
   static getDerivedStateFromProps(props: Props, state: State) {
     const unvalidatedClips = state.clips.filter(
@@ -217,6 +219,9 @@ class ListenPage extends React.Component<Props, State> {
   }
 
   private vote = (isValid: boolean) => {
+    if (this.isVotingInProgress) return
+    this.isVotingInProgress = true
+
     const { clips } = this.state
 
     const {
@@ -232,58 +237,70 @@ class ListenPage extends React.Component<Props, State> {
     // Guard against invalid clip index
     if (clipIndex < 0 || clipIndex >= clips.length || !clips[clipIndex]) {
       console.error('Invalid clip index:', clipIndex)
+      this.isVotingInProgress = false
       return
     }
 
-    this.stop()
-    this.props.vote(isValid, clips[clipIndex].id)
-
+    // Release the lock even if something below throws before setState.
     try {
-      sessionStorage.setItem('challengeEnded', JSON.stringify(challengeEnded))
-      sessionStorage.setItem('hasContributed', 'true')
-    } catch (e) {
-      console.warn(`A sessionStorage error occurred ${e.message}`)
-    }
+      this.stop()
+      this.props.vote(isValid, clips[clipIndex].id)
 
-    if (showFirstContributionToast) {
-      addAchievement(
-        50,
-        "You're on your way! Congrats on your first contribution.",
-        'success'
+      try {
+        sessionStorage.setItem('challengeEnded', JSON.stringify(challengeEnded))
+        sessionStorage.setItem('hasContributed', 'true')
+      } catch (e) {
+        console.warn(`A sessionStorage error occurred ${e.message}`)
+      }
+
+      if (showFirstContributionToast) {
+        addAchievement(
+          50,
+          "You're on your way! Congrats on your first contribution.",
+          'success'
+        )
+      }
+      if (showFirstStreakToast) {
+        addAchievement(
+          50,
+          'You completed a three-day streak! Keep it up.',
+          'success'
+        )
+      }
+      if (
+        !JSON.parse(sessionStorage.getItem('challengeEnded')) &&
+        JSON.parse(sessionStorage.getItem('hasShared')) &&
+        !hasEarnedSessionToast
+      ) {
+        addAchievement(
+          50,
+          "You're on a roll! You sent an invite and contributed in the same session.",
+          'success'
+        )
+        sessionStorage.removeItem('hasShared')
+        // Tell back-end user get unexpected achievement: invite + contribute in the same session
+        // Each user can only get once.
+        api.setInviteContributeAchievement()
+      }
+      clearInterval(this.playedSomeInterval)
+      this.setState(
+        {
+          hasPlayed: false,
+          hasPlayedSome: false,
+          isPlaying: false,
+          isSubmitted: clipIndex === SET_COUNT - 1,
+          clips: clips.map((clip, i) =>
+            i === clipIndex ? { ...clip, isValid } : clip
+          ),
+        },
+        () => {
+          this.isVotingInProgress = false
+        }
       )
+    } catch (e) {
+      console.error('Vote handling failed:', e)
+      this.isVotingInProgress = false
     }
-    if (showFirstStreakToast) {
-      addAchievement(
-        50,
-        'You completed a three-day streak! Keep it up.',
-        'success'
-      )
-    }
-    if (
-      !JSON.parse(sessionStorage.getItem('challengeEnded')) &&
-      JSON.parse(sessionStorage.getItem('hasShared')) &&
-      !hasEarnedSessionToast
-    ) {
-      addAchievement(
-        50,
-        "You're on a roll! You sent an invite and contributed in the same session.",
-        'success'
-      )
-      sessionStorage.removeItem('hasShared')
-      // Tell back-end user get unexpected achievement: invite + contribute in the same session
-      // Each user can only get once.
-      api.setInviteContributeAchievement()
-    }
-    clearInterval(this.playedSomeInterval)
-    this.setState({
-      hasPlayed: false,
-      hasPlayedSome: false,
-      isPlaying: false,
-      isSubmitted: clipIndex === SET_COUNT - 1,
-      clips: clips.map((clip, i) =>
-        i === clipIndex ? { ...clip, isValid } : clip
-      ),
-    })
   }
 
   private voteYes = () => {

--- a/web/src/components/pages/contribution/sentence-collector/review/use-review.ts
+++ b/web/src/components/pages/contribution/sentence-collector/review/use-review.ts
@@ -185,6 +185,7 @@ const useReview = ({ getString, showReportModal }: UseReviewParams) => {
 
   const handleKeyDown = (evt: KeyboardEvent) => {
     if (isTyping()) return
+    if (evt.repeat) return
 
     if (
       evt.ctrlKey ||

--- a/web/src/components/pages/contribution/sentence-collector/write/sentence-write/hooks/use-sentence-write.ts
+++ b/web/src/components/pages/contribution/sentence-collector/write/sentence-write/hooks/use-sentence-write.ts
@@ -227,20 +227,20 @@ export const useSentenceWrite = (mode: WriteMode) => {
       })
     } catch (error) {
       if (error.message === TOO_MANY_REQUESTS) {
-        const retryLimit =
-          Number(error.retryAfter) > 60
-            ? secondsToMinutes(error.retryAfter)
-            : Number(error.retryAfter)
+        const retryAfterSeconds = Number(error.retryAfter) || 0
+        const useMinutes = retryAfterSeconds > 60
+        const retryLimit = useMinutes
+          ? secondsToMinutes(retryAfterSeconds)
+          : retryAfterSeconds
 
         dispatchError({
           errorType: SentenceSubmissionError.RATE_LIMIT_EXCEEDED,
-          localizedMessageKey:
-            Number(error.retryAfter) > 60
-              ? 'rate-limit-toast-message-minutes'
-              : 'rate-limit-toast-message-seconds',
+          localizedMessageKey: useMinutes
+            ? 'rate-limit-toast-message-minutes'
+            : 'rate-limit-toast-message-seconds',
           localizedMessageVars: { retryLimit },
           errorIcon: AlertIcon,
-          errorData: { retryLimit: Number(error.retryAfter) },
+          errorData: { retryLimit: retryAfterSeconds },
         })
       } else {
         dispatchError({

--- a/web/src/stores/clips.ts
+++ b/web/src/stores/clips.ts
@@ -277,10 +277,8 @@ export namespace Clips {
 
           // 429: clip already restored above — show a toast and keep voting.
           if (errName === 'RateLimitError') {
-            const retryAfter = parseInt(
-              (error as RateLimitError).retryAfter ?? '',
-              10
-            )
+            const retryAfter =
+              parseInt((error as RateLimitError).retryAfter ?? '', 10) || 0
             const content = React.createElement(
               Localized,
               retryAfter > 0

--- a/web/src/stores/clips.ts
+++ b/web/src/stores/clips.ts
@@ -2,7 +2,12 @@ import { Action as ReduxAction, Dispatch } from 'redux'
 import * as Sentry from '@sentry/react'
 import StateTree from './tree'
 import { User } from './user'
+import { Notifications } from './notifications'
 import { Clip } from 'common'
+import { RateLimitError } from '../services/app-error'
+import * as React from 'react'
+import { Localized } from '@fluent/react'
+import { secondsToMinutes } from 'date-fns'
 
 // Feature flag: Enable detailed error telemetry in Sentry
 // Set to true to track handled clip-load and clip-vote failures in Sentry
@@ -186,7 +191,7 @@ export namespace Clips {
     vote:
       (isValid: boolean, clipId?: string) =>
       async (
-        dispatch: Dispatch<Action | User.Action>,
+        dispatch: Dispatch<Action | User.Action | Notifications.Action>,
         getState: () => StateTree
       ) => {
         const state = getState()
@@ -252,6 +257,7 @@ export namespace Clips {
           // Error types come from backend API responses (see server/src/lib/clip.ts):
           // - NotFoundError: HTTP 404 - clip doesn't exist in database
           // - BusinessLogicError: HTTP 400 - validation failed (e.g., already voted)
+          // - RateLimitError: HTTP 429 - request rejected before processing (vote was NOT saved)
           //
           // Network errors (timeout, connection lost) are NOT definite failures because:
           // - Vote may have been saved on backend before response was sent
@@ -260,13 +266,46 @@ export namespace Clips {
           // Our strategy against comms errors: Only restore on errors where we KNOW vote didn't succeed
           const isDefiniteFailure =
             errName === 'NotFoundError' || // 404: Clip doesn't exist
-            errName === 'BusinessLogicError' // 400: Business rule violation
+            errName === 'BusinessLogicError' || // 400: Business rule violation
+            errName === 'RateLimitError' // 429: Rejected before processing — safe to restore
 
           if (clipToRemove && isDefiniteFailure) {
             dispatch({
               type: ActionType.REFILL_CACHE,
               clips: [clipToRemove],
             })
+          }
+
+          // 429: clip already restored above — show a toast and keep voting.
+          if (errName === 'RateLimitError') {
+            const retryAfter = Number((error as RateLimitError).retryAfter)
+            // Localized rate-limit strings; no Retry-After → generic message.
+            const content = Number.isFinite(retryAfter)
+              ? React.createElement(
+                  Localized,
+                  {
+                    id:
+                      retryAfter > 60
+                        ? 'rate-limit-toast-message-minutes'
+                        : 'rate-limit-toast-message-seconds',
+                    vars: {
+                      retryLimit:
+                        retryAfter > 60
+                          ? secondsToMinutes(retryAfter)
+                          : retryAfter,
+                    },
+                  },
+                  React.createElement('span')
+                )
+              : React.createElement(
+                  Localized,
+                  { id: 'review-error-rate-limit-exceeded' },
+                  React.createElement('span')
+                )
+            dispatch(
+              Notifications.actions.addPill(content, 'error') as Notifications.Action
+            )
+            return
           }
 
           dispatch({ type: ActionType.LOAD_ERROR })
@@ -342,7 +381,7 @@ export namespace Clips {
             hasEarnedSessionToast: false,
             showFirstContributionToast: false,
             showFirstStreakToast: false,
-            challengeEnded: true,
+            challengeEnded: localeState.challengeEnded,
           },
         }
       }

--- a/web/src/stores/clips.ts
+++ b/web/src/stores/clips.ts
@@ -7,7 +7,6 @@ import { Clip } from 'common'
 import { RateLimitError } from '../services/app-error'
 import * as React from 'react'
 import { Localized } from '@fluent/react'
-import { secondsToMinutes } from 'date-fns'
 
 // Feature flag: Enable detailed error telemetry in Sentry
 // Set to true to track handled clip-load and clip-vote failures in Sentry
@@ -278,30 +277,17 @@ export namespace Clips {
 
           // 429: clip already restored above — show a toast and keep voting.
           if (errName === 'RateLimitError') {
-            const retryAfter = Number((error as RateLimitError).retryAfter)
-            // Localized rate-limit strings; no Retry-After → generic message.
-            const content = Number.isFinite(retryAfter)
-              ? React.createElement(
-                  Localized,
-                  {
-                    id:
-                      retryAfter > 60
-                        ? 'rate-limit-toast-message-minutes'
-                        : 'rate-limit-toast-message-seconds',
-                    vars: {
-                      retryLimit:
-                        retryAfter > 60
-                          ? secondsToMinutes(retryAfter)
-                          : retryAfter,
-                    },
-                  },
-                  React.createElement('span')
-                )
-              : React.createElement(
-                  Localized,
-                  { id: 'review-error-rate-limit-exceeded' },
-                  React.createElement('span')
-                )
+            const retryAfter = parseInt(
+              (error as RateLimitError).retryAfter ?? '',
+              10
+            )
+            const content = React.createElement(
+              Localized,
+              retryAfter > 0
+                ? { id: 'error-title-429-with-time', vars: { retryAfter } }
+                : { id: 'error-title-429-no-time' },
+              React.createElement('span')
+            )
             dispatch(
               Notifications.actions.addPill(content, 'error') as Notifications.Action
             )


### PR DESCRIPTION
This PR reworks rate limiting to be keyed by user `client_id` (with IP fallback) across several server endpoints, and improves the client UX to prevent/handle accidental duplicate submissions and rate-limit responses during contribution flows.

- Server: adjust rate-limiter usage to key primarily by `client_id` (including adding a `byClientId` key function) and update rate-limit thresholds on key endpoints.
- Web: handle `RateLimitError` on clip voting by restoring the optimistically-removed clip and showing a localized notification.
- Web: reduce duplicate submissions by ignoring keyboard auto-repeat and adding an in-flight voting lock on Listen.
