### PR TITLE
1888-Add migration to add index for sentence validation query performance

### DIFF
--- a/server/src/lib/model/db/migrations/20260906000000-add-idx-validated-locale.ts
+++ b/server/src/lib/model/db/migrations/20260906000000-add-idx-validated-locale.ts
@@ -1,0 +1,29 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+//
+// 1888 - Index the sentence review filter: WHERE is_validated = ? AND locale_id = ?
+// Online (INPLACE/LOCK=NONE), ~10-20 min on 26.6M rows
+//
+export const up = async function (db: any): Promise<any> {
+  // Sampled statistics are far off (is_validated reports 118 distinct for two
+  // values), so raise the sample before building or the index is costed wrongly.
+  await db.runSql(`
+    ALTER TABLE sentences STATS_SAMPLE_PAGES = 200, ALGORITHM=INPLACE, LOCK=NONE
+  `)
+
+  console.log('Building idx_validated_locale - online, expect 10-20 minutes...')
+  const startedAt = Date.now()
+  await db.runSql(`
+    ALTER TABLE sentences
+      ADD INDEX idx_validated_locale (is_validated, locale_id),
+      ALGORITHM=INPLACE, LOCK=NONE
+  `)
+  console.log(`Built in ${Math.round((Date.now() - startedAt) / 1000)}s`)
+
+  await db.runSql(`ANALYZE TABLE sentences`)
+}
+
+export const down = async function (db: any): Promise<any> {
+  await db.runSql(`ALTER TABLE sentences DROP INDEX idx_validated_locale`)
+  await db.runSql(`ALTER TABLE sentences STATS_SAMPLE_PAGES = DEFAULT`)
+  await db.runSql(`ANALYZE TABLE sentences`)
+}


### PR DESCRIPTION
This is the first attempt to solve the very-slow query issue which times out for languages with large text-corpus.

This PR adds one index. No code changes, no behaviour change.

`GET /api/v1/sentences/review` filters `WHERE is_validated = FALSE AND locale_id = ?` and no index covers both columns. MySQL seeks the locale via `locale_clip_ct_idx`, then does one clustered-index lookup per row to read `is_validated`. Because the primary key is a hash, those lookups are uniformly random — so **the cost tracks the locale's _total_ sentence count, not its unvalidated ones.**

Each of those requests also pulls 19–36% of the buffer pool from disk, so it degrades every other query on the instance, not just review.

**Note:**

STATS_SAMPLE_PAGES = 200 is persistent on purpose. The whole reason the index needs it is that the default 20-page sample reports is_validated as having 118 distinct values for a column holding two (and locale_id as 13,847 for ~425). With estimates that wrong, the optimizer can cost idx_validated_locale incorrectly and refuse it — which is exactly what it already does today with the single-column is_validated index: it appears in possible_keys and gets rejected.
