### PR TITLE
1749-Uploader - Upgrade datacollective dependency and previous release disabling related code

### DIFF
--- a/bundler/uploader/README.md
+++ b/bundler/uploader/README.md
@@ -27,7 +27,7 @@ For architecture and development details see [DEVELOPER.md](DEVELOPER.md).
 - Can write all output to a log file via `--log-file` (always captures DEBUG level)
 - Can persist batch state to JSON after each locale for `--retry-failed` support
 - Can save log file and state JSON to `<base-dir>/<release>/upload-logs/` after each batch so they survive pod recycling
-- Can disable prior MDC dataset versions automatically via `--disable-prior pre` (bulk before upload) or `--disable-prior post` (per-locale after success) -- disabled by default (`skip`)
+- Can disable prior MDC dataset versions -- sets each to `visibility=private` via `--disable-prior pre` (before upload) or `post` (after each success), scoped to the locales being uploaded -- off by default (`skip`). On `-ut dev` the org id differs from prod, so set `MDC_ORG_ID`.
 
 ## Data Pipeline
 

--- a/bundler/uploader/pyproject.toml
+++ b/bundler/uploader/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = { text = "MPL-2.0" }
 requires-python = ">=3.12"
 dependencies = [
-    "datacollective==0.5.1",
+    "datacollective==0.5.2",
     "click>=8.1,<9.0",
     "tenacity>=8.2,<10.0",
     "httpx>=0.27,<1.0",

--- a/bundler/uploader/src/mdc_uploader/cli.py
+++ b/bundler/uploader/src/mdc_uploader/cli.py
@@ -35,6 +35,7 @@ Environment variables:
   MDC_API_KEY_DEV   MDC API key for dev target (required for -ut dev)
   MDC_API_KEY_PROD  MDC API key for prod target (required for -ut prod)
   MDC_API_URL       Override MDC API base URL (default: from -ut)
+  MDC_ORG_ID        Override org id scraped for --disable-prior (default: per -ut; dev unset)
   UPLOAD_BASE_DIR              Override --base-dir (highest priority after CLI flag)
   UPLOAD_LOG_FILE              Override --log-file
   DATASETS_BUNDLER_BUCKET_NAME Auto-resolves to gs://<value> (shared with bundler)

--- a/bundler/uploader/src/mdc_uploader/config.py
+++ b/bundler/uploader/src/mdc_uploader/config.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 
-from mdc_uploader.constants import DEFAULT_BASE_DIR, MDC_API_URLS
+from mdc_uploader.constants import (
+    DEFAULT_BASE_DIR,
+    MDC_API_URLS,
+    MDC_ORG_ID,
+    MDC_ORG_IDS,
+    MDC_SITE_BASE,
+    MDC_SITE_URLS,
+)
 from mdc_uploader.models import DisableMode, ReleaseType
 from mdc_uploader.typedef import MDCTarget, _OrphanedSubmission
 
@@ -47,6 +54,9 @@ class UploaderConfig:
     # Disable-prior mode and cache control
     disable_mode: DisableMode = DisableMode.SKIP
     force_rescrape: bool = False
+    # Org-page scrape target (resolved from upload_target; org_id may be "" if unknown)
+    site_base: str = MDC_SITE_BASE
+    org_id: str = MDC_ORG_ID
 
     def __post_init__(self) -> None:
         """Validate config invariants."""
@@ -88,6 +98,9 @@ class UploaderConfig:
         resolved_url = mdc_api_url or MDC_API_URLS[upload_target]
         resolved_base_dir = resolve_base_dir(base_dir)
         locale_list = [loc.strip() for loc in locales.split() if loc.strip()] if locales else None
+        # Org-page scrape target; MDC_ORG_ID env overrides the org id.
+        resolved_site_base = MDC_SITE_URLS.get(upload_target, MDC_SITE_BASE)
+        resolved_org_id = os.environ.get("MDC_ORG_ID") or MDC_ORG_IDS.get(upload_target, "")
 
         return cls(
             release_name=release,
@@ -107,4 +120,6 @@ class UploaderConfig:
             resume_submission_id=resume_submission_id,
             disable_mode=DisableMode(disable_mode),
             force_rescrape=force_rescrape,
+            site_base=resolved_site_base,
+            org_id=resolved_org_id,
         )

--- a/bundler/uploader/src/mdc_uploader/constants.py
+++ b/bundler/uploader/src/mdc_uploader/constants.py
@@ -46,10 +46,15 @@ DESCRIPTIONS: dict[str, DescriptionTemplate] = {
 # Max Retry-After value (seconds) before giving up on a 429
 MAX_RETRY_AFTER_SECONDS = 3600
 
-# MDC org page (disable-prior feature)
-# Set once MDC team confirms endpoint. E.g. ("DELETE", "/submissions/{id}")
-# or ("PATCH", "/submissions/{id}") with body {"status": "disabled"}.
-# When None: all disable calls are logged no-ops (Q1 guard).
-MDC_DISABLE_ENDPOINT: tuple[str, str] | None = None
-MDC_ORG_ID = "cmfh0j9o10006ns07jq45h7xk"
-MDC_SITE_BASE = "https://mozilladatacollective.com"
+# Org-page scrape host + org id for --disable-prior, per target. Dev is a different org
+# than prod (the prod org id 404s on dev). MDC_ORG_ID env overrides the org id.
+MDC_SITE_URLS: dict[MDCTarget, str] = {
+    "dev": "https://dev.mozilladatacollective.com",
+    "prod": "https://mozilladatacollective.com",
+}
+MDC_ORG_IDS: dict[MDCTarget, str] = {
+    "prod": "cmfh0j9o10006ns07jq45h7xk",
+    "dev": "",  # TODO: dev org id (or set MDC_ORG_ID env)
+}
+MDC_SITE_BASE = MDC_SITE_URLS["prod"]
+MDC_ORG_ID = MDC_ORG_IDS["prod"]

--- a/bundler/uploader/src/mdc_uploader/mdc.py
+++ b/bundler/uploader/src/mdc_uploader/mdc.py
@@ -460,13 +460,8 @@ class MDCClient:
             )
         except Exception as exc:  # pylint: disable=broad-exception-caught
             status_code, _ = _extract_response_detail(exc)
-            logger.error(
-                "MDC",
-                "Failed to disable %s (HTTP %s): %s",
-                submission_id,
-                status_code,
-                exc,
-            )
+            detail = f" (HTTP {status_code})" if status_code is not None else ""
+            logger.error("MDC", "Failed to disable %s%s: %s", submission_id, detail, exc)
             return False
         return True
 

--- a/bundler/uploader/src/mdc_uploader/mdc.py
+++ b/bundler/uploader/src/mdc_uploader/mdc.py
@@ -11,6 +11,7 @@ from datacollective import (
     DatasetSubmission,
     License,
     Task,
+    Visibility,
     create_submission_draft,
     submit_submission,
     update_submission,
@@ -36,8 +37,12 @@ from mdc_uploader.log import logger
 from mdc_uploader.models import ReleaseSpec
 from mdc_uploader.streaming import stream_upload_from_gcs
 
-# 256 MB parts: MDC doesn't return partSize so SDK falls back to this default (must target upload_utils).
-_dc_upload_utils.DEFAULT_PART_SIZE = 256 * 1024 * 1024  # 256 MB
+# 256 MB multipart parts. Passed explicitly to upload_dataset_file because its part_size
+# default is import-bound (0.5.2), so the patch below only reaches the streaming path.
+UPLOAD_PART_SIZE = 256 * 1024 * 1024
+
+# Fallback when MDC omits partSize. Patch the module attribute, not a from-import copy.
+_dc_upload_utils.DEFAULT_PART_SIZE = UPLOAD_PART_SIZE
 
 # -- 429 / transient error detection ------------------------------------------
 
@@ -214,6 +219,7 @@ class MDCClient:
             upload_kwargs: dict = {
                 "file_path": file_path,
                 "submission_id": submission_id,
+                "part_size": UPLOAD_PART_SIZE,
                 "enable_logging": self.verbose,
                 "show_progress": self.verbose,
             }
@@ -331,6 +337,7 @@ class MDCClient:
                 file_path=file_path,
                 submission_id=submission_id,
                 state_path=resume_state_path,
+                part_size=UPLOAD_PART_SIZE,  # ignored by SDK when resuming (keeps state.partSize)
                 enable_logging=self.verbose,
                 show_progress=self.verbose,
             )
@@ -432,6 +439,7 @@ class MDCClient:
             upload_dataset_file(
                 file_path=file_path,
                 submission_id=submission_id,
+                part_size=UPLOAD_PART_SIZE,
                 enable_logging=self.verbose,
                 show_progress=self.verbose,
             )
@@ -441,38 +449,26 @@ class MDCClient:
         return True
 
     def disable_submission(self, submission_id: str) -> bool:
-        """Disable one MDC dataset submission.
-
-        Returns False (logged as PENDING) when MDC_DISABLE_ENDPOINT is not yet
-        confirmed. Returns True on success, False on API failure (non-fatal;
-        caller decides whether to abort or continue).
+        """Make one prior submission private via update_submission (MDC has no
+        disable endpoint). PATCHes only `visibility`; returns False on failure (non-fatal).
         """
-        from mdc_uploader.constants import (  # pylint: disable=import-outside-toplevel
-            MDC_DISABLE_ENDPOINT,
-        )
-
-        if MDC_DISABLE_ENDPOINT is None:
-            logger.info(
-                "MDC",
-                "PENDING: would disable %s (endpoint not yet confirmed)",
-                submission_id,
-            )
-            return False
-
-        method, path_template = MDC_DISABLE_ENDPOINT
-        path = path_template.format(id=submission_id)
-        logger.info("MDC", "Disabling %s via %s %s", submission_id, method, path)
+        logger.info("MDC", "Disabling %s (visibility=private)", submission_id)
         try:
-            # TODO: implement actual call once endpoint is confirmed.
-            # Example: requests.request(method, f"{self.api_url}{path}")
-            raise NotImplementedError(
-                f"MDC_DISABLE_ENDPOINT is set to {MDC_DISABLE_ENDPOINT!r} "
-                "but the HTTP call is not implemented yet. "
-                "Add the call here once the endpoint is confirmed."
+            update_submission(
+                submission_id,
+                DatasetSubmission(visibility=Visibility.PRIVATE),
             )
         except Exception as exc:  # pylint: disable=broad-exception-caught
-            logger.error("MDC", "Failed to disable %s: %s", submission_id, exc)
+            status_code, _ = _extract_response_detail(exc)
+            logger.error(
+                "MDC",
+                "Failed to disable %s (HTTP %s): %s",
+                submission_id,
+                status_code,
+                exc,
+            )
             return False
+        return True
 
     def disable_submissions(
         self, submission_ids: list[str]
@@ -491,12 +487,12 @@ class MDCClient:
                 results[sid] = False
 
         success = sum(1 for v in results.values() if v)
-        pending_or_failed = len(results) - success
+        failed = len(results) - success
         logger.info(
             "MDC",
-            "disable_submissions: %d succeeded, %d pending/failed (of %d total)",
+            "disable_submissions: %d succeeded, %d failed (of %d total)",
             success,
-            pending_or_failed,
+            failed,
             len(submission_ids),
         )
         return results

--- a/bundler/uploader/src/mdc_uploader/org_page.py
+++ b/bundler/uploader/src/mdc_uploader/org_page.py
@@ -296,12 +296,12 @@ def build_prior_map(
     modality: Modality,
     current_version: str,
     current_submission_ids: set[str] | None = None,
+    locales: set[str] | None = None,
 ) -> dict[str, list[str]]:
-    """Return {locale_code -> [prior_submission_ids]} for the given modality.
+    """Return {locale_code -> [prior_submission_ids]}.
 
-    A "prior" entry matches on modality, has a version != current_version,
-    and is not in current_submission_ids. Entries with a different modality
-    are left untouched (one-time uploads preserved).
+    Keeps entries matching `modality`, version != current_version, not in
+    `current_submission_ids`, and (when given) locale in `locales`.
     """
     modality_val = modality.value
     exclude = current_submission_ids or set()
@@ -309,6 +309,8 @@ def build_prior_map(
 
     for d in datasets:
         if d.modality != modality_val:
+            continue
+        if locales is not None and d.locale_code not in locales:
             continue
         if d.version == current_version:
             continue

--- a/bundler/uploader/src/mdc_uploader/pipeline.py
+++ b/bundler/uploader/src/mdc_uploader/pipeline.py
@@ -356,20 +356,11 @@ def _disable_prior_version(
     prior_ids: list[str],
     client: MDCClient,
 ) -> tuple[list[str], list[str], list[str]]:
-    """Disable prior MDC submissions for one locale.
+    """Set each prior submission for one locale to private.
 
-    Returns (disabled_ids, failed_ids, pending_ids).
-    Never raises -- all exceptions are caught and logged.
+    Returns (disabled, failed, pending); pending is always empty (kept for the
+    dry-run result shape). Never raises.
     """
-    from mdc_uploader.constants import (  # pylint: disable=import-outside-toplevel
-        MDC_DISABLE_ENDPOINT,
-    )
-
-    if MDC_DISABLE_ENDPOINT is None:
-        for sid in prior_ids:
-            logger.info("MDC", "[%s] PENDING: would disable %s", locale, sid)
-        return [], [], list(prior_ids)
-
     disabled: list[str] = []
     failed: list[str] = []
     for sid in prior_ids:
@@ -932,20 +923,34 @@ def run_batch(config: UploaderConfig) -> bool:
         # Empty for skip mode or when org page is unavailable.
         prior_map: dict[str, list[str]] = {}
         if config.disable_mode != DisableMode.SKIP:
-            prior_map = prior_module.load_prior_map(
-                disable_mode=config.disable_mode,
-                base_dir=config.base_dir,
-                release_spec=release_spec,
-                force_rescrape=config.force_rescrape,
-            )
-            # Exclude the target submission when --submission-id is used with --disable-prior.
-            if config.submission_id:
-                prior_map = {
-                    loc: [s for s in ids if s != config.submission_id]
-                    for loc, ids in prior_map.items()
-                    if any(s != config.submission_id for s in ids)
-                }
-            state.locales_with_prior = len(prior_map)
+            if not config.org_id:
+                # No org id for this target -> skip (avoid scraping the wrong env).
+                logger.warning(
+                    "UPLOAD",
+                    "--disable-prior set but no org id resolved for target '%s' -- "
+                    "skipping disable. Set MDC_ORG_ID or add the org id to constants.",
+                    config.upload_target,
+                )
+            else:
+                # Disable only the locales uploaded this run (modality already enforced).
+                run_locales = {job.locale for job in jobs}
+                prior_map = prior_module.load_prior_map(
+                    disable_mode=config.disable_mode,
+                    base_dir=config.base_dir,
+                    release_spec=release_spec,
+                    force_rescrape=config.force_rescrape,
+                    locales=run_locales,
+                    site_base=config.site_base,
+                    org_id=config.org_id,
+                )
+                # Exclude the target submission when --submission-id is used with --disable-prior.
+                if config.submission_id:
+                    prior_map = {
+                        loc: [s for s in ids if s != config.submission_id]
+                        for loc, ids in prior_map.items()
+                        if any(s != config.submission_id for s in ids)
+                    }
+                state.locales_with_prior = len(prior_map)
 
         # Pre-mode: bulk disable all prior versions before starting uploads.
         if config.disable_mode == DisableMode.PRE and prior_map:

--- a/bundler/uploader/src/mdc_uploader/prior.py
+++ b/bundler/uploader/src/mdc_uploader/prior.py
@@ -17,20 +17,21 @@ def load_prior_map(
     base_dir: str,
     release_spec: ReleaseSpec,
     force_rescrape: bool = False,
+    locales: set[str] | None = None,
+    site_base: str = MDC_SITE_BASE,
+    org_id: str = MDC_ORG_ID,
 ) -> dict[str, list[str]]:
-    """Return {locale_code -> [prior_submission_ids]}.
+    """Scrape the org page and return {locale_code -> [prior_submission_ids]}.
 
-    Returns {} when disable_mode is SKIP or the org page cannot be loaded.
-    Calls org_page.load_or_fetch() for both pre and post modes.
-
-    Note: version filter in build_prior_map already excludes current-version entries.
+    {} when disable_mode is SKIP or the page can't be loaded. `locales` (if given)
+    restricts the map to those codes.
     """
     if disable_mode == DisableMode.SKIP:
         return {}
 
     datasets = org_page.load_or_fetch(
-        site_base=MDC_SITE_BASE,
-        org_id=MDC_ORG_ID,
+        site_base=site_base,
+        org_id=org_id,
         gcs_base=base_dir,
         force_rescrape=force_rescrape,
     )
@@ -43,4 +44,5 @@ def load_prior_map(
         datasets=datasets,
         modality=release_spec.modality,
         current_version=release_spec.version,
+        locales=locales,
     )

--- a/bundler/uploader/src/mdc_uploader/streaming.py
+++ b/bundler/uploader/src/mdc_uploader/streaming.py
@@ -27,7 +27,6 @@ from datacollective.api_utils import _get_api_url, _send_api_request
 from datacollective.models import UploadPart
 from datacollective.upload_utils import (
     DEFAULT_MIME_TYPE,
-    MAX_UPLOAD_BYTES,
     UploadState,
     _complete_upload,
     _extract_etag,
@@ -107,11 +106,6 @@ def stream_upload_from_gcs(
     file_size = blob.size
     if not file_size or file_size <= 0:
         raise ValueError(f"Blob has no content: gs://{bucket_name}/{blob_path}")
-    if file_size > MAX_UPLOAD_BYTES:
-        raise ValueError(
-            f"Blob exceeds upload limit ({format_size(file_size)} > "
-            f"{format_size(MAX_UPLOAD_BYTES)})"
-        )
 
     filename = os.path.basename(blob_path)
     state_file = Path(state_path)

--- a/bundler/uploader/src/mdc_uploader/streaming.py
+++ b/bundler/uploader/src/mdc_uploader/streaming.py
@@ -29,6 +29,7 @@ from datacollective.upload_utils import (
     DEFAULT_MIME_TYPE,
     UploadState,
     _complete_upload,
+    _ensure_part_size_is_valid,
     _extract_etag,
     _get_presigned_part_url,
     _load_upload_state,
@@ -106,6 +107,8 @@ def stream_upload_from_gcs(
     file_size = blob.size
     if not file_size or file_size <= 0:
         raise ValueError(f"Blob has no content: gs://{bucket_name}/{blob_path}")
+    # Validate part_size vs the SDK's limits (this path bypasses _initiate_upload).
+    _ensure_part_size_is_valid(file_size, part_size)
 
     filename = os.path.basename(blob_path)
     state_file = Path(state_path)

--- a/bundler/uploader/tests/test_mdc.py
+++ b/bundler/uploader/tests/test_mdc.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
+from datacollective import Visibility
 from requests import Response
 from requests.exceptions import HTTPError
 
 from mdc_uploader.mdc import (
+    UPLOAD_PART_SIZE,
     MDCClient,
     OrphanedDraftError,
     RateLimitError,
@@ -374,6 +376,7 @@ class TestResumeAndUpload:
             file_path="/fake/file.tar.gz",
             submission_id="sub-existing",
             state_path="/state/mdc-upload-fr.json",
+            part_size=UPLOAD_PART_SIZE,
             enable_logging=False,
             show_progress=False,
         )
@@ -533,29 +536,27 @@ class TestDisableSubmission:
     def _client(self) -> MDCClient:
         return MDCClient(api_key="test", api_url="http://test")
 
-    def test_disable_submission_pending_when_endpoint_none(self) -> None:
-        """When MDC_DISABLE_ENDPOINT is None, returns False and logs PENDING."""
-        import mdc_uploader.constants as consts
-        original = consts.MDC_DISABLE_ENDPOINT
-        try:
-            consts.MDC_DISABLE_ENDPOINT = None
+    def test_disable_submission_sets_visibility_private(self) -> None:
+        """disable_submission PATCHes visibility=private via update_submission and returns True."""
+        with patch("mdc_uploader.mdc.update_submission") as mock_update:
             result = self._client().disable_submission("sub-123")
-        finally:
-            consts.MDC_DISABLE_ENDPOINT = original
+        assert result is True
+        mock_update.assert_called_once()
+        call_args, _ = mock_update.call_args
+        assert call_args[0] == "sub-123"
+        assert call_args[1].visibility == Visibility.PRIVATE
+
+    def test_disable_submission_returns_false_on_error(self) -> None:
+        """API failure is caught; disable_submission returns False (non-fatal)."""
+        with patch("mdc_uploader.mdc.update_submission", side_effect=RuntimeError("boom")):
+            result = self._client().disable_submission("sub-123")
         assert result is False
 
     def test_disable_submissions_returns_map(self) -> None:
-        """disable_submissions returns {id -> result} map."""
-        import mdc_uploader.constants as consts
-        original = consts.MDC_DISABLE_ENDPOINT
-        try:
-            consts.MDC_DISABLE_ENDPOINT = None
+        """disable_submissions returns {id -> success} map."""
+        with patch("mdc_uploader.mdc.update_submission"):
             result = self._client().disable_submissions(["sub-a", "sub-b"])
-        finally:
-            consts.MDC_DISABLE_ENDPOINT = original
-        assert set(result.keys()) == {"sub-a", "sub-b"}
-        assert result["sub-a"] is False
-        assert result["sub-b"] is False
+        assert result == {"sub-a": True, "sub-b": True}
 
     def test_disable_submissions_empty_list(self) -> None:
         """disable_submissions on empty list returns empty dict."""
@@ -563,16 +564,9 @@ class TestDisableSubmission:
         assert result == {}
 
     def test_disable_submissions_nonfatal_on_exception(self) -> None:
-        """Unhandled exception in disable_submission is caught; result is False."""
-        client = self._client()
-        import mdc_uploader.constants as consts
-        original = consts.MDC_DISABLE_ENDPOINT
-        try:
-            consts.MDC_DISABLE_ENDPOINT = ("DELETE", "/submissions/{id}")
-            result = client.disable_submissions(["sub-fail"])
-        finally:
-            consts.MDC_DISABLE_ENDPOINT = original
-        # NotImplementedError is caught as broad exception, result = False
+        """An exception for one id is caught; that id maps to False."""
+        with patch("mdc_uploader.mdc.update_submission", side_effect=RuntimeError("boom")):
+            result = self._client().disable_submissions(["sub-fail"])
         assert result["sub-fail"] is False
 
 

--- a/bundler/uploader/tests/test_org_page.py
+++ b/bundler/uploader/tests/test_org_page.py
@@ -331,3 +331,23 @@ class TestBuildPriorMap:
         ]
         result = build_prior_map(datasets, Modality.SCS, "25.0")
         assert len(result["en"]) == 2
+
+    def test_filters_by_locales_when_provided(self) -> None:
+        """With locales given, only those locale codes are kept (e.g. -l 'en tr')."""
+        datasets = [
+            _make_dataset("en", "scs", "24.0", "cmn1aaaaaaaaaaaaaaaaaaaaa"),
+            _make_dataset("tr", "scs", "24.0", "cmn2bbbbbbbbbbbbbbbbbbbb"),
+            _make_dataset("de", "scs", "24.0", "cmn3ccccccccccccccccccccc"),
+        ]
+        result = build_prior_map(datasets, Modality.SCS, "25.0", locales={"en", "tr"})
+        assert set(result.keys()) == {"en", "tr"}
+        assert "de" not in result
+
+    def test_locales_none_includes_all(self) -> None:
+        """locales=None (default) keeps every prior locale for the modality."""
+        datasets = [
+            _make_dataset("en", "scs", "24.0", "cmn1aaaaaaaaaaaaaaaaaaaaa"),
+            _make_dataset("de", "scs", "24.0", "cmn3ccccccccccccccccccccc"),
+        ]
+        result = build_prior_map(datasets, Modality.SCS, "25.0")
+        assert set(result.keys()) == {"en", "de"}

--- a/bundler/uploader/tests/test_streaming.py
+++ b/bundler/uploader/tests/test_streaming.py
@@ -140,6 +140,7 @@ class TestStreamUploadFromGcs:
         blob.download_as_bytes = MagicMock(side_effect=download_range)
         return blob
 
+    @patch("mdc_uploader.streaming._ensure_part_size_is_valid")
     @patch("mdc_uploader.streaming._complete_upload")
     @patch("mdc_uploader.streaming._extract_etag")
     @patch("mdc_uploader.streaming._upload_part_with_retry")
@@ -149,7 +150,7 @@ class TestStreamUploadFromGcs:
     @patch("mdc_uploader.streaming.gcs_storage")
     def test_small_file_single_part(
         self, mock_gcs, mock_save, mock_init, mock_presigned,
-        mock_put, mock_etag, mock_complete, tmp_path,
+        mock_put, mock_etag, mock_complete, mock_ensure, tmp_path,
     ) -> None:
         """A file smaller than part_size uploads in one part."""
         data = b"hello world" * 100  # 1100 bytes
@@ -179,6 +180,7 @@ class TestStreamUploadFromGcs:
         mock_put.assert_called_once()
         mock_complete.assert_called_once()
 
+    @patch("mdc_uploader.streaming._ensure_part_size_is_valid")
     @patch("mdc_uploader.streaming._complete_upload")
     @patch("mdc_uploader.streaming._extract_etag")
     @patch("mdc_uploader.streaming._upload_part_with_retry")
@@ -188,7 +190,7 @@ class TestStreamUploadFromGcs:
     @patch("mdc_uploader.streaming.gcs_storage")
     def test_multi_part_upload(
         self, mock_gcs, mock_save, mock_init, mock_presigned,
-        mock_put, mock_etag, mock_complete, tmp_path,
+        mock_put, mock_etag, mock_complete, mock_ensure, tmp_path,
     ) -> None:
         """A file larger than part_size splits into multiple parts."""
         data = b"x" * 1000
@@ -217,6 +219,7 @@ class TestStreamUploadFromGcs:
         assert mock_put.call_count == 4
         assert state.checksum == hashlib.sha256(data).hexdigest()
 
+    @patch("mdc_uploader.streaming._ensure_part_size_is_valid")
     @patch("mdc_uploader.streaming._complete_upload")
     @patch("mdc_uploader.streaming._extract_etag")
     @patch("mdc_uploader.streaming._upload_part_with_retry")
@@ -225,7 +228,7 @@ class TestStreamUploadFromGcs:
     @patch("mdc_uploader.streaming.gcs_storage")
     def test_resume_skips_uploaded_parts(
         self, mock_gcs, mock_save, mock_presigned,
-        mock_put, mock_etag, mock_complete, tmp_path,
+        mock_put, mock_etag, mock_complete, mock_ensure, tmp_path,
     ) -> None:
         """Resuming skips already-uploaded parts but still reads for hash."""
         data = b"y" * 600
@@ -276,4 +279,18 @@ class TestStreamUploadFromGcs:
                 bucket_name="b", blob_path="p",
                 submission_id="s",
                 state_path=str(tmp_path / "state.json"),
+            )
+
+    @patch("mdc_uploader.streaming.gcs_storage")
+    def test_invalid_part_size_raises(self, mock_gcs, tmp_path) -> None:
+        """A part_size below the SDK minimum is rejected before initiating."""
+        blob = self._setup_blob(b"z" * 1000)
+        mock_gcs.Client.return_value.bucket.return_value.blob.return_value = blob
+
+        with pytest.raises(ValueError):
+            stream_upload_from_gcs(
+                bucket_name="b", blob_path="p",
+                submission_id="s",
+                state_path=str(tmp_path / "state.json"),
+                part_size=300,  # < MINIMUM_PART_SIZE (5 MB)
             )

--- a/bundler/uploader/typings/datacollective/__init__.pyi
+++ b/bundler/uploader/typings/datacollective/__init__.pyi
@@ -1,8 +1,9 @@
-"""Type stubs for datacollective SDK v0.5.1."""
+"""Type stubs for datacollective SDK v0.5.2."""
 
 from datacollective.models import DatasetSubmission as DatasetSubmission
 from datacollective.models import License as License
 from datacollective.models import Task as Task
+from datacollective.models import Visibility as Visibility
 from datacollective.submissions import (
     create_submission_draft as create_submission_draft,
 )

--- a/bundler/uploader/typings/datacollective/api_utils.pyi
+++ b/bundler/uploader/typings/datacollective/api_utils.pyi
@@ -1,4 +1,4 @@
-"""Type stubs for datacollective.api_utils (v0.5.1)."""
+"""Type stubs for datacollective.api_utils (v0.5.2)."""
 
 from typing import Any
 
@@ -11,4 +11,4 @@ def _send_api_request(
     json_body: dict[str, Any] | None = ...,
     **kwargs: Any,
 ) -> requests.Response: ...
-def _format_bytes(size: int) -> str: ...
+def _format_bytes(bytes_val: int, base: int = ...) -> str: ...

--- a/bundler/uploader/typings/datacollective/models.pyi
+++ b/bundler/uploader/typings/datacollective/models.pyi
@@ -6,7 +6,7 @@ class Task(str, Enum):
     NA = "N/A"
     NLP = "NLP"
     ASR = "ASR"
-    LI = "LI"
+    LID = "LID"
     TTS = "TTS"
     MT = "MT"
     LM = "LM"
@@ -17,7 +17,7 @@ class Task(str, Enum):
     RAG = "RAG"
     CV = "CV"
     ML = "ML"
-    OTHER = "Other"
+    OTH = "OTH"
 
 class License(str, Enum):
     APACHE_2_0 = "Apache-2.0"
@@ -45,6 +45,11 @@ class License(str, Enum):
     OPUBL_1_0 = "OPUBL-1.0"
     OGDL_TAIWAN_1_0 = "OGDL-Taiwan-1.0"
     UNLICENSE = "Unlicense"
+
+class Visibility(str, Enum):
+    PUBLIC = "public"
+    PRIVATE = "private"
+    RESTRICTED = "restricted"
 
 class NonEmptyStrModel: ...
 
@@ -77,6 +82,8 @@ class DatasetSubmission:
     createdByEmail: str | None
     intendedUsage: str | None
     ethicalReviewProcess: str | None
+    showContactInfo: bool | None
+    visibility: Visibility | None
     exclusivityOptOut: bool | None
     agreeToSubmit: bool | None
     id: str | None
@@ -115,6 +122,8 @@ class DatasetSubmission:
         createdByEmail: str | None = ...,
         intendedUsage: str | None = ...,
         ethicalReviewProcess: str | None = ...,
+        showContactInfo: bool | None = ...,
+        visibility: Visibility | None = ...,
         exclusivityOptOut: bool | None = ...,
         agreeToSubmit: bool | None = ...,
         id: str | None = ...,

--- a/bundler/uploader/typings/datacollective/submissions.pyi
+++ b/bundler/uploader/typings/datacollective/submissions.pyi
@@ -9,7 +9,8 @@ def create_submission_with_upload(
     file_path: str,
     submission: DatasetSubmission,
     state_path: str | None = ...,
-    verbose: bool = ...,
+    enable_logging: bool = ...,
+    part_size: int = ...,
 ) -> dict[str, Any]: ...
 def update_submission(submission_id: str, submission: DatasetSubmission) -> dict[str, Any]: ...
 def submit_submission(submission_id: str, submission: DatasetSubmission) -> dict[str, Any]: ...

--- a/bundler/uploader/typings/datacollective/upload.pyi
+++ b/bundler/uploader/typings/datacollective/upload.pyi
@@ -1,4 +1,4 @@
-"""Type stubs for datacollective.upload (v0.5.1)."""
+"""Type stubs for datacollective.upload (v0.5.2)."""
 
 from datacollective.upload_utils import UploadState
 
@@ -8,4 +8,5 @@ def upload_dataset_file(
     state_path: str | None = ...,
     show_progress: bool = ...,
     enable_logging: bool = ...,
+    part_size: int = ...,
 ) -> UploadState: ...

--- a/bundler/uploader/typings/datacollective/upload_utils.pyi
+++ b/bundler/uploader/typings/datacollective/upload_utils.pyi
@@ -1,4 +1,4 @@
-"""Type stubs for datacollective.upload_utils (v0.5.1)."""
+"""Type stubs for datacollective.upload_utils (v0.5.2)."""
 
 from pathlib import Path
 from typing import Any
@@ -11,7 +11,8 @@ MAX_UPLOAD_RETRIES: int
 RETRY_BACKOFF_SECONDS: int
 DEFAULT_PART_SIZE: int
 DEFAULT_MIME_TYPE: str
-MAX_UPLOAD_BYTES: int
+MINIMUM_PART_SIZE: int
+MAX_UPLOAD_PARTS: int
 
 class UploadSession:
     fileUploadId: str
@@ -49,8 +50,9 @@ class PresignedPartUrl:
     expiresAt: str | None
 
 def _initiate_upload(
-    submission_id: str, filename: str, file_size: int, mime_type: str
+    submission_id: str, filename: str, file_size: int, mime_type: str, part_size: int
 ) -> UploadSession: ...
+def _ensure_part_size_is_valid(file_size: int, part_size: int) -> None: ...
 def _get_presigned_part_url(
     file_upload_id: str, part_number: int
 ) -> PresignedPartUrl: ...
@@ -68,6 +70,7 @@ def _load_or_create_state(
     submission_id: str,
     final_filename: str,
     file_size: int,
+    part_size: int,
 ) -> UploadState: ...
 def _init_progress_bar(
     show_progress: bool,


### PR DESCRIPTION
This PR updates the bundler/uploader’s pinned `datacollective` SDK from v0.5.1 to v0.5.2, refreshes the local type stubs to match, and adjusts uploader behavior around multipart uploads and “disable prior” handling (now implemented via setting `visibility=private` and scoping org-page scraping by target + uploaded locales).
